### PR TITLE
Adding Pillow (PIL) and pycurl to required dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,9 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
     install_requires=[
         "tornado",
         "redis",
-        "pyCrypto"
+        "pyCrypto",
+        "pycurl",
+        "pillow"
     ],
 
     entry_points = {


### PR DESCRIPTION
As thumbor defaults to http_loader and to PIL image engine lets add then to the required libraries.

If adding PIL and pycurl is not desired, we could raise exceptions in config.py.

I did not went too far on thumbor's code but can it be used without any engine or storage ? If not, i really do see a point for adding these dependencies, as the user can have a ready to use app.
