### PR TITLE
Fix no put_detector_data do mongo_storage

### DIFF
--- a/thumbor/storages/mongo_storage.py
+++ b/thumbor/storages/mongo_storage.py
@@ -64,9 +64,7 @@ class Storage(BaseStorage):
     def put_detector_data(self, path, data):
         connection, db, storage = self.__conn__()
 
-        doc = storage.find_one({'path': path})
-        doc['detector_data'] = data
-        storage.update(doc)
+        storage.update({'path': path}, {"$set": {"detector_data": data}})
 
     def get_crypto(self, path):
         connection, db, storage = self.__conn__()


### PR DESCRIPTION
No método put_detector_data do módulo thumbor.storages.mongo_storage, a chamada para o método update do pymongo tinha apenas um parâmetro, sendo que o necessário são no mínimo dois (segundo a versão 2.0.1).
