### PR TITLE
PIL Engine: save image optimized otherwise save image without enhancement

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -14,6 +14,7 @@ from PIL import Image, ImageFile
 from tornado.options import options
 
 from thumbor.engines import BaseEngine
+from thumbor.utils import logger
 
 FORMATS = {
     '.jpg': 'JPEG',
@@ -58,7 +59,11 @@ class Engine(BaseEngine):
             options['optimize'] = True
             options['progressive'] = True
 
-        self.image.save(img_buffer, FORMATS[ext], **options)
+        try:
+            self.image.save(img_buffer, FORMATS[ext], **options)
+        except IOError, e:
+            logger.warning('Could not save as improved image, consider to increase ImageFile.MAXBLOCK')
+            self.image.save(img_buffer, FORMATS[ext])
 
         results = img_buffer.getvalue()
         img_buffer.close()


### PR DESCRIPTION
Some large JPEG images (say 3000x3000) would trigger an IOError
exception when PIL engine is storing the image. The solution is to
increase ImageFile.MAXBLOCK. This modification allows to save the image
without enhancement when it is bigger than ImageFile.MAXBLOCK, so the
image is stored anyway, but it logs a message in order to hint one to
increase the value of ImageFile.MAXBLOCK for fine tuning.
