### PR TITLE
Add Cache-Control and Expires HTTP headers in response

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -16,6 +16,7 @@ import math
 
 from PIL import Image
 from tornado.testing import AsyncHTTPTestCase
+from tornado.options import options
 
 from thumbor.app import ThumborServiceApp
 
@@ -40,6 +41,16 @@ class MainHandlerTest(AsyncHTTPTestCase):
         self.http_client.fetch(self.get_url('/unsafe/www.globo.com/media/globocom/img/sprite1.png'), self.stop)
         response = self.wait(timeout=20)
         self.assertEqual(200, response.code)
+
+    def test_returns_cache_control_header(self):
+        options.MAX_AGE = 3600
+        self.http_client.fetch(self.get_url('/unsafe/meta/s.glbimg.com/es/ge/f/original/2011/03/22/boavista_x_botafogo.jpg'), self.stop)
+        response = self.wait()
+        d = datetime.datetime.now() + datetime.timedelta(seconds=3600)
+
+        assert response.code == 200
+        self.assertEqual("max-age=3600,public", response.headers['Cache-Control'] )
+        self.assertEqual(d, datetime.strptime(response.headers['Cache-Control'],"%a, %d %b %Y %H:%M:00 GMT"))
 
 class ImageTestCase(AsyncHTTPTestCase):
 

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -15,6 +15,7 @@ from tornado.options import options, define
 
 define('MAX_WIDTH', type=int, default=0)
 define('MAX_HEIGHT', type=int, default=0)
+define('MAX_AGE',type=int, default=0)
 define('ALLOWED_SOURCES', default=[], multiple=True)
 define('QUALITY', type=int, default=80)
 

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -12,6 +12,7 @@ import functools
 from os.path import splitext
 
 import tornado.web
+import datetime
 from tornado.options import options
 
 from thumbor.transformer import Transformer
@@ -189,6 +190,10 @@ class BaseHandler(tornado.web.RequestHandler):
             content_type = CONTENT_TYPE[context['extension']]
 
         self.set_header('Content-Type', content_type)
+
+        if options.MAX_AGE:
+                self.set_header('Cache-Control', 'max-age=' + str(options.MAX_AGE) + ',public')
+                self.set_header('Expires', datetime.datetime.utcnow() + datetime.timedelta(seconds=options.MAX_AGE))
 
         results = context['engine'].read(context['extension'], context['quality'])
 


### PR DESCRIPTION
Hello,

This is a small patch to add some cache control in configuration.
If you use some caching technologies like varnishd in front of thumbor it could be usefull to add Cache-Control and Expires header to make varnish storing fine the generated image preventing request at thumbor to often.

I add some tests with it but wasn't able to make them working, all the tests ends with :
AssertionError: Async operation timed out after X seconds
Did I missed something ?

Best regards,
## 

Damien
