### PR TITLE
Prevent from loading documents that are not images.

### DIFF
--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -44,7 +44,7 @@ def load(context, url, callback):
         #return None
 
     def return_contents(response):
-        if response.error:
+        if response.error or not response.headers['Content-Type'][:6] == 'image/':
             callback(None)
         else:
             callback(response.body)


### PR DESCRIPTION
If the URL does not return an image do not try to load at all.
