### PR TITLE
empty files raise 500 'IOError: cannot identify image file' better to return 404

### DIFF
--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -31,7 +31,7 @@ def validate(context, url):
     return False
 
 def return_contents(response, callback):
-    if response.error or not response.headers['Content-Type'][:6] == 'image/':
+    if response.error or not response.headers['Content-Type'][:6] == 'image/' or len(response.body) == 0:
         callback(None)
     else:
         callback(response.body)


### PR DESCRIPTION
Do not treat for empty existing files.
