### PR TITLE
correct tests and except wrong base64/crypted string errors

### DIFF
--- a/thumbor/crypto.py
+++ b/thumbor/crypto.py
@@ -62,8 +62,11 @@ class Crypto(object):
     def decrypt(self, encrypted):
         cipher = AES.new(self.salt)
 
-        debased = base64.urlsafe_b64decode(encrypted.encode("utf-8"))
-        decrypted = cipher.decrypt(debased).rstrip('{')
+        try:
+            debased = base64.urlsafe_b64decode(encrypted.encode("utf-8"))
+            decrypted = cipher.decrypt(debased).rstrip('{')
+        except TypeError:
+            return None
 
         result = Url.parse('/%s' % decrypted, with_unsafe=False)
 

--- a/vows/crypto_vows.py
+++ b/vows/crypto_vows.py
@@ -31,7 +31,7 @@ class CryptoVows(Vows.Context):
             return crypto.decrypt('some string')
 
         def should_be_null(self, topic):
-            expect(topic).not_to_be_null()
+            expect(topic).to_be_null()
 
     class Encrypt(Vows.Context):
         def topic(self, crypto):


### PR DESCRIPTION
Hello,

Here a correction on a test and exception in code :

an url with /foo is OK (no handler so 404) but an url with /foo/bar => 500

Cheers,
## 

Damien
