### PR TITLE
add format detection by magic number

### DIFF
--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -19,6 +19,14 @@ class BaseEngine(object):
         self.icc_profile = None
 
     def load(self, buffer, extension):
+        #magic number detection
+        if ( buffer[:4] == 'GIF8'):
+            extension = '.gif'
+        elif ( buffer[:8] == '\x89PNG\r\n\x1a\n'):
+            extension = '.png'
+        elif ( buffer[:2] == '\xff\xd8'):
+            extension = '.jpg'
+
         self.extension = extension
         self.image = self.create_image(buffer)
         if self.source_width is None:


### PR DESCRIPTION
Hello,

This is a small patch to allow automatic detection of image format directly from its content base on magic number ( cf : https://en.wikipedia.org/wiki/Magic_number_%28programming%29#Examples )

This allow fake '.jpg' that are PNG in reality (some people still believe that "mv foo.jpg bar.png" change also its format...).
There is also some URL that does not present image extensions.

There is no vows test for the moment on engines and still need help (i.e. template) on that purpose.

Cheers
## 

Damien
