### PR TITLE
improve fill() filter with 0 requested size

### DIFF
--- a/thumbor/filters/fill.py
+++ b/thumbor/filters/fill.py
@@ -9,15 +9,14 @@
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
 from thumbor.filters import BaseFilter
-from PIL import Image
 
 class Filter(BaseFilter):
     regex = r'(?:fill\((?P<value>[\w]+)\))'
 
     def run_filter(self):
         self.fill_engine = self.engine.__class__(self.context)
-        bx = self.context.request.width
-        by = self.context.request.height
+        bx = self.context.request.width if self.context.request.width != 0 else self.engine.image.size[0]
+        by = self.context.request.height if self.context.request.height != 0 else self.engine.image.size[1]
         (ix, iy) = self.engine.image.size
         try:
             self.fill_engine.image = self.fill_engine.gen_image((bx,by),self.params['value'])
@@ -26,6 +25,7 @@ class Filter(BaseFilter):
 
         px = ( bx - ix )/2 #top left
         py = ( by - iy )/2
-	
+
+
         self.fill_engine.paste(self.engine, (px, py))
         self.engine.image = self.fill_engine.image

--- a/vows/fill_filter_vows.py
+++ b/vows/fill_filter_vows.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+from pyvows import Vows, expect
+
+from thumbor.filters import create_instances, compile_filters
+from thumbor.filters.fill import Filter
+from thumbor.context import Context, RequestParameters
+from thumbor.config import Config
+from thumbor.importer import Importer
+
+DATA = [ #size requested, resized/croped image size, result size
+	((20,20),(10,10),(20,20)),
+        ((20,0),(10,10),(20,10)),
+        ((0,20),(10,10),(10,20)),
+]
+
+@Vows.batch
+class QualityFilterVows(Vows.Context):
+    def topic(self):
+        conf = Config()
+        conf.ENGINE = 'thumbor.engines.pil'
+        imp = Importer(conf)
+        imp.import_modules()
+        ctx = Context(None, conf, imp)
+
+	for item in DATA:
+            ctx.modules.engine.image = ctx.modules.engine.gen_image(item[1],'#fff')
+            req = RequestParameters(fit_in=True,width=item[0][0],height=item[0][1])
+            ctx.request = req
+
+            filters = [Filter]
+            compile_filters(filters)
+            filter_instances = create_instances(ctx, filters, "fill(blue)")
+
+            filter_instances[0].run_filter()
+            yield (filter_instances[0].engine.image.size,item[2])
+
+    def image_should_be_filled(self, topic):
+        expect(topic[0]).to_equal(topic[1])


### PR DESCRIPTION
One of my users filled this bug if image size is "200x", "x200", "0x200" or "200x0" the fill() filter fail with a 500.

So take the resized image size to get the missing dimension result.

I also create a test for it. Not really sure it is the easier way to do it but it works :)

Cheers,
## 

Damien
