### PR TITLE
return better status code "201 Created" or "409 Conflict" for /upload

### DIFF
--- a/thumbor/handlers/upload.py
+++ b/thumbor/handlers/upload.py
@@ -36,8 +36,13 @@ class UploadHandler(ContextHandler):
         file_data = self.extract_file_data()
         body = file_data['body']
         filename = file_data['filename']
-
-        path = self.write_file(filename, body, overwrite=overwrite)
+        path = ""
+        try:
+            path = self.write_file(filename, body, overwrite=overwrite)
+            self.set_status(201)
+        except RuntimeError:
+            self.set_status(409)
+            path = 'File already exists.'
         self.write(path)
 
     def post(self):

--- a/vows/upload_vows.py
+++ b/vows/upload_vows.py
@@ -111,7 +111,7 @@ class Upload(BaseContext):
                 return response[0]
 
             def should_not_be_an_error(self, topic):
-                expect(topic).to_equal(200)
+                expect(topic).to_equal(201)
 
         class Body(TornadoHTTPContext):
             def topic(self, response):
@@ -135,7 +135,7 @@ class Upload(BaseContext):
                 return response[0]
 
             def should_not_be_an_error(self, topic):
-                expect(topic).to_equal(200)
+                expect(topic).to_equal(201)
 
         class Body(TornadoHTTPContext):
             def topic(self, response):
@@ -159,7 +159,7 @@ class Upload(BaseContext):
                     return response[0]
 
                 def should_be_an_error(self, topic):
-                    expect(topic).to_equal(500)
+                    expect(topic).to_equal(409)
 
             class WhenDeleting(BaseContext):
                 def topic(self):


### PR DESCRIPTION
Those HTTP status code fit better in the /upload context than 200 OK or 500 internal server error.

A 500 error is not well perceived from client side and give to service a low quality feeling.

Cheers,
## 

Damien
