### PR TITLE
Validate upload

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -87,6 +87,8 @@ class Config(object):
 
 Config.define('MAX_WIDTH', 0)
 Config.define('MAX_HEIGHT', 0)
+Config.define('MIN_WIDTH', 1)
+Config.define('MIN_HEIGHT', 1)
 Config.define('ALLOWED_SOURCES', [])
 Config.define('QUALITY', 80)
 Config.define('MAX_AGE', 0)


### PR DESCRIPTION
Hello,

I overload the validate() method to restrict uploaded file to real images (manageable by engines) and introduce MIN_WITH and MIN_HEIGHT to prevent uploading to small images 

default is 1x1 that also permit too restrict invalid image for graphickmagik that load everything without complaining but return size of 0x0

Cheers,
## 

Damien
