### PR TITLE
EXIF Orientation information is lost after the image is processed

### DIFF
--- a/thumbor/engines/pil_rotated.py
+++ b/thumbor/engines/pil_rotated.py
@@ -1,0 +1,39 @@
+from thumbor.engines.pil import Engine as BasePilEngine
+from PIL import Image
+from cStringIO import StringIO
+
+EXIF_ORIENTATAION=274
+
+class Engine(BasePilEngine):
+  def create_image(self, buffer):
+        img = super(Engine,self).create_image(buffer)
+        try:
+            exif = img._getexif()
+        except:
+            return img
+        orientation = None
+        if exif:
+            orientation = exif.get(EXIF_ORIENTATAION,1)
+        
+        if orientation == 2:
+            # Vertical Mirror
+            img = img.transpose(Image.FLIP_LEFT_RIGHT)
+        elif orientation == 3:
+            # Rotation 180
+            img = img.transpose(Image.ROTATE_180)
+        elif orientation == 4:
+            # Horizontal Mirror
+            img = img.transpose(Image.FLIP_TOP_BOTTOM)
+        elif orientation == 5:
+            # Horizontal Mirror + Rotation 270
+            img = img.transpose(Image.FLIP_TOP_BOTTOM).transpose(Image.ROTATE_270)
+        elif orientation == 6:
+            # Rotation 270
+            img = img.transpose(Image.ROTATE_270)
+        elif orientation == 7:
+            # Vertical Mirror + Rotation 270
+            img = img.transpose(Image.FLIP_LEFT_RIGHT).transpose(Image.ROTATE_270)
+        elif orientation == 8:
+            # Rotation 90
+            img = img.transpose(Image.ROTATE_90)
+        return img


### PR DESCRIPTION
Hey Guys,

I ran in to a problem generating images that were uploaded in portrait mode from devices like iPhones. After the image was processed the original image rotation was lost causing the image to display 90 deg's off.

After some digging around I noticed that when PIL processes the image it removes any EXIF Orientation information so to display the image correctly I had to somehow add the EXIF information manually or rotate the image.

I ended up with the Image rotation.

I'm pretty new with this project so I'm not sure where the best place to put this code would be. Originally I thought about using a filter but this code is PIL specific. I ended up just extending the current PIL engine to keep this code separate.

Not sure if this code is of any value to you but just in case I thought I would pass it along.

Thanks!
