### PR TITLE
Upload configuration variables naming

### DIFF
--- a/thumbor/app.py
+++ b/thumbor/app.py
@@ -25,7 +25,7 @@ class ThumborServiceApp(tornado.web.Application):
             (r'/healthcheck', HealthcheckHandler),
         ]
 
-        if context.config.ENABLE_ORIGINAL_PHOTO_UPLOAD:
+        if context.config.UPLOAD_ENABLED:
             handlers.append(
                 (r'/upload', UploadHandler, { 'context': context })
             )

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -129,11 +129,11 @@ Config.define('STORES_CRYPTO_KEY_FOR_EACH_IMAGE', False, 'Indicates whether thum
 Config.define('FILE_STORAGE_ROOT_PATH', join(tempfile.gettempdir(), 'thumbor', 'storage'), 'The root path where the File Storage will try to find images', 'File Storage')
 
 # PHOTO UPLOAD OPTIONS
-Config.define('MAX_SIZE', 0, "Max size in Kb for images uploaded to thumbor", 'Upload')
-Config.define('ENABLE_ORIGINAL_PHOTO_UPLOAD', False, 'Indicates whether thumbor should enable File uploads', 'Upload')
-Config.define('ORIGINAL_PHOTO_STORAGE', 'thumbor.storages.file_storage', 'The type of storage to store uploaded images with', 'Upload')
-Config.define('ALLOW_ORIGINAL_PHOTO_DELETION', False, 'Indicates whether image deletion should be allowed', 'Upload')
-Config.define('ALLOW_ORIGINAL_PHOTO_PUTTING', False, 'Indicates whether image overwrite should be allowed', 'Upload')
+Config.define('UPLOAD_MAX_SIZE', 0, "Max size in Kb for images uploaded to thumbor", 'Upload')
+Config.define('UPLOAD_ENABLED', False, 'Indicates whether thumbor should enable File uploads', 'Upload')
+Config.define('UPLOAD_PHOTO_STORAGE', 'thumbor.storages.file_storage', 'The type of storage to store uploaded images with', 'Upload')
+Config.define('UPLOAD_DELETE_ALLOWED', False, 'Indicates whether image deletion should be allowed', 'Upload')
+Config.define('UPLOAD_PUT_ALLOWED', False, 'Indicates whether image overwrite should be allowed', 'Upload')
 
 # MONGO STORAGE OPTIONS
 Config.define('MONGO_STORAGE_SERVER_HOST', 'localhost', 'MongoDB storage server host', 'MongoDB Storage')

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -153,9 +153,9 @@ class ContextImporter:
         if importer.result_storage:
             self.result_storage = importer.result_storage(context)
 
-        self.original_photo_storage = None
-        if importer.original_photo_storage:
-            self.original_photo_storage = importer.original_photo_storage(context)
+        self.upload_photo_storage = None
+        if importer.upload_photo_storage:
+            self.upload_photo_storage = importer.upload_photo_storage(context)
 
 
         self.loader = importer.loader

--- a/thumbor/handlers/upload.py
+++ b/thumbor/handlers/upload.py
@@ -15,7 +15,7 @@ from thumbor.handlers import ContextHandler
 class UploadHandler(ContextHandler):
 
     def write_file(self, filename, body, overwrite):
-        storage = self.context.modules.original_photo_storage
+        storage = self.context.modules.upload_photo_storage
         path = storage.resolve_original_photo_path(filename)
 
         if not overwrite and storage.exists(path):
@@ -53,7 +53,7 @@ class UploadHandler(ContextHandler):
             self.write('File is too big, not an image or too small image')
 
     def put(self):
-        if not self.context.config.ALLOW_ORIGINAL_PHOTO_PUTTING: return
+        if not self.context.config.UPLOAD_PUT_ALLOWED: return
         if self.validate():
             self.save_and_render(overwrite=True)
         else:
@@ -61,7 +61,7 @@ class UploadHandler(ContextHandler):
             self.write('File is too big, not an image or too small image')
 
     def delete(self):
-        if not self.context.config.ALLOW_ORIGINAL_PHOTO_DELETION: return
+        if not self.context.config.UPLOAD_DELETE_ALLOWED: return
         path = 'file_path' in self.request.arguments and self.request.arguments['file_path'] or None
         if path is None and self.request.body is None: raise RuntimeError('The file_path argument is mandatory to delete an image')
         path = urllib.unquote(self.request.body.split('=')[-1])
@@ -73,7 +73,7 @@ class UploadHandler(ContextHandler):
         conf = self.context.config
         engine = self.context.modules.engine
 
-        if ( conf.MAX_SIZE != 0 and  len(self.extract_file_data()['body']) > conf.MAX_SIZE ):
+        if ( conf.UPLOAD_MAX_SIZE != 0 and  len(self.extract_file_data()['body']) > conf.UPLOAD_MAX_SIZE ):
             return False
 
         try:

--- a/thumbor/importer.py
+++ b/thumbor/importer.py
@@ -15,7 +15,7 @@ class Importer:
         self.config = config
         self.engine = None
         self.loader = None
-        self.original_photo_storage = None
+        self.upload_photo_storage = None
         self.storage = None
         self.result_storage = None
         self.detectors = []
@@ -42,8 +42,8 @@ class Importer:
         if self.config.RESULT_STORAGE:
             self.import_item('RESULT_STORAGE', 'Storage')
 
-        if self.config.ORIGINAL_PHOTO_STORAGE:
-            self.import_item('ORIGINAL_PHOTO_STORAGE', 'Storage')
+        if self.config.UPLOAD_PHOTO_STORAGE:
+            self.import_item('UPLOAD_PHOTO_STORAGE', 'Storage')
 
     def import_item(self, config_key=None, class_name=None, is_multiple=False, item_value=None, ignore_errors=False):
         if item_value is None:

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -45,14 +45,14 @@ LOADER = 'thumbor.loaders.http_loader'
 # THIS ONLY WORKS WITH http_loader.
 MAX_SOURCE_SIZE = 0
 
-# if you set ENABLE_ORIGINAL_PHOTO_UPLOAD to True,
+# if you set UPLOAD_ENABLED to True,
 # a route /upload will be enabled for your thumbor process
 # You can then do a put to this URL to store the photo
 # using the specified Storage
-ENABLE_ORIGINAL_PHOTO_UPLOAD = False
-ORIGINAL_PHOTO_STORAGE = 'thumbor.storages.file_storage'
-ALLOW_ORIGINAL_PHOTO_PUTTING = False
-ALLOW_ORIGINAL_PHOTO_DELETION = False
+UPLOAD_ENABLED = False
+UPLOAD_PHOTO_STORAGE = 'thumbor.storages.file_storage'
+UPLOAD_PUT_ALLOWED = False
+UPLOAD_DELETE_ALLOWED = False
 
 # how to store the loaded images so we don't have to load
 # them again with the loader

--- a/vows/importer_vows.py
+++ b/vows/importer_vows.py
@@ -24,7 +24,7 @@ test_data = [
     ('ENGINE', pil_engine),
     ('LOADER', http_loader),
     ('STORAGE', file_storage),
-    ('ORIGINAL_PHOTO_STORAGE', file_storage),
+    ('UPLOAD_PHOTO_STORAGE', file_storage),
     ('RESULT_STORAGE', result_file_storage),
     ('DETECTORS', (face_detector,)),
     ('FILTERS', (rgb_filter,)),
@@ -40,7 +40,7 @@ class ImporterVows(Vows.Context):
                     ENGINE=r'thumbor.engines.pil',
                     LOADER=r'thumbor.loaders.http_loader',
                     STORAGE=r'thumbor.storages.file_storage',
-                    ORIGINAL_PHOTO_STORAGE=r'thumbor.storages.file_storage',
+                    UPLOAD_PHOTO_STORAGE=r'thumbor.storages.file_storage',
                     RESULT_STORAGE=r'thumbor.result_storages.file_storage',
                     DETECTORS=['thumbor.detectors.face_detector'],
                     FILTERS=['thumbor.filters.rgb']

--- a/vows/upload_vows.py
+++ b/vows/upload_vows.py
@@ -91,11 +91,11 @@ class BaseContext(TornadoHTTPContext):
 class Upload(BaseContext):
     def get_app(self):
         cfg = Config()
-        cfg.ENABLE_ORIGINAL_PHOTO_UPLOAD = True
-        cfg.ORIGINAL_PHOTO_STORAGE = 'thumbor.storages.file_storage'
+        cfg.UPLOAD_ENABLED = True
+        cfg.UPLOAD_PHOTO_STORAGE = 'thumbor.storages.file_storage'
         cfg.FILE_STORAGE_ROOT_PATH = storage_path
-        cfg.ALLOW_ORIGINAL_PHOTO_DELETION = True
-        cfg.ALLOW_ORIGINAL_PHOTO_PUTTING = True
+        cfg.UPLOAD_DELETE_ALLOWED = True
+        cfg.UPLOAD_PUT_ALLOWED = True
 
         importer = Importer(cfg)
         importer.import_modules()
@@ -256,10 +256,10 @@ class Upload(BaseContext):
 class UploadWithoutDeletingAllowed(BaseContext):
     def get_app(self):
         cfg = Config()
-        cfg.ENABLE_ORIGINAL_PHOTO_UPLOAD = True
-        cfg.ORIGINAL_PHOTO_STORAGE = 'thumbor.storages.file_storage'
+        cfg.UPLOAD_ENABLED = True
+        cfg.UPLOAD_PHOTO_STORAGE = 'thumbor.storages.file_storage'
         cfg.FILE_STORAGE_ROOT_PATH = storage_path
-        cfg.ALLOW_ORIGINAL_PHOTO_DELETION = False
+        cfg.UPLOAD_DELETE_ALLOWED = False
 
         importer = Importer(cfg)
         importer.import_modules()
@@ -295,9 +295,9 @@ class UploadWithoutDeletingAllowed(BaseContext):
 class UploadWithMinWidthAndHeight(BaseContext):
     def get_app(self):
         cfg = Config()
-        cfg.ENABLE_ORIGINAL_PHOTO_UPLOAD = True
-        cfg.ALLOW_ORIGINAL_PHOTO_PUTTING = True
-        cfg.ORIGINAL_PHOTO_STORAGE = 'thumbor.storages.file_storage'
+        cfg.UPLOAD_ENABLED = True
+        cfg.UPLOAD_PUT_ALLOWED = True
+        cfg.UPLOAD_PHOTO_STORAGE = 'thumbor.storages.file_storage'
         cfg.FILE_STORAGE_ROOT_PATH = storage_path
         cfg.MIN_WIDTH = 40
         cfg.MIN_HEIGHT = 40
@@ -330,11 +330,11 @@ class UploadWithMinWidthAndHeight(BaseContext):
 class UploadWithMaxSize(BaseContext):
     def get_app(self):
         cfg = Config()
-        cfg.ENABLE_ORIGINAL_PHOTO_UPLOAD = True
-        cfg.ALLOW_ORIGINAL_PHOTO_PUTTING = True
-        cfg.ORIGINAL_PHOTO_STORAGE = 'thumbor.storages.file_storage'
+        cfg.UPLOAD_ENABLED = True
+        cfg.UPLOAD_PUT_ALLOWED = True
+        cfg.UPLOAD_PHOTO_STORAGE = 'thumbor.storages.file_storage'
         cfg.FILE_STORAGE_ROOT_PATH = storage_path
-        cfg.MAX_SIZE = 40000
+        cfg.UPLOAD_MAX_SIZE = 40000
 
         importer = Importer(cfg)
         importer.import_modules()


### PR DESCRIPTION
Hi there,

I'd like to submit my first pull request on Thumbor about the naming of configuration variables for the `Upload` module in order to homogenize the naming with the other modules (for example Mongo storage where all variables starts with `MONGO_`)

Regards,

Nicolas
