### PR TITLE
thumbor-config aborts with error

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -102,7 +102,7 @@ Config.define('REDIS_QUEUE_SERVER_DB', 0, 'Server database index for the queued 
 Config.define('REDIS_QUEUE_SERVER_PASSWORD', None, 'Server password for the queued redis detector', 'Queued Redis Detector')
 
 def generate_config():
-    Config.get_config_text()
+    print Config.get_config_text()
 
 def format_value(value):
     if isinstance(value, basestring):


### PR DESCRIPTION
thumbor-config currently fails with this error message:

```
$ bin/thumbor-config 
Traceback (most recent call last):
  File "bin/thumbor-config", line 20, in <module>
    thumbor.config.generate_config()
  File "/home/wichert/lib/buildout/eggs/thumbor-3.4.0-py2.7-linux-x86_64.egg/thumbor/config.py", line 105, in generate_config
    Config.generate_config()
AttributeError: type object 'Config' has no attribute 'generate_config'
```

This appears to be caused by an API mismatch with the current version of deprconf.
