### PR TITLE
Fixing crop() parameters types before calling Geometry constructor to avoid "did not match C++ signature"

### DIFF
--- a/thumbor/engines/graphicsmagick.py
+++ b/thumbor/engines/graphicsmagick.py
@@ -51,10 +51,10 @@ class Engine(BaseEngine):
         self.image.zoom('%dx%d!'% (width,height))
 
     def crop(self, left, top, right, bottom):
-        offset_left = left
-        offset_top = top
-        width = right - left
-        height = bottom - top
+        offset_left = int(left)
+        offset_top = int(top)
+        width = int(right - left)
+        height = int(bottom - top)
 
         self.image.crop(
             Geometry(width, height, offset_left, offset_top)


### PR DESCRIPTION
CraphicsMagick version: 1.2.0

Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/tornado-2.1.1-py2.6.egg/tornado/web.py", line 1040, in wrapper
    return method(self, _args, *_kwargs)
  File "/usr/lib/python2.6/site-packages/thumbor-3.3.0-py2.6-linux-x86_64.egg/thumbor/handlers/image.py", line 80, in get
    return self.execute_image_operations()
  File "/usr/lib/python2.6/site-packages/thumbor-3.3.0-py2.6-linux-x86_64.egg/thumbor/handlers/**init**.py", line 65, in execute_image_operations
    self.get_image()
  File "/usr/lib/python2.6/site-packages/thumbor-3.3.0-py2.6-linux-x86_64.egg/thumbor/handlers/**init**.py", line 117, in get_image
    self._fetch(self.context.request.image_url, self.context.request.extension, callback)
  File "/usr/lib/python2.6/site-packages/thumbor-3.3.0-py2.6-linux-x86_64.egg/thumbor/handlers/__init__.py", line 204, in _fetch
    callback(False, buffer=buffer)
  File "/usr/lib/python2.6/site-packages/thumbor-3.3.0-py2.6-linux-x86_64.egg/thumbor/handlers/__init__.py", line 115, in callback
    Transformer(self.context).transform(after_transform_cb)
  File "/usr/lib/python2.6/site-packages/thumbor-3.3.0-py2.6-linux-x86_64.egg/thumbor/transformer.py", line 77, in transform
    self.smart_detect()
  File "/usr/lib/python2.6/site-packages/thumbor-3.3.0-py2.6-linux-x86_64.egg/thumbor/transformer.py", line 117, in smart_detect
    self.after_smart_detect([])
  File "/usr/lib/python2.6/site-packages/thumbor-3.3.0-py2.6-linux-x86_64.egg/thumbor/transformer.py", line 142, in after_smart_detect
    self.auto_crop()
  File "/usr/lib/python2.6/site-packages/thumbor-3.3.0-py2.6-linux-x86_64.egg/thumbor/transformer.py", line 191, in auto_crop
    self.engine.crop(crop_left, crop_top, crop_right, crop_bottom)
  File "/usr/lib/python2.6/site-packages/thumbor-3.3.0-py2.6-linux-x86_64.egg/thumbor/engines/graphicsmagick.py", line 60, in crop
    Geometry(width, height, offset_left, offset_top)
ArgumentError: Python argument types in
    Geometry.**init**(Geometry, int, int, float, int)
did not match C++ signature:
    **init**(_object*, Magick::Geometry)
    __init__(_object_, char const_)
    __init__(_object*, std::string)
    __init__(_object*, unsigned int, unsigned int)
    __init__(_object*, unsigned int, unsigned int, unsigned int)
    __init__(_object*, unsigned int, unsigned int, unsigned int, unsigned int)
    __init__(_object*, unsigned int, unsigned int, unsigned int, unsigned int, bool)
    __init__(_object*, unsigned int, unsigned int, unsigned int, unsigned int, bool, bool)
    __init__(_object*)
ERROR:root:500 GET /...
