### PR TITLE
Some improvements on install-opencv script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build
 nohup.out
 *.idea
 *.iml
+opencv

--- a/install-opencv.sh
+++ b/install-opencv.sh
@@ -1,18 +1,21 @@
+rm -rf ./opencv
 mkdir ./opencv
 cd ./opencv
 wget ftp://ftp.videolan.org/pub/videolan/x264/snapshots/last_stable_x264.tar.bz2
 tar xjf last_stable_x264.tar.bz2
 rm last_stable_x264.tar.bz2
-cd last_stable_x264
+cd `ls` # because directory name could be "last_stable_x264" or "x264-snapshot-20120824-2245-stable"
 ./configure --enable-static && make && sudo make install
+if [ "$?" != "0" ]; then echo "Installation failed." && exit $?; fi
 cd ..
-rm -rf last_stable_x264
+rm -rf `ls`
 
 wget http://ffmpeg.org/releases/ffmpeg-0.11.1.tar.gz
 tar xzf ffmpeg-0.11.1.tar.gz
 rm ffmpeg-0.11.1.tar.gz
 cd ffmpeg-0.11.1
 ./configure --enable-gpl --enable-libfaac --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libtheora --enable-libvorbis --enable-libx264 --enable-libxvid --enable-nonfree --enable-postproc --enable-version3 --enable-x11grab && make && sudo make install
+if [ "$?" != "0" ]; then echo "Installation failed." && exit $?; fi
 cd ..
 rm -rf ffmpeg-0.11.1
 
@@ -23,5 +26,6 @@ cd OpenCV-2.4.1
 mkdir release
 cd release
 cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_PYTHON_SUPPORT=ON -D BUILD_EXAMPLES=ON .. && make && sudo make install
+if [ "$?" != "0" ]; then echo "Installation failed." && exit $?; fi
 cd ../../..
 rm -rf opencv


### PR DESCRIPTION
Some improvements on install-opencv script: (1) Fixed access and deletion of x264 directory that changed in their last build; (2) Stop script if any compilation fails; (3) Cleanup opencv directory before starting to remove old files - useful when compilation failed previously.
