### PR TITLE
Disable the REST Upload API by default

### DIFF
--- a/thumbor/app.py
+++ b/thumbor/app.py
@@ -26,21 +26,21 @@ class ThumborServiceApp(tornado.web.Application):
             (r'/healthcheck', HealthcheckHandler),
         ]
 
-        # TODO Old handler to upload images
         if context.config.UPLOAD_ENABLED:
+            # TODO Old handler to upload images
             handlers.append(
                 (r'/upload', UploadHandler, { 'context': context })
             )
 
-        # Handler to upload images (POST).
-        handlers.append(
-            (r'/image', ImagesHandler, { 'context': context })
-        )
+            # Handler to upload images (POST).
+            handlers.append(
+                (r'/image', ImagesHandler, { 'context': context })
+            )
 
-        # Handler to retrieve or modify existing images  (GET, PUT, DELETE)
-        handlers.append(
-            (r'/image/(.*)', ImageHandler, { 'context': context })
-        )
+            # Handler to retrieve or modify existing images  (GET, PUT, DELETE)
+            handlers.append(
+                (r'/image/(.*)', ImageHandler, { 'context': context })
+            )
 
         # Imaging handler (GET)
         handlers.append(


### PR DESCRIPTION
Hii Bernardo,

Apparently there's no way to make a pull request for wiki pages in GitHub. Coud you manually copy the content from my fork : https://github.com/nhuray/thumbor/wiki/How-upload-images-in-thumbor.

Moreover I submit this pull request cause currently the REST Upload API is enabled, so it will be better if the end-point is disabled like the /upload end-point.  

Regards,
