### PR TITLE
Adding the "auto" option to the fill filter

### DIFF
--- a/thumbor/filters/fill.py
+++ b/thumbor/filters/fill.py
@@ -10,23 +10,79 @@
 
 from thumbor.filters import BaseFilter, filter_method
 
+
 class Filter(BaseFilter):
+
+    def detect_most_present_color(self):
+        # importing opencv here
+        # so thumbor keeps not depending on it
+        # for the basic features
+        import cv
+
+        sz = self.engine.size
+        mode, converted_image = self.engine.convert_to_rgb()
+
+        image = cv.CreateImageHeader(sz, cv.IPL_DEPTH_8U, 3)
+        cv.SetData(image, converted_image)
+
+        # Prepare the data for K-means. Represent each pixel in the image as a 3D
+        # vector (each dimension corresponds to one of B,G,R color channel value).
+        # Create a column of such vectors -- it will be width * height tall, 1 wide
+        # and have a total of 3 channels.
+        col = cv.Reshape(image, 3, image.width * image.height)
+        samples = cv.CreateMat(col.height, 1, cv.CV_32FC3)
+        cv.Scale(col, samples)
+        labels = cv.CreateMat(col.height, 1, cv.CV_32SC1)
+
+        # Run 10 iterations of the K-means algorithm.
+        termination_criteria = (cv.CV_TERMCRIT_EPS + cv.CV_TERMCRIT_ITER, 10, 1.0)
+        # one cluster of pixels
+        cv.KMeans2(samples, 1, labels, termination_criteria)
+
+        sum_r = sum_g = sum_b = 0
+        n_pixels = col.rows
+        for i in xrange(n_pixels):
+            r, g, b, _ = cv.Get1D(samples, i)
+            sum_r += r
+            sum_g += g
+            sum_b += b
+
+        # Determine the center of the cluster. The old OpenCV interface (C-style)
+        # doesn't seem to provide an easy way to get these directly, so we have to
+        # calculate them ourselves.
+        r = int(sum_r / n_pixels)
+        g = int(sum_g / n_pixels)
+        b = int(sum_b / n_pixels)
+
+        return '{:02x}{:02x}{:02x}'.format(r, g, b)
 
     @filter_method(r'[\w]+')
     def fill(self, value):
+
         self.fill_engine = self.engine.__class__(self.context)
         bx = self.context.request.width if self.context.request.width != 0 else self.engine.image.size[0]
         by = self.context.request.height if self.context.request.height != 0 else self.engine.image.size[1]
 
-        (ix, iy) = self.engine.size
+        # if the value is 'auto'
+        # we will use kmeans (from opencv) to define
+        # the most predominant color on the image
+        # and set it is the filling color
+        # more info:
+        # http://stackoverflow.com/questions/3923906/kmeans-in-opencv-python-interface
+        # http://docs.opencv.org/modules/core/doc/clustering.html
+        # credits to misha http://stackoverflow.com/users/356020/misha
+        if value == 'auto':
+            value = self.detect_most_present_color()
 
         try:
-            self.fill_engine.image = self.fill_engine.gen_image((bx,by), value)
+            self.fill_engine.image = self.fill_engine.gen_image((bx, by), value)
         except (ValueError, RuntimeError):
-            self.fill_engine.image = self.fill_engine.gen_image((bx,by), '#%s' % value)
+            self.fill_engine.image = self.fill_engine.gen_image((bx, by), '#%s' % value)
 
-        px = ( bx - ix ) / 2 #top left
-        py = ( by - iy ) / 2
+        ix, iy = self.engine.size
+
+        px = (bx - ix) / 2  # top left
+        py = (by - iy) / 2
 
         self.fill_engine.paste(self.engine, (px, py), merge=False)
         self.engine.image = self.fill_engine.image


### PR DESCRIPTION
Now its posible to pass "auto" as an option to the  fill filter and it will choose a color that looks ok with the current image.

The implementation uses opencv's K-means implementation. I'm not really sure if it's the best option when you have only one cluster, but it's working fine.

http://docs.opencv.org/modules/core/doc/clustering.html

Also got the idea from this post:

http://charlesleifer.com/blog/using-python-and-k-means-to-find-the-dominant-colors-in-images/

So, credits for him.

Examples of the current implementation:
![](http://f.cl.ly/items/2e3e06111J2p1U0v1x2v/Image%202013.02.05%206:07:09%20PM.png)
![](http://f.cl.ly/items/3H2D0n242V1U1L0N0933/Image%202013.02.05%206:19:09%20PM.png)
![](http://f.cl.ly/items/450J261q3j0r2E1s3y1b/Image%202013.02.05%206:19:45%20PM.png)
![](http://f.cl.ly/items/3w01192M2g0j3H3I2q3n/Image%202013.02.05%206:20:04%20PM.png)
![](http://f.cl.ly/items/3S3c032p0c2l0x3Q1Q0z/Image%202013.02.05%206:20:26%20PM.png)
