### PR TITLE
Adding in S3 Loader/Storage/Result Storage

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -111,6 +111,20 @@ Config.define('SQS_QUEUE_KEY_ID', None, 'AWS key id', 'Queued SQS Detector')
 Config.define('SQS_QUEUE_KEY_SECRET', None, 'AWS key secret', 'Queued SQS Detector')
 Config.define('SQS_QUEUE_REGION', 'us-east-1', 'AWS SQS region', 'Queued SQS Detector')
 
+#AWS SETTINGS
+Config.define('AWS_ACCESS_KEY',None,'AWS access key','For AWS loaders/storages/result_storages')
+Config.define('AWS_SECRET_KEY',None,'AWS secret key','For AWS loaders/storages/result_storages')
+
+#S3 STORAGE
+Config.define('STORAGE_BUCKET',None,'Storage bucket','S3 Storage')
+
+#S3 RESULT STORAGE
+Config.define('RESULT_STORAGE_BUCKET',None,'Storage bucket','S3 Result Storage')
+
+#S3 LOADER
+Config.define('S3_LOADER_BUCKET','','Bucket to load paths from','S3 Loader')
+Config.define('S3_ALLOWED_BUCKETS',[],'Buckets allowed to load from','S3 Loader')
+
 def generate_config():
     config.generate_config()
 

--- a/thumbor/loaders/s3_loader.py
+++ b/thumbor/loaders/s3_loader.py
@@ -1,0 +1,50 @@
+# coding: utf-8
+
+from boto.s3.connection import S3Connection
+from boto.s3.bucket import Bucket
+from boto.s3.key import Key
+
+connection = None
+
+def _get_bucket(url):
+	#first item in URL
+	arr = url.lstrip('/').split('/')
+	return arr[0],"/".join(arr[1:])
+
+def _validate_bucket(context,bucket):
+	if not context.config.S3_ALLOWED_BUCKETS:
+		return True
+
+	for allowed in context.config.S3_ALLOWED_BUCKETS:
+		#s3 is case sensitive
+		if allowed == bucket:
+			return True
+
+	return False
+
+def load(context, url, callback):
+	
+	if context.config.S3_LOADER_BUCKET:
+		bucket = context.config.S3_LOADER_BUCKET
+	else:
+		bucket,url = _get_bucket(url)
+		if not _validate_bucket(context,bucket):
+			return callback(None)
+
+	if connection is None:
+		#Store connection not bucket
+		connection = S3Connection(
+			context.config.AWS_ACCESS_KEY,
+			context.config.AWS_SECRET_KEY
+		)
+
+	bucketLoader = Bucket(
+		connection=connection,
+		name=bucket
+	)
+
+	file_key = bucketLoader.get_key(file_abspath)
+	if not file_key:
+		return callback(None)
+
+	return callback(file_key.read())

--- a/thumbor/result_storages/s3_storage.py
+++ b/thumbor/result_storages/s3_storage.py
@@ -1,0 +1,69 @@
+#coding: utf-8
+
+import calendar
+from datetime import datetime, timedelta
+import hashlib
+
+from thumbor.result_storages import BaseStorage
+from thumbor.utils import logger
+
+from boto.s3.connection import S3Connection
+from boto.s3.bucket import Bucket
+from boto.s3.key import Key
+from dateutil.parser import parse as parse_ts
+
+
+class Storage(BaseStorage):
+
+    def __init__(self, context):
+        BaseStorage.__init__(self, context)
+        self.storage = self.__get_s3_bucket()
+
+    def __get_s3_connection(self):
+        return S3Connection(
+            self.context.config.AWS_ACCESS_KEY,
+            self.context.config.AWS_SECRET_KEY
+        )
+        
+    def __get_s3_bucket(self):
+        return Bucket(
+            connection=self.__get_s3_connection(),
+            name=self.context.config.RESULT_STORAGE_BUCKET
+        )
+
+    def put(self, bytes):
+        file_abspath = self.normalize_path(self.context.request.url)
+        file_key=Key(self.storage)
+        file_key.key = file_abspath
+        file_key.set_contents_from_string(bytes)
+
+    def get(self):
+        file_abspath = self.normalize_path(self.context.request.url)
+        file_key = self.storage.get_key(file_abspath)
+
+        if not file_key or self.is_expired(file_key):
+            logger.debug("[RESULT_STORAGE] s3 key not found at %s" % file_abspath)
+            return None
+
+        return file_key.read()
+
+    def normalize_path(self, path):
+        digest = hashlib.sha1(path.encode('utf-8')).hexdigest()
+        return "thumbor/result_storage/"+digest
+
+    def is_expired(self, key):
+        if key:
+            timediff = datetime.now() - self.utc_to_local(parse_ts(key.last_modified))
+            return timediff.seconds > self.context.config.STORAGE_EXPIRATION_SECONDS
+        else:
+            #If our key is bad just say we're expired
+            return True
+
+    def utc_to_local(self,utc_dt):
+        # get integer timestamp to avoid precision lost
+        timestamp = calendar.timegm(utc_dt.timetuple())
+        local_dt = datetime.fromtimestamp(timestamp)
+        assert utc_dt.resolution >= timedelta(microseconds=1)
+        return local_dt.replace(microsecond=utc_dt.microsecond)
+
+

--- a/thumbor/storages/s3_storage.py
+++ b/thumbor/storages/s3_storage.py
@@ -1,0 +1,152 @@
+#coding: utf-8
+
+import calendar
+from datetime import datetime, timedelta
+import hashlib
+from json import loads, dumps
+
+from os.path import splitext
+
+from thumbor.storages import BaseStorage
+from thumbor.utils import logger
+
+from boto.s3.connection import S3Connection
+from boto.s3.bucket import Bucket
+from boto.s3.key import Key
+from dateutil.parser import parse as parse_ts
+
+
+class Storage(BaseStorage):
+
+    
+    def __init__(self, context):
+        BaseStorage.__init__(self, context)
+        self.storage = self.__get_s3_bucket()
+
+    def __get_s3_connection(self):
+        return S3Connection(
+            self.context.config.AWS_ACCESS_KEY,
+            self.context.config.AWS_SECRET_KEY
+        )
+
+    def __get_s3_bucket(self):
+        return Bucket(
+            connection=self.__get_s3_connection(),
+            name=self.context.config.STORAGE_BUCKET
+        )
+
+    def put(self, path, bytes):
+        file_abspath = self.normalize_path(path)
+
+        file_key=Key(self.storage)
+        file_key.key = file_abspath
+
+        file_key.set_contents_from_string(bytes)
+
+        return path
+
+    def put_crypto(self, path):
+        if not self.context.config.STORES_CRYPTO_KEY_FOR_EACH_IMAGE:
+            return
+
+        file_abspath = self.normalize_path(path)
+
+        if not self.context.server.security_key:
+            raise RuntimeError("STORES_CRYPTO_KEY_FOR_EACH_IMAGE can't be True if no SECURITY_KEY specified")
+
+        crypto_path = '%s.txt' % splitext(file_abspath)[0]
+
+        file_key=Key(self.storage)
+        file_key.key = crypto_path
+
+        file_key.set_contents_from_string(self.context.server.security_key)
+
+        return crypto_path
+
+    def put_detector_data(self, path, data):
+        file_abspath = self.normalize_path(path)
+
+        path = '%s.detectors.txt' % splitext(file_abspath)[0]
+        
+        file_key=Key(self.storage)
+        file_key.key = path
+
+        file_key.set_contents_from_string(dumps(data))
+
+        return path
+
+    def get_crypto(self, path):
+        file_abspath = self.normalize_path(path)
+        crypto_file = "%s.txt" % (splitext(file_abspath)[0])
+
+        file_key = self.storage.get_key(crypto_path)
+        if not file_key:
+            return None
+
+        return file_key.read()
+
+    def get(self, path):
+
+        file_abspath = self.normalize_path(path)
+
+        file_key = self.storage.get_key(file_abspath)
+
+        if not file_key or self.is_expired(file_abspath):
+            logger.debug("[STORAGE] s3 key not found at %s" % file_abspath)
+            return None
+
+        return file_key.read()
+
+    def get_detector_data(self, path):
+        file_abspath = self.normalize_path(path)
+        path = '%s.detectors.txt' % splitext(file_abspath)[0]
+        
+        file_key = self.storage.get_key(path)
+
+        if not file_key or self.is_expired(path):
+            return None
+
+        return loads(file_key.read())
+
+    def exists(self, path):
+        file_abspath = self.normalize_path(path)
+        file_key = self.storage.get_key(file_abspath)
+        if not file_key:
+            return False
+        return True
+
+    def normalize_path(self, path):
+        digest = hashlib.sha1(path.encode('utf-8')).hexdigest()
+        return "thumbor/storage/"+digest
+
+    def is_expired(self, key):
+        if key:
+            expire_in_seconds = self.context.config.get('RESULT_STORAGE_EXPIRATION_SECONDS', None)
+
+            #Never expire
+            if expire_in_seconds is None or expire_in_seconds == 0:
+                return False
+
+            timediff = datetime.now() - self.utc_to_local(parse_ts(key.last_modified))
+            return timediff.seconds > expire_in_seconds
+        else:
+            #If our key is bad just say we're expired
+            return True
+
+    def remove(self, path):
+
+        if not self.exists(path):
+            return
+
+        if not self.storage.delete_key(path):
+            return False
+        return True
+
+    def utc_to_local(utc_dt):
+        # get integer timestamp to avoid precision lost
+        timestamp = calendar.timegm(utc_dt.timetuple())
+        local_dt = datetime.fromtimestamp(timestamp)
+        assert utc_dt.resolution >= timedelta(microseconds=1)
+        return local_dt.replace(microsecond=utc_dt.microsecond)
+
+

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -154,3 +154,28 @@ FILTERS = [
     # has already went through remote detection
     # 'thumbor.filters.redeye',
 ]
+
+#AWS parameters for storage/result_storage/loader
+# AWS_ACCESS_KEY = ""
+# AWS_SECRET_KEY =""
+
+#Storage bucket for S3 storage
+# STORAGE_BUCKET = ""
+
+#Storage bucket for S3 result_storage
+# RESULT_STORAGE_BUCKET = ""
+
+#Note about S3 Loader paths:
+#When using the S3 loader then first thing in your path should be the bucket name
+#However if you have S3_LOADER_BUCKET defined then the bucket should not be in the path at all
+
+#Example without S3_LOADER_BUCKET:
+# http://thumbor-server/unsafe/300x300/smart/BUCKET/path/to/image/file
+#Example with S3_LOADER_BUCKET
+# http://thumbor-server/unsafe/300x300/smart/path/to/image/file
+
+#Bucket to load files out of for S3 Loader
+# S3_LOADER_BUCKET = ""
+
+#Allowed buckets for S3 Loader
+# S3_ALLOWED_BUCKETS


### PR DESCRIPTION
Have also added in the necessary config settings to thumbor.conf and config.py

Have taken code from some extensions I wrote to provide this functionality. You can see them at https://github.com/willtrking/thumbor_aws

These extensions are going to be used in production at upout.com very soon

Required python packages:
boto (all)
python-dateutil (storage/result_storage provides expiration functionality)

Config options:
AWS_ACCESS_KEY
AWS_SECRET_KEY

STORAGE_BUCKET

RESULT_STORAGE_BUCKET

S3_LOADER_BUCKET
S3_ALLOWED_BUCKETS
