### PR TITLE
[Thumbor] reply 204 on every HEAD method

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -46,6 +46,9 @@ class BaseHandler(tornado.web.RequestHandler):
             logger.warn(msg)
         self.finish()
 
+    def head(self, *args, **kwargs):
+        self.set_status(204)
+
     def init_request_params(self):
         self.context.request.quality = self.context.config.QUALITY
         self.context.request.url = self.request.path

--- a/vows/healthcheck_vows.py
+++ b/vows/healthcheck_vows.py
@@ -42,3 +42,16 @@ class HealthCheck(TornadoHTTPContext):
 
             def should_equal_working(self, topic):
                 expect(topic.lower().strip()).to_equal('working')
+
+    class HeadHandler(TornadoHTTPContext):
+        def topic(self):
+            response = self.head('/healthcheck')
+            return (response.code, response.body)
+
+        class StatusCode(TornadoHTTPContext):
+            def topic(self, response):
+                return response[0]
+
+            def should_not_be_an_error(self, topic):
+                expect(topic).to_equal(204)
+


### PR DESCRIPTION
Nginx reverse HTTP service does not provide (out of the box) method to check health on upstream services.
It only do periodically HEAD requests on the / given its configuration.

In thumbor HEAD method is not implemented resulting in 405 method not allowed.

I just added a basic implementation of head in handler that only reply "204 no content" on every requests. so that nginx service should be happy.
