### PR TITLE
Check first few bytes for gif files

### DIFF
--- a/thumbor/engines/opencv.py
+++ b/thumbor/engines/opencv.py
@@ -27,7 +27,7 @@ class Engine(BaseEngine):
         # segfaults when trying to decoding a gif. An exception is a
         # less drastic measure.
         try:
-            if FORMATS[self.extension] == 'GIF':
+            if FORMATS[self.extension] == 'GIF' or buffer[:3] == "GIF":
                 raise ValueError("opencv doesn't support gifs")
         except KeyError:
             pass


### PR DESCRIPTION
Thumbor segfaults when the image type is gif but the extension is not.  So including an extra check for the image header to see if it's a GIF.

Program received signal SIGSEGV, Segmentation fault.
0x00007fffeb4c61cb in FROM_IplImagePTR(_IplImage*) () from /usr/lib64/python2.6/site-packages/cv2.so
(gdb) bt
#0  0x00007fffeb4c61cb in FROM_IplImagePTR(_IplImage*) () from /usr/lib64/python2.6/site-packages/cv2.so
#1  0x00007fffeb4c640c in pycvDecodeImage(_object_, _object_, _object*) () from /usr/lib64/python2.6/site-packages/cv2.so
#2  0x00007ffff7b0c9e4 in PyEval_EvalFrameEx () from /usr/lib64/libpython2.6.so.1.0
#3  0x00007ffff7b0db8f in PyEval_EvalFrameEx () from /usr/lib64/libpython2.6.so.1.0
#4  0x00007ffff7b0db8f in PyEval_EvalFrameEx () from /usr/lib64/libpython2.6.so.1.0
#5  0x00007ffff7b0e657 in PyEval_EvalCodeEx () from /usr/lib64/libpython2.6.so.1.0
#6  0x00007ffff7b0caa4 in PyEval_EvalFrameEx () from /usr/lib64/libpython2.6.so.1.0
