### PR TITLE
[ErrorHandlers] add a file error handler to store error as json logs file...

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -243,6 +243,9 @@ Config.define(
     'Sentry thumbor project dsn. i.e.: ' +
     'http://5a63d58ae7b94f1dab3dee740b301d6a:73eea45d3e8649239a973087e8f21f98@localhost:9000/2', 'Errors - Sentry')
 
+# FILE REPORTING MODULE
+Config.define('ERROR_FILE_LOGGER', None, 'File of error log as json', 'Errors')
+
 
 def generate_config():
     config.generate_config()

--- a/thumbor/error_handlers/file.py
+++ b/thumbor/error_handlers/file.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import logging, logging.handlers, json
+from thumbor import __version__
+
+class ErrorHandler(object):
+    def __init__(self, config):
+
+        file = config.ERROR_FILE_LOGGER
+        if not file:
+            raise RuntimeError(
+                "If you set USE_CUSTOM_ERROR_HANDLING to True, and you are using thumbor_file_logger.logger, " +
+                "then you must specify the file path to log to with the ERROR_FILE_LOGGER configuration."
+            )
+
+
+        self.logger = logging.getLogger('error_handler')
+        self.logger.setLevel(logging.ERROR)
+        self.logger.addHandler(logging.handlers.WatchedFileHandler(config.ERROR_FILE_LOGGER))
+            
+    def handle_error(self, context, handler, exception):
+        req = handler.request
+        extra = {
+            'thumbor-version': __version__
+        }
+        extra.update({
+            'Headers': req.headers
+        })
+        cookies_header = extra.get('Headers', {}).get('Cookie', {})
+        if isinstance(cookies_header, basestring):
+            cookies = {}
+            for cookie in cookies_header.split(';'):
+                if not cookie:
+                    continue
+                values = cookie.strip().split('=')
+                key, val = values[0], "".join(values[1:])
+                cookies[key] = val
+        else:
+            cookies = cookies_header
+        extra['Headers']['Cookie'] = cookies
+
+        data = {
+            'Http': {
+                'url': req.full_url(),
+                'method': req.method,
+                'data': req.arguments,
+                'body': req.body,
+                'query_string': req.query
+            },
+            'interfaces.User': {
+                'ip': req.remote_ip,
+            },
+            'exception': str(exception),
+            'extra': extra
+        }
+
+        self.logger.error(json.dumps(data))

--- a/vows/file_error_handler_vows.py
+++ b/vows/file_error_handler_vows.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+from pyvows import Vows, expect
+
+from thumbor import __version__
+from thumbor.error_handlers.file import ErrorHandler
+from thumbor.config import Config
+from thumbor.context import Context, ServerParameters
+
+import json,tempfile
+
+
+class FakeRequest(object):
+    def __init__(self):
+        self.headers = {
+            'header1': 'value1',
+            'Cookie': 'cookie1=value; cookie2=value2;'
+        }
+
+        self.url = "test/"
+        self.method = "GET"
+        self.arguments = []
+        self.body = "body"
+        self.query = "a=1&b=2"
+        self.remote_ip = "127.0.0.1"
+
+    def full_url(self):
+        return "http://test/%s" % self.url
+
+
+class FakeHandler(object):
+    def __init__(self):
+        self.request = FakeRequest()
+
+@Vows.batch
+class ErrorHandlerVows(Vows.Context):
+    class WhenInvalidConfiguration(Vows.Context):
+        def topic(self):
+            cfg = Config()
+            ErrorHandler(cfg)
+
+        def should_be_error(self, topic):
+            expect(topic).to_be_an_error()
+            expect(topic).to_be_an_error_like(RuntimeError)
+
+    class WhenErrorOccurs(Vows.Context):
+        def topic(self):
+            #use temporary file to store logs
+            tmp = tempfile.NamedTemporaryFile(prefix='thumborTest')
+
+            cfg = Config(SECURITY_KEY='ACME-SEC', ERROR_FILE_LOGGER=tmp.name)
+            server = ServerParameters(8889, 'localhost', 'thumbor.conf', None, 'info', None)
+            server.security_key = 'ACME-SEC'
+            ctx = Context(server, cfg, None)
+
+            handler = ErrorHandler(cfg)
+            http_handler = FakeHandler()
+
+            handler.handle_error(ctx, http_handler, RuntimeError("Test"))
+            #return content of file
+            return tmp.read()
+      
+        def should_have_called_client(self, topic):
+            #check against json version
+            expect(json.loads(topic)).to_be_like ({
+                'Http': {
+                    'url': 'http://test/test/',
+                    'method': 'GET',
+                    'data': [],
+                    'body': "body",
+                    'query_string': "a=1&b=2"
+                },
+                'interfaces.User': {
+                    'ip': "127.0.0.1",
+                },
+                'exception': 'Test',
+                'extra': {
+                    'thumbor-version':  __version__,
+                    'Headers' : {
+                        'header1': 'value1', 
+                        'Cookie': {
+                            'cookie1': 'value', 
+                            'cookie2': 'value2'
+                        }
+                    },
+                }
+            })
+


### PR DESCRIPTION
This error handler store 1 json object per line representing context or exception (inspired by sentry content).

I choose Json because I prefer keep structured data for logs.
This keep readable for humans but easily parsed for engines and wildly used.

I started it as a independent module, but maybe a file logger could in the native application make sens.
Let me know if you prefer keep it out of the code base.
