### PR TITLE
Server Socket from File Desriptor

### DIFF
--- a/thumbor/console.py
+++ b/thumbor/console.py
@@ -18,7 +18,7 @@ def get_server_parameters(arguments=None):
     parser = optparse.OptionParser(usage="thumbor or type thumbor -h (--help) for help", description=__doc__, version=__version__)
     parser.add_option("-p", "--port", type="int", dest="port", default=8888, help="The port to run this thumbor instance at [default: %default].")
     parser.add_option("-i", "--ip", dest="ip", default="0.0.0.0", help="The host address to run this thumbor instance at [default: %default].")
-    parser.add_option("-f", "--fd", type="int", dest="fd", help="The file descriptor to listen for connections on (--port and --ip will be ignored if this is set) [default: %default].")
+    parser.add_option("-f", "--filedescriptor", type="int", dest="filedescriptor", help="The file descriptor to listen for connections on (--port and --ip will be ignored if this is set) [default: %default].")
     parser.add_option("-c", "--conf", dest="conf", default="", help="The path of the configuration file to use for this thumbor instance [default: %default].")
     parser.add_option("-k", "--keyfile", dest="keyfile", default="", help="The path of the security key file to use for this thumbor instance [default: %default].")
     parser.add_option("-l", "--log-level", dest="log_level", default="warning", help="The log level to be used. Possible values are: debug, info, warning, error, critical or notset. [default: %default].")
@@ -28,14 +28,14 @@ def get_server_parameters(arguments=None):
 
     port = options.port
     ip = options.ip
-    fd = options.fd
+    filedescriptor = options.filedescriptor
     conf = options.conf or None
     keyfile = options.keyfile or None
     log_level = options.log_level
 
     return ServerParameters(port=port,
                             ip=ip,
-                            fd=fd,
+                            filedescriptor=filedescriptor,
                             config_path=conf,
                             keyfile=keyfile,
                             log_level=log_level,

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -37,10 +37,10 @@ class Context:
 
 
 class ServerParameters(object):
-    def __init__(self, port, ip, fd, config_path, keyfile, log_level, app_class):
+    def __init__(self, port, ip, filedescriptor, config_path, keyfile, log_level, app_class):
         self.port = port
         self.ip = ip
-        self.fd = fd
+        self.filedescriptor = filedescriptor
         self.config_path = config_path
         self.keyfile = keyfile
         self.log_level = log_level

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -60,8 +60,10 @@ def main(arguments=None):
     application = importer.import_class(server_parameters.app_class)(context)
 
     server = HTTPServer(application)
-    if context.server.fd is not None:
-        sock = socket.fromfd(context.server.fd, socket.AF_INET | socket.AF_INET, socket.SOCK_STREAM)
+    if context.server.filedescriptor is not None:
+        sock = socket.fromfd(context.server.filedescriptor,
+                             socket.AF_INET | socket.AF_INET6,
+                             socket.SOCK_STREAM)
         server.add_socket(sock)
     else:
         server.bind(context.server.port, context.server.ip)


### PR DESCRIPTION
Update thumbor server to take a new option, -f/--fd, which expects a
file descriptor to create a socket from. This socket is then given to
the HTTPServer. This change makes it possible to run thumbor under
something like circus.

I'd like to run thumbor under circus (http://circus.readthedocs.org/en/latest/) and the best way to do that is to allow circus to manage your sockets for you and have your program open a socket based on a file descriptor that circus provides to you. This change makes that possible. A sample circus.ini that this works with would be:

```
[socket:thumbor]
port = 8888
host = 0.0.0.0

[watcher:thumbor]
cmd = .env/bin/thumbor --fd $(circus.sockets.thumbor)
use_sockets = True
```

Running thumbor this way also makes it much easier to run multiple instances since you don't have to worry about managing multiple ports.
