### PR TITLE
Keep transparency when converting gif to png

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -49,12 +49,13 @@ class Engine(BaseEngine):
 
     def create_image(self, buffer):
         img = Image.open(BytesIO(buffer))
-        self.icc_profile = img.info.get('icc_profile', None)
+        self.icc_profile = img.info.get('icc_profile')
+        self.transparency = img.info.get('transparency')
 
         if self.context.config.ALLOW_ANIMATED_GIFS and self.extension == '.gif':
             frames = []
             for frame in ImageSequence.Iterator(img):
-                frames.append(frame.convert())
+                frames.append(frame.convert('P'))
             img.seek(0)
             return frames
 
@@ -125,6 +126,9 @@ class Engine(BaseEngine):
             exif = self.image.info.get('exif', None)
             if exif is not None:
                 options['exif'] = exif
+
+        if self.image.mode == 'P' and self.transparency:
+            options['transparency'] = self.transparency
 
         try:
             if ext == '.webp':


### PR DESCRIPTION
Hello,

I commented on issue #136 a problem I had when converting a transparent gif to png, it would turn the background black instead of keeping the transparency.

I found a solution to my problem, unfortunately not generic enough to fix the issue (not sure if it's that much related after all, I should have opened a new issue).

This change fixes my problem, I also tested animated gifs to make sure I didn't broken them. But I'm not an expert on PIL or images modes and conversion in general, so I appreciate any code review, more testing for other cases, suggestions to make the solution more generic.

The tests pass but I didn't add any more tests. Do you have any test that actually modifies images and checks the metadata for results, or something like that? I couldn't find a place to add a test for this change.

Thanks, hope to get this fix to start using in prod! :)
