### PR TITLE
Revert "Installing pexif from untrusted source" (fixes #270)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ install:
     - wget http://python-distribute.org/distribute_setup.py
     - python distribute_setup.py
 
-    - pip install pexif==0.13 --allow-external pexif --allow-unverified pexif
-
     # install python requirements
     - make setup
 


### PR DESCRIPTION
This reverts commit adbb51c75bbb0d5c1268b84413e99b7f33dbe572.

pexif 0.13 now installs from PyPI, see bennoleslie/pexif#3
