### PR TITLE
Pass log level through upstart script

### DIFF
--- a/debian/thumbor-worker.upstart
+++ b/debian/thumbor-worker.upstart
@@ -33,7 +33,7 @@ end script
 
 script
     . "/tmp/${UPSTART_JOB}-${p}"
-    $DAEMON -c "${conffile}" -i "${ip}" -k "${keyfile}" -p "${p}" -l debug
+    $DAEMON -c "${conffile}" -i "${ip}" -k "${keyfile}" -p "${p}" -l "${level}"
 end script
 
 post-start script

--- a/debian/thumbor.default
+++ b/debian/thumbor.default
@@ -18,3 +18,8 @@ conffile=/etc/thumbor.conf
 # port=8888,8889,8890
 # or
 # port=8888 #Default
+
+# The log level to be used.
+# Possible values are: debug, info, warning, error, critical or notset.
+# More on that at http://docs.python.org/library/logging.html. It defaults to warning.
+# level=warning

--- a/debian/thumbor.ubuntu.upstart
+++ b/debian/thumbor.ubuntu.upstart
@@ -7,6 +7,7 @@ stop on runlevel [!2345]
 console output
 
 env port=8888
+env level=warning
 
 pre-start script
     [ -r /etc/default/thumbor ] && . /etc/default/thumbor
@@ -16,6 +17,6 @@ pre-start script
         exit 0
     fi
     for p in `echo ${port} | tr ',' ' '`; do
-        start thumbor-worker p=$p
+        start thumbor-worker p=$p level=$level
     done
 end script


### PR DESCRIPTION
It was hardcoded to debug before, so probably not the best idea.
