### PR TITLE
Creating directory before attempting to create file for detection.

### DIFF
--- a/thumbor/storages/file_storage.py
+++ b/thumbor/storages/file_storage.py
@@ -61,6 +61,10 @@ class Storage(storages.BaseStorage):
 
         path = '%s.detectors.txt' % splitext(file_abspath)[0]
         temp_abspath = "%s.%s" % (path, str(uuid4()).replace('-', ''))
+
+        file_dir_abspath = dirname(file_abspath)
+        self.ensure_dir(file_dir_abspath)
+
         with open(temp_abspath, 'w') as _file:
             _file.write(dumps(data))
 


### PR DESCRIPTION
Error solved:

```
IFile "lib/python2.7/site-packages/thumbor/storages/file_storage.py", line 64, in put_detector_data
IOError: [Errno 2] No such file or directory: '/path/to/file/ba/4ed3bf706f2efff35373ae03b52f850bd3a695.detectors.txt.e666f83dd1f94f96925b79f9ee272ebe'
```

This error occurs only when the storage configuration is as follows:

``` python
MIXED_STORAGE_FILE_STORAGE = 'thumbor.storages.no_storage'
MIXED_STORAGE_CRYPTO_STORAGE = 'thumbor.storages.no_storage'
MIXED_STORAGE_DETECTOR_STORAGE = 'thumbor.storages.file_storage'
```

if MIXED_STORAGE_FILE_STORAGE is enabled for file cache, the folder already exists when will save the detection
