### PR TITLE
Add image files to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ recursive-include thumbor *.py
 recursive-include thumbor *.conf
 recursive-include thumbor *.xml
 recursive-include thumbor *.h
+recursive-include thumbor/integration_tests/imgs *


### PR DESCRIPTION
These images are used in integration tests which in turn are used by engines such as [opencv-engine](/thumbor/opencv-engine). The lack of such images make the [tests fail with a 404 error](https://travis-ci.org/scorphus/opencv-engine/builds/29798087).

As one can see in [this travis build](https://travis-ci.org/scorphus/opencv-engine/builds/29798048), installing thumbor from this very branch (`pip install -U https://github.com/scorphus/thumbor/tarball/fix-integration`) makes the integration tests work.

What's left to see is if there's a better way make those images available to integration tests.
