### PR TITLE
Add blacklist functionality

### DIFF
--- a/thumbor/app.py
+++ b/thumbor/app.py
@@ -10,6 +10,7 @@
 import tornado.web
 import tornado.ioloop
 
+from thumbor.handlers.blacklist import BlacklistHandler
 from thumbor.handlers.healthcheck import HealthcheckHandler
 from thumbor.handlers.legacy_upload import LegacyImageUploadHandler
 from thumbor.handlers.upload import ImageUploadHandler
@@ -43,6 +44,11 @@ class ThumborServiceApp(tornado.web.Application):
             # Handler to retrieve or modify existing images  (GET, PUT, DELETE)
             handlers.append(
                 (r'/image/(.*)', ImageResourceHandler, {'context': self.context})
+            )
+
+        if self.context.config.USE_BLACKLIST:
+            handlers.append(
+                (r'/blacklist', BlacklistHandler, {'context': self.context})
             )
 
         # Imaging handler (GET)

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -56,6 +56,10 @@ Config.define(
     'Indicates whether thumbor should use gifsicle engine. Please note that smart cropping and filters are not supported for gifs using gifsicle (but won\'t give an error).', 'Imaging')
 
 Config.define(
+    'USE_BLACKLIST', False,
+    'Indicates whether thumbor should enable blacklist functionality to prevent processing certain images.', 'Imaging')
+
+Config.define(
     'LOADER', 'thumbor.loaders.http_loader',
     'The loader thumbor should use to load the original image. This must be the full name of a python module ' +
     '(python must be able to import it)', 'Extensibility')

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -320,6 +320,12 @@ class BaseHandler(tornado.web.RequestHandler):
 
             self.context.modules.loader.load(self.context, url, handle_loader_loaded)
 
+    def get_blacklist_contents(self):
+      filename = 'blacklist.txt'
+      if self.context.modules.storage.exists(filename):
+          return self.context.modules.storage.get(filename)
+      else:
+          return ""
 
 class ContextHandler(BaseHandler):
     def initialize(self, context):

--- a/thumbor/handlers/blacklist.py
+++ b/thumbor/handlers/blacklist.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+from thumbor.handlers import ContextHandler
+from thumbor.utils import logger
+import pdb
+
+class BlacklistHandler(ContextHandler):
+
+    def get(self):
+        blacklist = self.get_blacklist_contents()
+        self.write(blacklist)
+        self.set_header('Content-Type', 'text/plain')
+        self.set_status(200)
+
+    def put(self):
+        blacklist = self.get_blacklist_contents()
+        blacklist +=  self.request.query + "\n"
+        logger.debug('Adding to blacklist: %s' % self.request.query)
+        self.context.modules.storage.put('blacklist.txt', blacklist)
+        self.set_status(200)

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -46,6 +46,12 @@ class ImagingHandler(ContextHandler):
             self._error(404, 'URL has unsafe but unsafe is not allowed by the config: %s' % url)
             return
 
+        if self.context.config.USE_BLACKLIST:
+            blacklist = self.get_blacklist_contents()
+            if self.context.request.image_url in blacklist:
+              self._error(404, 'Source image url has been blacklisted: %s' % self.context.request.image_url )
+              return
+
         url_signature = self.context.request.hash
         if url_signature:
             signer = Signer(self.context.server.security_key)

--- a/vows/blacklist_vows.py
+++ b/vows/blacklist_vows.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+from pyvows import Vows, expect
+from tornado_pyvows.context import TornadoHTTPContext
+
+from thumbor.app import ThumborServiceApp
+from thumbor.importer import Importer
+from thumbor.config import Config
+from thumbor.context import Context, ServerParameters
+
+from os.path import abspath, join, dirname, exists
+from shutil import rmtree
+import pdb
+
+
+class BaseContext(TornadoHTTPContext):
+    def get_app(self):
+        file_storage_root_path = '/tmp/thumbor-vows/storage'
+        if exists(file_storage_root_path):
+            rmtree(file_storage_root_path)
+
+        cfg = Config()
+        cfg.USE_BLACKLIST = True
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = abspath(join(dirname(__file__), 'fixtures/'))
+        cfg.STORAGE = 'thumbor.storages.file_storage'
+        cfg.FILE_STORAGE_ROOT_PATH = file_storage_root_path
+
+        importer = Importer(cfg)
+        importer.import_modules()
+
+        server = ServerParameters(8889, 'localhost', 'thumbor.conf', None, 'debug', None)
+        ctx = Context(server, cfg, importer)
+        application = ThumborServiceApp(ctx)
+        return application
+
+@Vows.batch
+class Blacklist(BaseContext):
+
+    class BaseBlacklist(TornadoHTTPContext):
+        def topic(self):
+            response = self.get('/blacklist')
+            return (response.code, response.body)
+
+        def should_return_blank(self, topic):
+            expect(topic[1]).to_equal("")
+
+        def should_return_200(self, topic):
+            expect(topic[0]).to_equal(200)
+
+        class AddingToBlacklist(TornadoHTTPContext):
+            def topic(self):
+                response = self.fetch('/blacklist?blocked.jpg', method='PUT', body='')
+                return (response.code, response.body)
+
+            def should_return_200(self, topic):
+                expect(topic[0]).to_equal(200)
+
+            class ReadingUpdatedBlacklist(TornadoHTTPContext):
+                def topic(self):
+                    response = self.get('/blacklist')
+                    return (response.code, response.body)
+
+                def should_return_200(self, topic):
+                    expect(topic[0]).to_equal(200)
+
+                def should_contain_blacklisted_file(self, topic):
+                    expect("blocked.jpg\n" in topic[1] ).to_equal(True)
+
+@Vows.batch
+class BlacklistIntegration(BaseContext):
+
+    class NormalGetImage(TornadoHTTPContext):
+        def topic(self):
+            response = self.get('/unsafe/image.jpg')
+            return response.code
+
+        def should_return_200(self, topic):
+            expect(topic).to_equal(200)
+
+        class BlacklistedGetImage(TornadoHTTPContext):
+
+            def topic(self):
+                self.fetch('/blacklist?image.jpg', method='PUT', body='')
+                response = self.get('/unsafe/image.jpg')
+                return response.code
+
+            def should_return_200(self, topic):
+                expect(topic).to_equal(404)


### PR DESCRIPTION
From time to time, our business is legally compelled to remove all traces of hosting certain content from our servers. We can delete the original assets and invalidate CDN links, but Thumbor will keep serving stored results until they expire, which is too long for our needs. To solve this, this pull request adds a new blacklist endpoint to ensure Thumbor never serves images from a blacklisted source file. It does this by checking any processed image source against the blacklist, and 404s if appropriate.

The blacklist can be seen at `/blacklist`. To add `image_url` to the blacklist, just PUT to `/blacklist?image_url`. The blacklist is persisted using your STORAGE engine of choice - without a storage backend, it won't work.

If merged, I'd be happy to add a Wiki page about the new functionality.
