### PR TITLE
Add curve filter for applying RGB curves.

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -267,6 +267,7 @@ Config.define(
         'thumbor.filters.no_upscale',
         'thumbor.filters.saturation',
         'thumbor.filters.max_age',
+        'thumbor.filters.curve',
     ],
     'List of filters that thumbor will allow to be used in generated images. All of them must be ' +
     'full names of python modules (python must be able to import it)', 'Filters')

--- a/thumbor/ext/filters/_curve.c
+++ b/thumbor/ext/filters/_curve.c
@@ -1,0 +1,150 @@
+#include "filter.h"
+
+unsigned char* get_curve(PyObject *points) {
+    Py_ssize_t i, size = PyTuple_Size(points);
+    unsigned char*items = (unsigned char*)malloc(size * sizeof(char) * 2);
+
+    for (i = 0; i < size; ++i) {
+        PyObject *p = PyTuple_GET_ITEM(points, i);
+        items[i * 2] = (unsigned char)PyInt_AS_LONG(PyTuple_GET_ITEM(p, 0));
+        items[i * 2 + 1] = (unsigned char)PyInt_AS_LONG(PyTuple_GET_ITEM(p, 1));
+    }
+
+    return items;
+}
+
+double* calculate_second_derivative(unsigned char *points, unsigned char size) {
+    double* matrix = (double*)malloc(size * sizeof(double) * 3), *result = (double*)malloc(size * sizeof(double)),  *y2 = (double*)malloc(size * sizeof(double));
+    int i, n = size;
+
+    for (i = 0; i < n; i++) {
+        result[i] = 0;
+        matrix[i * 3] = 0;
+        matrix[i * 3 + 1] = 0;
+        matrix[i * 3 + 2] = 0;
+    }
+    matrix[1] = 1.0;
+
+
+    for (i = 1; i < n - 1; i++) {
+        int j = i* 2, k = i * 3;
+        matrix[k] = (double)(points[j] - points[j - 2]) / 6;
+        matrix[k + 1] = (double)(points[j + 2] - points[j - 2]) / 3;
+        matrix[k + 2] = (double)(points[j + 2] - points[j]) /6;
+        result[i] = (double)(points[j + 2 + 1] - points[j + 1]) / (points[j + 2] - points[j]) - (double)(points[j + 1] - points[j - 2 + 1]) / (points[j] - points[j - 2]);
+
+    }
+
+    matrix[(n - 1) * 3 + 1] = 1.0;
+
+    for (i = 1; i < n; i++) {
+        int j = i * 3;
+        double k = matrix[j] / matrix[j - 3 + 1];
+        matrix[j + 1] -= k * matrix[j - 3 + 2];
+        matrix[j] = 0;
+        result[i] -= k * result[i - 1];
+    }
+
+    for (i = n - 2; i >= 0; i--) {
+        int j = i * 3;
+        double k = matrix[j + 2] / matrix[j + 3 + 1];
+        matrix[j + 1] -= k * matrix[j + 3];
+        matrix[j + 2] = 0;
+        result[i] -= k * result[i + 1];
+    }
+
+    for (i = 0; i < n; i++) {
+        y2[i] = result[i] / matrix[i * 3 + 1];
+    }
+
+    free(matrix);
+    free(result);
+    return y2;
+}
+
+#define MINMAX(x, min, max) ((x > max) ? (max) : ((x < min) ? min : x))
+
+unsigned char* cubic_spline_interpolation(unsigned char *points, int count_p, int size) {
+    unsigned char*items = (unsigned char*)malloc(size * sizeof(char));
+    double* sd = calculate_second_derivative(points, count_p);
+
+    int i;
+    for (i = 0; i < size; i ++) {
+        items[i] = (unsigned char)points[1];
+    }
+    for (i = 0; i < count_p - 1; i++) {
+        unsigned char current_x = points[i * 2], current_y = points[i * 2 + 1], next_x = points[i * 2 + 2], next_y = points[i * 2 + 2 + 1], x;
+        for (x = current_x; x < next_x; x++) {
+            double t = (double)(x - current_x) / (next_x - current_x),
+                   a = 1 - t,
+                   b = t,
+                   h = next_x - current_x,
+                   y = a * current_y + b * next_y + (h * h / 6) * ((a * a * a - a) * sd[i] + (b * b * b - b) * sd[i + 1]);
+
+            items[x] = (unsigned char)(MINMAX(round(y), 0, 255));
+        }
+    }
+    for (i = points[count_p * 2 - 2]; i<size; i++){
+        items[i] = points[count_p * 2 - 1];
+    }
+    free(sd);
+    return items;
+}
+static PyObject*
+_curve_apply(PyObject *self, PyObject *args)
+{
+    char *image_mode;
+    PyObject *buffer = NULL, *curve_a = NULL, *curve_r = NULL, *curve_g = NULL, *curve_b = NULL;
+
+    if (!PyArg_ParseTuple(args, "sOOOOO:apply", &image_mode, &buffer, &curve_a, &curve_r, &curve_g, &curve_b)) {
+        return NULL;
+    }
+
+    unsigned char *points_a = cubic_spline_interpolation(get_curve(curve_a), PyTuple_Size(curve_a), 256),
+                  *points_r = cubic_spline_interpolation(get_curve(curve_r), PyTuple_Size(curve_r), 256),
+                  *points_g = cubic_spline_interpolation(get_curve(curve_g), PyTuple_Size(curve_g), 256),
+                  *points_b = cubic_spline_interpolation(get_curve(curve_b), PyTuple_Size(curve_b), 256);
+
+    Py_ssize_t size = PyString_Size(buffer);
+    unsigned char *ptr = (unsigned char *) PyString_AsString(buffer);
+    int num_bytes = bytes_per_pixel(image_mode);
+
+    int r_idx = rgb_order(image_mode, 'R'),
+        g_idx = rgb_order(image_mode, 'G'),
+        b_idx = rgb_order(image_mode, 'B'),
+        i = 0, r, g, b;
+
+    size -= num_bytes;
+
+    for (; i <= size; i += num_bytes) {
+        r = ptr[i + r_idx];
+        g = ptr[i + g_idx];
+        b = ptr[i + b_idx];
+
+        r = points_r[r];
+        g = points_g[g];
+        b = points_b[b];
+
+        r = points_a[r];
+        g = points_a[g];
+        b = points_a[b];
+
+        ptr[i + r_idx] = ADJUST_COLOR(r);
+        ptr[i + g_idx] = ADJUST_COLOR(g);
+        ptr[i + b_idx] = ADJUST_COLOR(b);
+    }
+
+    free(points_a);
+    free(points_r);
+    free(points_g);
+    free(points_b);
+
+    Py_INCREF(buffer);
+    return buffer;
+}
+
+FILTER_MODULE(_curve,
+    "apply(image_mode, buffer, curve_a, curve_r, curve_g, curve_b) -> string"
+)
+
+

--- a/thumbor/filters/curve.py
+++ b/thumbor/filters/curve.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+from thumbor.filters import BaseFilter, filter_method
+from thumbor.ext.filters import _curve
+import ast
+
+
+class Filter(BaseFilter):
+    """
+        Usage: /filters:curve(<curve of all channels>, <curve of R>, <curve o f G>, <curve of B>)
+        Format of each curve : [(x1,y1),(x2,y2),...]
+        Examples of use:
+            /filters:curve([(0,0),(40,59),(255,255)],[(32,59),(64,80),(92,111),(128,153),(140,169),(164,201),(192,214),(224,215),(240,214),(255,212)],[(34,41),(64,51),(92,76),(128,112),(140,124),(164,147),(192,180),(224,216),(240,236),(255,255)],[(40,46),(64,55),(92,83),(128,127),(140,144),(164,174),(192,197),(224,199),(240,197),(255,198)])/
+            /filters:curve([(0,0),(255,255)],[(0,50),(16,51),(32,69),(58,85),(92,120),(128,170),(140,186),(167,225),(192,245),(225,255),(244,255),(255,254)],[(0,0),(16,2),(32,18),(64,59),(92,116),(128,182),(167,211),(192,227),(224,240),(244,247),(255,252)],[(0,48),(16,50),(62,77),(92,110),(128,144),(140,153),(167,180),(192,192),(224,217),(244,225),(255,225)])/
+    """
+
+    regex = r'\[(?:\(\d+,\d+\),?)*\]'
+
+    @filter_method(regex, regex, regex, regex)
+    def curve(self, a, r, g, b):
+        mode, data = self.engine.image_data_as_rgb()
+        imgdata = _curve.apply(mode, data, tuple(ast.literal_eval(a)), tuple(ast.literal_eval(r)), tuple(ast.literal_eval(g)), tuple(ast.literal_eval(b)))
+        self.engine.set_image_data(imgdata)

--- a/vows/config_vows.py
+++ b/vows/config_vows.py
@@ -62,6 +62,7 @@ TEST_DATA = (
         'thumbor.filters.no_upscale',
         'thumbor.filters.saturation',
         'thumbor.filters.max_age',
+        'thumbor.filters.curve',
     ])
 )
 


### PR DESCRIPTION
## Usage

    /filters:curve(<curve of all channels>, <curve of R>, <curve o f G>, <curve of B>)

### Format of each curve

    [(x1,y1),(x2,y2),...]

### Examples of use

#### Original image
![image](https://cloud.githubusercontent.com/assets/982461/4415799/4b231498-4532-11e4-9798-c39ad95ed63a.png)

#### Demo 1
    /filters:curve([(0,0),(40,59),(255,255)],[(32,59),(64,80),(92,111),(128,153),(140,169),(164,201),(192,214),(224,215),(240,214),(255,212)],[(34,41),(64,51),(92,76),(128,112),(140,124),(164,147),(192,180),(224,216),(240,236),(255,255)],[(40,46),(64,55),(92,83),(128,127),(140,144),(164,174),(192,197),(224,199),(240,197),(255,198)])/
![image](https://cloud.githubusercontent.com/assets/982461/4415716/fd91798c-4530-11e4-963a-9c2be9f29183.png)

#### Demo 2
    /filters:curve([(0,0),(255,255)],[(0,50),(16,51),(32,69),(58,85),(92,120),(128,170),(140,186),(167,225),(192,245),(225,255),(244,255),(255,254)],[(0,0),(16,2),(32,18),(64,59),(92,116),(128,182),(167,211),(192,227),(224,240),(244,247),(255,252)],[(0,48),(16,50),(62,77),(92,110),(128,144),(140,153),(167,180),(192,192),(224,217),(244,225),(255,225)])/
![image](https://cloud.githubusercontent.com/assets/982461/4415722/160c41c2-4531-11e4-93ef-5ed821ce5ea7.png)
