### PR TITLE
Add http loader configuration keys for cacerts and client ssl

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -116,6 +116,15 @@ Config.define(
 Config.define(
     'HTTP_LOADER_PROXY_PASSWORD', None,
     'The proxy password for the proxy host', 'HTTP Loader')
+Config.define(
+    'HTTP_LOADER_CA_CERTS', None,
+    'The filename of CA certificates in PEM format', 'HTTP Loader')
+Config.define(
+    'HTTP_LOADER_CLIENT_KEY', None,
+    'The filename for client SSL key', 'HTTP Loader')
+Config.define(
+    'HTTP_LOADER_CLIENT_CERT', None,
+    'The filename for client SSL certificate', 'HTTP Loader')
 
 # FILE STORAGE GENERIC OPTIONS
 Config.define(

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -72,7 +72,10 @@ def load(context, url, callback):
         proxy_host=encode(context.config.HTTP_LOADER_PROXY_HOST),
         proxy_port=context.config.HTTP_LOADER_PROXY_PORT,
         proxy_username=encode(context.config.HTTP_LOADER_PROXY_USERNAME),
-        proxy_password=encode(context.config.HTTP_LOADER_PROXY_PASSWORD)
+        proxy_password=encode(context.config.HTTP_LOADER_PROXY_PASSWORD),
+        ca_certs=encode(context.config.HTTP_LOADER_CA_CERTS),
+        client_key=encode(context.config.HTTP_LOADER_CLIENT_KEY),
+        client_cert=encode(context.config.HTTP_LOADER_CLIENT_CERT)
     )
 
     client.fetch(req, callback=partial(return_contents, url=url, callback=callback))


### PR DESCRIPTION
These changes allow you to specify your own ca_certs file as well as client ssl certs if your server is using client SSL validation.  
