### PR TITLE
vows.url_vows: Remove old_format reference

### DIFF
--- a/vows/url_vows.py
+++ b/vows/url_vows.py
@@ -129,13 +129,6 @@ class UrlVows(Vows.Context):
         def should_contain_image(self, topic):
             expect(topic).to_include('(?P<image>.+)')
 
-        class WithOldFormat(Vows.Context):
-            def topic(self):
-                return Url.regex(old_format=True)
-
-            def should_not_include_image(self, topic):
-                expect(topic).not_to_include('(?:(?P<hash>[^/]{28,}?)/)?')
-
     class Parse(Vows.Context):
         class WithoutInitialSlash(Vows.Context):
             def topic(self):


### PR DESCRIPTION
The argument was removed by f015a672 (Either we have unsafe or a hash,
we can't have both, 2012-07-09), which has left me with:

    $ make test
    …
        Url vows
          Regex
            With old format

             Error in topic:
              regex() got an unexpected keyword argument 'old_format'

              Traceback (most recent call last):
                File "/…/pyvows/runner/gevent.py", line 104, in _run_setup_and_topic
                  topic = topic_func(*topic_list)
                File "/…/vows/url_vows.py", line 134, in topic
                  return Url.regex(old_format=True)
              TypeError: regex() got an unexpected keyword argument 'old_format'
    …

Or maybe I'm just doing something wrong?  It's hard to believe the
test suite has been broken for two years without anyone noticing…