### PR TITLE
sentry_error_handler_vows: Fix 'Sentr' -> 'Sentry' typo

### DIFF
--- a/vows/sentry_error_handler_vows.py
+++ b/vows/sentry_error_handler_vows.py
@@ -48,7 +48,7 @@ class FakeHandler(object):
 
 
 @Vows.batch
-class SentrErrorHandlerVows(Vows.Context):
+class SentryErrorHandlerVows(Vows.Context):
     class WhenInvalidConfiguration(Vows.Context):
         def topic(self):
             cfg = Config()


### PR DESCRIPTION
This dates back to the creation of this vow in 44c432d2 (Error handler
vows. 100% covered now, 2013-03-28).
