### PR TITLE
.travis.yml: Don't install distribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,6 @@ install:
     # verify both requirements were met
     - INSTALLDIR=$(python -c "import os; import numpy; print(os.path.dirname(numpy.__file__))")
 
-    # Fix distribute
-    - wget http://python-distribute.org/distribute_setup.py
-    - python distribute_setup.py
-
     # webp - compiling from source
     - wget "https://webp.googlecode.com/files/libwebp-0.4.0.tar.gz" -O libwebp-0.4.0.tar.gz
     - tar xvzf libwebp-0.4.0.tar.gz
@@ -36,7 +32,7 @@ install:
     - sudo ldconfig
 
     # install python requirements
-    - make setup
+    - sudo make setup
 
 script:
     # finally run tests


### PR DESCRIPTION
http://python-distribute.org doesn't seem to be up anymore, which is
not surprising so long after the Distutils/Setuptools merge of
2013-06-01 [1](https://pythonhosted.org/setuptools/merge-faq.html#what-is-the-timeframe-of-release).  This reverts 3b41da8d6 (Fix travis CI builds,
2014-02-04).  We'll see if Travis has a recent enough version of
Setuptools by default, or if we need to update Setuptools ourselves.

This should probably wait until we have passing Travis tests before it
gets merged.
