### PR TITLE
vows.mongo_storage_vows: Set a server in GetNothingAfterExpiration

### DIFF
--- a/vows/mongo_storage_vows.py
+++ b/vows/mongo_storage_vows.py
@@ -206,7 +206,8 @@ class MongoStorageVows(MongoDBContext):
                     MONGO_STORAGE_SERVER_PORT=7777, STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True,
                     SECURITY_KEY='ACME-SEC', STORAGE_EXPIRATION_SECONDS=0
                 )
-                storage = MongoStorage(Context(config=config))
+                server = get_server('ACME-SEC')
+                storage = MongoStorage(Context(server=server, config=config))
                 storage.put(IMAGE_URL % 10, IMAGE_BYTES)
 
                 item = storage.get(IMAGE_URL % 10)


### PR DESCRIPTION
Avoid:

```
Traceback (most recent call last):
  File "/…/pyvows/runner/gevent.py", line 104, in _run_setup_and_topic
    topic = topic_func(*topic_list)
  File "/…/vows/mongo_storage_vows.py", line 210, in topic
    storage.put(IMAGE_URL % 10, IMAGE_BYTES)
  File "/…/thumbor/storages/mongo_storage.py", line 39, in put
    if not self.context.server.security_key:
AttributeError: 'NoneType' object has no attribute 'security_key'
```
