### PR TITLE
Bump Pillow requirement to >= 2.3.0, < 3.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ The following packages are required:
 * Tornado >= 2.3.0
 * pyCrypto >= 2.4.1
 * pycurl >= 7.19.0
-* Pillow >= 1.7.5
+* Pillow >= 2.1.0
 * redis >= 2.4.11
 * pymongo >= 2.1.1
 * pyvows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ The following packages are required:
 * Tornado >= 2.3.0
 * pyCrypto >= 2.4.1
 * pycurl >= 7.19.0
-* Pillow >= 2.1.0
+* Pillow >= 2.3.0
 * redis >= 2.4.11
 * pymongo >= 2.1.1
 * pyvows

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
             "tornado>2.3.0,<4.0.0",
             "pyCrypto>=2.1.0",
             "pycurl>=7.19.0,<7.20.0",
-            "Pillow>=2.1.0,<3.0.0",
+            "Pillow>=2.3.0,<3.0.0",
             "derpconf>=0.2.0",
             "python-magic>=0.4.3",
             "thumbor-pexif>=0.14,<1.0",

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
             "tornado>2.3.0,<4.0.0",
             "pyCrypto>=2.1.0",
             "pycurl>=7.19.0,<7.20.0",
-            "Pillow>=2.1.0,<2.4.0",
+            "Pillow>=2.1.0,<3.0.0",
             "derpconf>=0.2.0",
             "python-magic>=0.4.3",
             "thumbor-pexif>=0.14,<1.0",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 tornado>=2.3.0,<4.0.0
 pycrypto>=2.4.1,<2.5.0
 pycurl>=7.19.0,<7.20.0
-Pillow>=2.1.0,<3.0.0
+Pillow>=2.3.0,<3.0.0
 simplejson>=2.1.6,<2.2.0
 pymongo==2.1.1
 redis==2.4.9

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 tornado>=2.3.0,<4.0.0
 pycrypto>=2.4.1,<2.5.0
 pycurl>=7.19.0,<7.20.0
-Pillow>=2.1.0,<2.4.0
+Pillow>=2.1.0,<3.0.0
 simplejson>=2.1.6,<2.2.0
 pymongo==2.1.1
 redis==2.4.9


### PR DESCRIPTION
Avoiding the [FreeType >= 2.5.1 incompatibility][1] and giving Pillow
the benefit of the doubt for [semantic versioning][2].  Details in the
commit messages.

This PR is based on #369, so you probably want to merge/reject that
first.

[1]: https://github.com/thumbor/thumbor/issues/248
[2]: http://semver.org/