### PR TITLE
.travis.yml: Use 2.7_with_system_site_packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+    - "2.7_with_system_site_packages"
 
 install:
     #removing unwanted packages
@@ -16,15 +16,6 @@ install:
 
     - df -h
 
-    # weird travis-ci python paths
-    - export PYTHONPATH=$PYTHONPATH:/usr/lib/pymodules/python2.7/
-    - export PYTHONPATH=$PYTHONPATH:/usr/lib/python2.7/dist-packages
-    - export PYTHONPATH=$PYTHONPATH:/usr/lib/pyshared/python2.7/
-    - export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages/
-
-    # verify both requirements were met
-    - INSTALLDIR=$(python -c "import os; import numpy; print(os.path.dirname(numpy.__file__))")
-
     # webp - compiling from source
     - wget "https://webp.googlecode.com/files/libwebp-0.4.0.tar.gz" -O libwebp-0.4.0.tar.gz
     - tar xvzf libwebp-0.4.0.tar.gz
@@ -32,7 +23,7 @@ install:
     - sudo ldconfig
 
     # install python requirements
-    - sudo make setup
+    - make setup
 
 script:
     # finally run tests


### PR DESCRIPTION
The Travis runs currently die with:

```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.8/lib/python2.7/site-packages/nose/loader.py", line 414, in loadTestsFromName
    addr.filename, addr.module)
  File "/home/travis/virtualenv/python2.7.8/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/travis/virtualenv/python2.7.8/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/travis/build/thumbor/thumbor/thumbor/integration_tests/__init__.py", line 3, in <module>
    from tornado.testing import AsyncHTTPTestCase
ImportError: No module named tornado.testing
```

But we are installing Tornado.  This commit simplifies what we're
doing to try and get successful tests with less magic, dropping the
PYTHONPATH tweaks and removing sudo from 'make setup'.  The sudo had
been clearing the environment variables that setup the virtualenv and
giving us a system install.  Now that we can use both system and
virtuanlenv-local packages, we don't need it anymore.

Travis doesn't use system packages by default [1](http://docs.travis-ci.com/user/languages/python/#Travis-CI-Uses-Isolated-virtualenvs):

> CI Environment uses separate virtualenv instances for each Python
> version. System Python is not used and should not be relied on. If
> you need to install Python packages, do it via pip and not apt.
> 
> If you decide to use apt anyway, note that Python system packages
> only include Python 2.7 libraries on Ubuntu 12.04 LTS. This means
> that the packages installed from the repositories are not available
> in other virtualenvs even if you use the --system-site-packages
> option.

but 2.7 is fine for us, and it's annoying to install OpenCV using
other means (there's currently no Conda package).  Instead, use the
(undocumented?) _with_system_site_packages suffix mentioned by Donald
Stufft [2](https://github.com/travis-ci/travis-ci/issues/2219#issuecomment-41804942):

> However there's a work around here which I actually think is a much
> nicer way of handling things.
> ...
> You can do:
> 
>   language: python
> 
>   python:
>     - "pypy"
>     - 2.6
>     - 2.7
>     - "2.7_with_system_site_packages"
>     - 3.2
>     - "3.2_with_system_site_packages"
>     - 3.3
> 
> And get system site packages on the two Python versions it is
> supported on, and as a bonus you can test with and without system
> site packages for the same Python version.
