### PR TITLE
PIL: convert palette to RGBA before resize()

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -68,6 +68,9 @@ class Engine(BaseEngine):
         del d
 
     def resize(self, width, height):
+        if self.image.mode == 'P':
+            logger.debug('converting image from 8-bit palette to 32-bit RGBA for resize')
+            self.image = self.image.convert('RGBA')
         self.image = self.image.resize((int(width), int(height)), Image.ANTIALIAS)
 
     def crop(self, left, top, right, bottom):

--- a/vows/pil_engine_vows.py
+++ b/vows/pil_engine_vows.py
@@ -13,9 +13,46 @@ ctx = Vows.Context
 
 import thumbor.engines.pil as PIL
 
+class MockImage:
+    def __init__(self, mode, width, height):
+        self.mode = mode
+        self.width = width
+        self.height = height
+        self.calls = []
+    def convert(self, mode):
+        self.calls.append('convert')
+        self.mode = mode
+        return self
+    def resize(self, size, filter):
+        self.calls.append('resize')
+        self.width = size[0]
+        self.height = size[1]
+        return self
 
 @Vows.batch
 class PilEngineVows(ctx):
+
+    class ResizedPaletteImage(ctx):
+        def topic(self):
+            engine = PIL.Engine(None)
+            engine.image = MockImage('P', 640, 480)
+            engine.resize(320, 240)
+            return engine.image
+        def should_convert_p_to_rgba(self, image):
+            expect(image.mode).to_equal('RGBA')
+            expect((image.width, image.height)).to_equal((320, 240))
+            expect(image.calls.index('convert') < image.calls.index('resize')).to_be_true()
+
+    class ResizedNonPaletteImage(ctx):
+        def topic(self):
+            engine = PIL.Engine(None)
+            engine.image = MockImage('other', 640, 480)
+            engine.resize(160, 120)
+            return engine.image
+        def should_not_convert_non_palette_images(self, image):
+            expect(image.mode).to_equal('other') # unchanged
+            expect((image.width, image.height)).to_equal((160, 120))
+            expect(image.calls).Not.to_include(['convert'])
 
     class ShouldRaiseIfFiltersNotAvailable(ctx):
         def topic(self):


### PR DESCRIPTION
Before resizing 8-bit indexed images, convert to RGBA to avoid the terrible results of nearest-neighbour resampling:

> The filter argument can be one of NEAREST, BILINEAR, BICUBIC, or ANTIALIAS. **If omitted, or if the image has mode “1” or “P”, it is set to NEAREST.**
— http://effbot.org/imagingbook/image.htm#tag-Image.Image.resize

Thumbor's PIL engine does specify `ANTIALIAS`, but as stated above, PIL disregards that for `1` and `P` images.

This patch converts indexed `P` images before resize, but not 1-bit black-and-white `1` images. This is partly because I'm not sure if antialiasing is desirable given a 1-bit image (1-bit is uncommon, and perhaps it was 1-bit for a reason?), and partly because it's irrelevant to my use-case. I'm happy to add `1` images too.

Note that the output PNG was RGBA anyway, but that conversion was happening *after* the resize, resulting in worst of both worlds — nearest neighbor resampling of a highly constrained palette for poorest image quality, and then re-encoded into 32-bit color space for largest file size.

Here's the before and after of the actual image thumbnail that flagged this issue:

![palette](https://cloud.githubusercontent.com/assets/15759/4751023/7952dc00-5a99-11e4-89a3-1f45d8cd1e3a.png) ![rgb](https://cloud.githubusercontent.com/assets/15759/4751032/8436da18-5a99-11e4-9e94-7b38efa2f880.png)

