### PR TITLE
Add option to switch behaviour to preserve entire image without cropping when doing `full-fit-in` operation

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -59,6 +59,8 @@ Config.define(
     'USE_BLACKLIST', False,
     'Indicates whether thumbor should enable blacklist functionality to prevent processing certain images.', 'Imaging')
 
+Config.define('FULL_FIT_IN_ENTIRE_IMAGE', False, 'Change full-fit-in behaviour to preserve entire image without cropping.', 'Imaging')
+
 Config.define(
     'LOADER', 'thumbor.loaders.http_loader',
     'The loader thumbor should use to load the original image. This must be the full name of a python module ' +

--- a/thumbor/transformer.py
+++ b/thumbor/transformer.py
@@ -296,6 +296,9 @@ class Transformer(object):
         if sign == 1 and self.target_width >= source_width and self.target_height >= source_height:
             return
 
+        if self.context.config.FULL_FIT_IN_ENTIRE_IMAGE:
+            sign = 1
+
         if source_width / self.target_width * sign >= source_height / self.target_height * sign:
             resize_height = round(source_height * self.target_width / source_width)
             resize_width = self.target_width


### PR DESCRIPTION
Hello Thumbor team,

Thank you for this wonderful tool!

I have added a configuration option `FULL_FIT_IN_ENTIRE_IMAGE` to allow the behaviour of the `full-fit-in` operation to be changed to preserve the entire image, instead of using the default behaviour of cropping out parts of the image to fit the specified target dimensions. This configuration option is `False` by default to preserve the already-established existing behaviour.

Feedback is appreciated on the choice of configuration option name. Looking forward to your reply! :smiley: 