### PR TITLE
Add Option to Disable Etags

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -80,6 +80,7 @@ Config.define('SECURITY_KEY', 'MY_SECURE_KEY', 'The security key thumbor uses to
 
 Config.define('ALLOW_UNSAFE_URL', True, 'Indicates if the /unsafe URL should be available', 'Security')
 Config.define('ALLOW_OLD_URLS', True, 'Indicates if encrypted (old style) URLs should be allowed', 'Security')
+Config.define('ENABLE_ETAGS', True, 'Enables automatically generated etags', 'HTTP')
 
 
 # FILE LOADER OPTIONS

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -19,6 +19,12 @@ from thumbor.url import Url
 
 class ImagingHandler(ContextHandler):
 
+    def compute_etag(self):
+        if self.context.config.ENABLE_ETAGS:
+            return super(ImagingHandler, self).compute_etag()
+        else:
+            return None
+
     def check_image(self, kw):
         # Check if an image with an uuid exists in storage
         if self.context.modules.storage.exists(kw['image'][:32]):


### PR DESCRIPTION
I noticed that Tornado is automatically calculating etags for
images, but that didn't work well with my caching strategy.  I have
added the option to disable this.  I have it on by default since
the current version of Thumbor will auto-generate etags for you.
