### PR TITLE
Result file storage: remove URL encoding from file paths

### DIFF
--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from shutil import move
 
 from os.path import exists, dirname, join, getmtime, abspath
+from urllib2 import unquote
 
 from thumbor.result_storages import BaseStorage
 from thumbor.utils import logger
@@ -65,7 +66,7 @@ class Storage(BaseStorage):
 
         path_segments.extend([self.partition(path), path.lstrip('/'), ])
 
-        normalized_path = join(*path_segments).replace('http://', '')
+        normalized_path = unquote(join(*path_segments).replace('http://', ''))
         return normalized_path
 
     def partition(self, path_raw):


### PR DESCRIPTION
We ran into a few "File name too long" IOErrors recently when trying to store results to the local filesystem.

In all cases, this was a side effect of URL-encoded non-ASCII paths (in Cyrillic), which made them 3 times as long.

Such encoding should be unnecessary when storing to modern filesystems (hopefully everything is UTF-8 compliant nowadays), so this patch URL decodes the paths before both the put & get operations.

Obviously this will cause the loss of existing objects with special characters in their paths.