### PR TITLE
Add CUSTOM_HANDLERS

### DIFF
--- a/thumbor/app.py
+++ b/thumbor/app.py
@@ -30,6 +30,14 @@ class ThumborServiceApp(tornado.web.Application):
             (r'/healthcheck', HealthcheckHandler),
         ]
 
+        if self.context.modules and self.context.modules.importer and self.context.modules.importer.custom_handlers:
+            for handler in self.context.modules.importer.custom_handlers:
+                url_regex_method = getattr(handler, "url_regex", None)
+                if callable(url_regex_method):
+                    handlers.append(
+                        (url_regex_method(), handler, {'context': self.context})
+                    )
+
         if self.context.config.UPLOAD_ENABLED:
             # TODO: Old handler to upload images. Will be deprecated soon.
             handlers.append(

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -75,6 +75,7 @@ Config.define(
     'ENGINE', 'thumbor.engines.pil',
     'The imaging engine thumbor should use to perform image operations. This must be the full name of a ' +
     'python module (python must be able to import it)', 'Extensibility')
+Config.define('CUSTOM_HANDLERS', [], "Extra handlers to be prepended to Thumbor Service App with custom URLs", 'Extensibility')
 
 Config.define('SECURITY_KEY', 'MY_SECURE_KEY', 'The security key thumbor uses to sign image URLs', 'Security')
 

--- a/thumbor/importer.py
+++ b/thumbor/importer.py
@@ -24,6 +24,7 @@ class Importer:
         self.filters = []
         self.optimizers = []
         self.error_handler_class = None
+        self.custom_handlers = []
 
     def import_class(self, name, get_module=False):
         module_name = get_module and name or '.'.join(name.split('.')[:-1])
@@ -43,6 +44,9 @@ class Importer:
         self.import_item('DETECTORS', 'Detector', is_multiple=True)
         self.import_item('FILTERS', 'Filter', is_multiple=True, ignore_errors=True)
         self.import_item('OPTIMIZERS', 'Optimizer', is_multiple=True)
+
+        if self.config.CUSTOM_HANDLERS:
+            self.import_item('CUSTOM_HANDLERS', 'HttpHandler', is_multiple=True, ignore_errors=True)
 
         if self.config.RESULT_STORAGE:
             self.import_item('RESULT_STORAGE', 'Storage')

--- a/vows/custom_handler_vows.py
+++ b/vows/custom_handler_vows.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+from pyvows import Vows, expect
+from tornado_pyvows.context import TornadoHTTPContext
+
+import tornado.web
+from thumbor.app import ThumborServiceApp
+from thumbor.importer import Importer
+from thumbor.config import Config
+from thumbor.context import Context
+from thumbor.handlers import ContextHandler
+
+
+@Vows.batch
+class CustomHandlerCheck(TornadoHTTPContext):
+    def get_app(self):
+        cfg = Config()
+        cfg.CUSTOM_HANDLERS = ['vows.custom_handler_vows']
+
+        importer = Importer(cfg)
+        importer.import_modules()
+
+        ctx = Context(None, cfg, importer)
+        application = ThumborServiceApp(ctx)
+        return application
+
+    class WhenRunning(TornadoHTTPContext):
+        def topic(self):
+            response = self.get('/hi/folks')
+            return (response.code, response.body)
+
+        class StatusCode(TornadoHTTPContext):
+            def topic(self, response):
+                return response[0]
+
+            def should_not_be_an_error(self, topic):
+                expect(topic).to_equal(200)
+
+        class Body(TornadoHTTPContext):
+            def topic(self, response):
+                return response[1]
+
+            def should_equal_working(self, topic):
+                expect(topic).to_equal('Hello folks!')
+
+    class HeadHandler(TornadoHTTPContext):
+        def topic(self):
+            response = self.head('/hi/folks')
+            return (response.code, response.body)
+
+        class StatusCode(TornadoHTTPContext):
+            def topic(self, response):
+                return response[0]
+
+            def should_not_be_an_error(self, topic):
+                expect(topic).to_equal(200)
+
+class HttpHandler(ContextHandler):
+
+    @classmethod
+    def url_regex(cls):
+        return '/hi/(?P<name>[^/]+)'
+
+    def get(self, **kw):
+        self.write("Hello %s!" % kw["name"])
+
+    def head(self, **kw):
+        self.write("Hello %s!" % kw["name"])


### PR DESCRIPTION
The idea is to make possible add new routes to the default ThumborServiceApp instead of replace it for a new one using a simple configuration.

The custom handler class must be called HttpHandler and has a static method called url_regexp which has to return the url pattern to be associated with this handler.

To enable the handler is necessary to set it on the thumbor.conf file like
CUSTOM_HANDLERS = [ 'module.where.the.handler.is' ]

Is possible to set multiple handlers, they will be added in order to the top of thumbor app.