### PR TITLE
Cleanup handler

### DIFF
--- a/thumbor/app.py
+++ b/thumbor/app.py
@@ -30,6 +30,14 @@ class ThumborServiceApp(tornado.web.Application):
             (r'/healthcheck', HealthcheckHandler),
         ]
 
+        if self.context.modules and self.context.modules.importer and self.context.modules.importer.custom_handlers:
+            for handler in self.context.modules.importer.custom_handlers:
+                url_regex_method = getattr(handler, "url_regex", None)
+                if callable(url_regex_method):
+                    handlers.append(
+                        (url_regex_method(), handler, {'context': self.context})
+                    )
+
         if self.context.config.UPLOAD_ENABLED:
             # TODO: Old handler to upload images. Will be deprecated soon.
             handlers.append(

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -75,6 +75,7 @@ Config.define(
     'ENGINE', 'thumbor.engines.pil',
     'The imaging engine thumbor should use to perform image operations. This must be the full name of a ' +
     'python module (python must be able to import it)', 'Extensibility')
+Config.define('CUSTOM_HANDLERS', [], "Extra handlers to be prepended to Thumbor Service App with custom URLs", 'Extensibility')
 
 Config.define('SECURITY_KEY', 'MY_SECURE_KEY', 'The security key thumbor uses to sign image URLs', 'Security')
 

--- a/thumbor/handlers/cleanup.py
+++ b/thumbor/handlers/cleanup.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+import tornado.web
+
+from thumbor.handlers import ContextHandler
+from thumbor.context import RequestParameters
+from thumbor.crypto import Cryptor, Signer
+from thumbor.utils import logger
+from thumbor.url import Url
+
+
+class HttpHandler(ContextHandler):
+
+    delete_hash = r'(?:(?P<delete_hash>[^/]{28,})/)?'
+
+    @classmethod
+    def url_regex(cls):
+        reg = ['/(?P<delete_type>(?:original|result))/']
+
+        reg.append(cls.delete_hash)
+        reg.append(Url.regex())
+
+        return ''.join(reg)
+
+    def delete_image(self, kw):
+        delete_type = kw.pop('delete_type')
+        url_signature = kw.pop('delete_hash')
+
+        # Check if an image with an uuid exists in storage
+        if self.context.modules.storage.exists(kw['image'][:32]):
+            kw['image'] = kw['image'][:32]
+
+        url = self.request.uri
+
+        if not self.validate(kw['image']):
+            self._error(404, 'No original image was specified in the given URL')
+            return
+
+        kw['request'] = self.request
+
+        self.context.request = RequestParameters(**kw)
+
+        has_none = not self.context.request.unsafe and not self.context.request.hash
+        has_both = self.context.request.unsafe and self.context.request.hash
+
+        if has_none or has_both:
+            self._error(404, 'URL does not have hash or unsafe, or has both: %s' % url)
+            return
+
+        if self.context.request.unsafe and not self.context.config.ALLOW_UNSAFE_URL:
+            self._error(404, 'URL has unsafe but unsafe is not allowed by the config: %s' % url)
+            return
+
+        signer = Signer(self.context.server.security_key)
+
+        url_to_validate = Url.encode_url(url).replace('/%s/' % url_signature, '/')
+        valid = signer.validate(url_signature, url_to_validate)
+
+        if not valid:
+            self._error(404, 'Malformed URL: %s' % url)
+            return
+
+        if delete_type == 'original':
+            if self.context.modules.storage and self.context.modules.storage.exists(self.context.request.image_url):
+                self.context.modules.storage.remove(self.context.request.image_url)
+            else:
+                self._error(404)
+                return
+        else:
+            self.context.request.url = self.context.request.url.replace('/%s/%s' % (delete_type, url_signature), '')
+            self.context.request.image_url = self.context.request.image_url.replace('/%s/%s' % (delete_type, url_signature), '')
+            if self.context.modules.result_storage and self.context.modules.result_storage.exists():
+                self.context.modules.result_storage.remove()
+            else:
+                self._error(404)
+                return
+
+        self.set_status(204)
+        self.finish()
+
+    @tornado.web.asynchronous
+    def delete(self, **kw):
+        self.delete_image(kw)

--- a/thumbor/importer.py
+++ b/thumbor/importer.py
@@ -24,6 +24,7 @@ class Importer:
         self.filters = []
         self.optimizers = []
         self.error_handler_class = None
+        self.custom_handlers = []
 
     def import_class(self, name, get_module=False):
         module_name = get_module and name or '.'.join(name.split('.')[:-1])
@@ -43,6 +44,9 @@ class Importer:
         self.import_item('DETECTORS', 'Detector', is_multiple=True)
         self.import_item('FILTERS', 'Filter', is_multiple=True, ignore_errors=True)
         self.import_item('OPTIMIZERS', 'Optimizer', is_multiple=True)
+
+        if self.config.CUSTOM_HANDLERS:
+            self.import_item('CUSTOM_HANDLERS', 'HttpHandler', is_multiple=True, ignore_errors=True)
 
         if self.config.RESULT_STORAGE:
             self.import_item('RESULT_STORAGE', 'Storage')

--- a/thumbor/result_storages/__init__.py
+++ b/thumbor/result_storages/__init__.py
@@ -30,3 +30,9 @@ class BaseStorage(object):
                 # FILE ALREADY EXISTS = 17
                 if err.errno != 17:
                     raise
+
+    def exists(self):
+        raise NotImplementedError()
+
+    def remove(self):
+        raise NotImplementedError()

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -8,6 +8,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
+import os
 from datetime import datetime
 from uuid import uuid4
 from shutil import move
@@ -80,3 +81,21 @@ class Storage(BaseStorage):
 
         timediff = datetime.now() - datetime.fromtimestamp(getmtime(path))
         return timediff.seconds > expire_in_seconds
+
+    def exists(self):
+        path = self.context.request.url
+        file_abspath = self.normalize_path(path)
+        if not self.validate_path(file_abspath):
+            logger.warn("[RESULT_STORAGE] unable to read from outside root path: %s" % file_abspath)
+            return False
+
+        return exists(file_abspath)
+
+    def remove(self):
+        path = self.context.request.url
+        file_abspath = self.normalize_path(path)
+        if not self.validate_path(file_abspath):
+            logger.warn("[RESULT_STORAGE] unable to read from outside root path: %s" % file_abspath)
+            return False
+
+        return os.remove(file_abspath)

--- a/thumbor/storages/__init__.py
+++ b/thumbor/storages/__init__.py
@@ -24,3 +24,9 @@ class BaseStorage(object):
                 # FILE ALREADY EXISTS = 17
                 if err.errno != 17:
                     raise
+
+    def exists(self):
+        raise NotImplementedError()
+
+    def remove(self):
+        raise NotImplementedError()

--- a/vows/cleanup_handler_vows.py
+++ b/vows/cleanup_handler_vows.py
@@ -1,0 +1,247 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+import os
+from os.path import abspath, join, dirname, exists
+from shutil import rmtree
+from urllib import quote
+
+from pyvows import Vows, expect
+from tornado_pyvows.context import TornadoHTTPContext
+
+from thumbor.app import ThumborServiceApp
+from thumbor.importer import Importer
+from thumbor.config import Config
+from thumbor.context import Context, ServerParameters
+from thumbor.engines.pil import Engine as PILEngine
+from thumbor.storages.file_storage import Storage as FileStorage
+
+storage_path = abspath(join(dirname(__file__), 'fixtures/'))
+
+FILE_STORAGE_ROOT_PATH = '/tmp/thumbor-vows/cleanup_handler_vows'
+RESULT_STORAGE_FILE_STORAGE_ROOT_PATH = '/tmp/thumbor-vows/cleanup_handler_result_vows'
+
+stored_original_file = "%s/%s" % (FILE_STORAGE_ROOT_PATH, "42/573d7391a7bc9dcdef39375562aa088c386c85")
+stored_original_file2 = "%s/%s" % (FILE_STORAGE_ROOT_PATH, "9f/ab80cf3ee85222531cdf226c17519b5f64c4a6")
+stored_result_file = "%s/%s" % (RESULT_STORAGE_FILE_STORAGE_ROOT_PATH, "/v2/_w/IU/_wIUeSaeHw8dricKG2MGhqu5thk=/smart/image.jpg")
+stored_result_file2 = "%s/%s" % (RESULT_STORAGE_FILE_STORAGE_ROOT_PATH, "/v2/YF/5M/YF5MwqgThS_B9IpDH9DXpLLYizo=/smart/hidrocarbonetos_9.jpg")
+
+class BaseContext(TornadoHTTPContext):
+    def __init__(self, *args, **kw):
+        super(BaseContext, self).__init__(*args, **kw)
+
+@Vows.batch
+class CleanupHandlerCheck(TornadoHTTPContext):
+    def get_app(self):
+        cfg = Config(SECURITY_KEY='ACME-SEC')
+        cfg.CUSTOM_HANDLERS = ['thumbor.handlers.cleanup']
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = storage_path
+        cfg.STORAGE = "thumbor.storages.file_storage"
+        cfg.FILE_STORAGE_ROOT_PATH = FILE_STORAGE_ROOT_PATH
+        if exists(FILE_STORAGE_ROOT_PATH):
+            rmtree(FILE_STORAGE_ROOT_PATH)
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(8889, 'localhost', 'thumbor.conf', None, 'info', None)
+        server.security_key = 'ACME-SEC'
+        ctx = Context(server, cfg, importer)
+        application = ThumborServiceApp(ctx)
+
+        return application
+
+    class without_unsafe_url_image(TornadoHTTPContext):
+        def topic(self):
+            response = self.delete('/original/JrDF8vTWrBFiiOsVMmcCtP3PFCk=/alabama1_ap620%C3%A9.jpg')
+            return (response.code, response.headers)
+
+        def should_be_404(self, response):
+            code, _ = response
+            expect(code).to_equal(404)
+
+    class without_image(TornadoHTTPContext):
+        def topic(self):
+            response = self.delete('/original/JrDF8vTWrBFiiOsVMmcCtP3PFCk=/unsafe/')
+            return (response.code, response.headers)
+
+        def should_be_404(self, response):
+            code, _ = response
+            expect(code).to_equal(404)
+
+    class with_unsafe_url_image(TornadoHTTPContext):
+        def setup(self):
+            self.get('/unsafe/alabama1_ap620%C3%A9.jpg')
+
+        def topic(self):
+            response = self.delete('/original/JrDF8vTWrBFiiOsVMmcCtP3PFCk=/unsafe/alabama1_ap620%C3%A9.jpg')
+            return (response.code, response.headers)
+
+        def should_be_204(self, response):
+            code, _ = response
+            expect(code).to_equal(204)
+
+    class with_UTF8_URLEncoded_image_name_using_encoded_url(TornadoHTTPContext):
+        def setup(self):
+            self.get('/lc6e3kkm_2Ww7NWho8HPOe-sqLU=/smart/alabama1_ap620%C3%A9.jpg')
+
+        def topic(self):
+            url = '/original/u6d2yBspIvwpmUv-aFph68hPonQ=/lc6e3kkm_2Ww7NWho8HPOe-sqLU=/smart/alabama1_ap620%C3%A9.jpg'
+            response = self.delete(url)
+            return (response.code, response.headers)
+
+        def should_be_204(self, response):
+            code, _ = response
+            expect(code).to_equal(204)
+
+    class with_unexistent_image(TornadoHTTPContext):
+        def topic(self):
+            response = self.delete('/original/JrDF8vTWrBFiiOsVMmcCtP3PFCk=/unsafe/alabama1_ap620%C3%A9.jpg')
+            return (response.code, response.headers)
+
+        def should_be_404(self, response):
+            code, _ = response
+            expect(code).to_equal(404)
+
+@Vows.batch
+class DeleteImageWithoutUnsafe(BaseContext):
+    def get_app(self):
+        cfg = Config(SECURITY_KEY='ACME-SEC')
+        cfg.CUSTOM_HANDLERS = ['thumbor.handlers.cleanup']
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = storage_path
+        cfg.STORAGE = "thumbor.storages.file_storage"
+        cfg.ALLOW_UNSAFE_URL = False
+        cfg.FILE_STORAGE_ROOT_PATH = FILE_STORAGE_ROOT_PATH
+        if exists(FILE_STORAGE_ROOT_PATH):
+            rmtree(FILE_STORAGE_ROOT_PATH)
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(8890, 'localhost', 'thumbor.conf', None, 'info', None)
+        server.security_key = 'ACME-SEC'
+        ctx = Context(server, cfg, importer)
+        application = ThumborServiceApp(ctx)
+
+        return application
+
+    class WithSignedRegularImage(TornadoHTTPContext):
+        def setup(self):
+            self.get('/_wIUeSaeHw8dricKG2MGhqu5thk=/smart/image.jpg')
+
+        def topic(self):
+            response = self.delete('/original/nA_PG5f_rx3o3Ohlh-JKXazuoBA=/_wIUeSaeHw8dricKG2MGhqu5thk=/smart/image.jpg')
+            return (response.code, response.headers)
+
+        def should_be_204(self, response):
+            code, _ = response
+            expect(code).to_equal(204)
+
+    class WithWrongSignedRegularImage(TornadoHTTPContext):
+        def topic(self):
+            response = self.delete('/original/An_PG5f_rx3o3Ohlh-JKXazuoBA=/_wIUeSaeHw8dricKG2MGhqu5thk=/smart/image.jpg')
+            return (response.code, response.headers)
+
+        def should_be_404(self, response):
+            code, _ = response
+            expect(code).to_equal(404)
+
+    class WithRegularImage(TornadoHTTPContext):
+        def topic(self):
+            response = self.delete('/original/AKUpqMnLJ9GeEmdnFGAc_D1urQg=/unsafe/smart/image.jpg')
+            return (response.code, response.headers)
+
+        def should_be_404(self, response):
+            code, _ = response
+            expect(code).to_equal(404)
+
+@Vows.batch
+class CheckingImageWasCleaned(BaseContext):
+    def get_app(self):
+        cfg = Config(SECURITY_KEY='ACME-SEC')
+        cfg.CUSTOM_HANDLERS = ['thumbor.handlers.cleanup']
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = storage_path
+        cfg.STORAGE = "thumbor.storages.file_storage"
+        cfg.FILE_STORAGE_ROOT_PATH = FILE_STORAGE_ROOT_PATH
+        if exists(FILE_STORAGE_ROOT_PATH):
+            rmtree(FILE_STORAGE_ROOT_PATH)
+
+        cfg.RESULT_STORAGE = "thumbor.result_storages.file_storage"
+        cfg.RESULT_STORAGE_FILE_STORAGE_ROOT_PATH = RESULT_STORAGE_FILE_STORAGE_ROOT_PATH
+        if exists(RESULT_STORAGE_FILE_STORAGE_ROOT_PATH):
+            rmtree(RESULT_STORAGE_FILE_STORAGE_ROOT_PATH)
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(8891, 'localhost', 'thumbor.conf', None, 'info', None)
+        server.security_key = 'ACME-SEC'
+        ctx = Context(server, cfg, importer)
+        application = ThumborServiceApp(ctx)
+
+        return application
+
+    class DeletingOriginalImage(TornadoHTTPContext):
+        def setup(self):
+            self.get('/_wIUeSaeHw8dricKG2MGhqu5thk=/smart/image.jpg')
+
+        def topic(self):
+            response = self.delete('/original/nA_PG5f_rx3o3Ohlh-JKXazuoBA=/_wIUeSaeHw8dricKG2MGhqu5thk=/smart/image.jpg')
+            return (response.code, response.headers)
+
+        def should_be_keep_the_result_image(self, response):
+            code, _ = response
+            expect(code).to_equal(204)
+            expect(exists(stored_original_file)).to_equal(False)
+            expect(exists(stored_result_file)).to_equal(True)
+
+    class DeletingResultImage(TornadoHTTPContext):
+        def setup(self):
+            self.get('/YF5MwqgThS_B9IpDH9DXpLLYizo=/smart/hidrocarbonetos_9.jpg')
+
+        def topic(self):
+            response = self.delete('/result/h1jMkQgyzZuVJsvRLIYsts85_4Y=/YF5MwqgThS_B9IpDH9DXpLLYizo=/smart/hidrocarbonetos_9.jpg')
+            return (response.code, response.headers)
+
+        def should_be_keep_the_original_image(self, response):
+            code, _ = response
+            expect(code).to_equal(204)
+            expect(exists(stored_original_file2)).to_equal(True)
+            expect(exists(stored_result_file2)).to_equal(False)
+
+@Vows.batch
+class DeleteResultImageWithoutResultStorage(BaseContext):
+    def get_app(self):
+        cfg = Config(SECURITY_KEY='ACME-SEC')
+        cfg.CUSTOM_HANDLERS = ['thumbor.handlers.cleanup']
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = storage_path
+        cfg.STORAGE = "thumbor.storages.file_storage"
+        cfg.FILE_STORAGE_ROOT_PATH = FILE_STORAGE_ROOT_PATH
+        if exists(FILE_STORAGE_ROOT_PATH):
+            rmtree(FILE_STORAGE_ROOT_PATH)
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(8890, 'localhost', 'thumbor.conf', None, 'info', None)
+        server.security_key = 'ACME-SEC'
+        ctx = Context(server, cfg, importer)
+        application = ThumborServiceApp(ctx)
+
+        return application
+
+    class WhenRunning(TornadoHTTPContext):
+        def topic(self):
+            response = self.delete('/result/vJe5HXzQul3XeRENGjuA-qI3j6c=/iUoB6VSZ1gocza4Qu87WvEcVfbw=/smart/image2.jpg')
+            return (response.code, response.headers)
+
+        def should_be_404(self, response):
+            code, _ = response
+            expect(code).to_equal(404)

--- a/vows/custom_handler_vows.py
+++ b/vows/custom_handler_vows.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+from pyvows import Vows, expect
+from tornado_pyvows.context import TornadoHTTPContext
+
+import tornado.web
+from thumbor.app import ThumborServiceApp
+from thumbor.importer import Importer
+from thumbor.config import Config
+from thumbor.context import Context
+from thumbor.handlers import ContextHandler
+
+
+@Vows.batch
+class CustomHandlerCheck(TornadoHTTPContext):
+    def get_app(self):
+        cfg = Config()
+        cfg.CUSTOM_HANDLERS = ['vows.custom_handler_vows']
+
+        importer = Importer(cfg)
+        importer.import_modules()
+
+        ctx = Context(None, cfg, importer)
+        application = ThumborServiceApp(ctx)
+        return application
+
+    class WhenRunning(TornadoHTTPContext):
+        def topic(self):
+            response = self.get('/hi/folks')
+            return (response.code, response.body)
+
+        class StatusCode(TornadoHTTPContext):
+            def topic(self, response):
+                return response[0]
+
+            def should_not_be_an_error(self, topic):
+                expect(topic).to_equal(200)
+
+        class Body(TornadoHTTPContext):
+            def topic(self, response):
+                return response[1]
+
+            def should_equal_working(self, topic):
+                expect(topic).to_equal('Hello folks!')
+
+    class HeadHandler(TornadoHTTPContext):
+        def topic(self):
+            response = self.head('/hi/folks')
+            return (response.code, response.body)
+
+        class StatusCode(TornadoHTTPContext):
+            def topic(self, response):
+                return response[0]
+
+            def should_not_be_an_error(self, topic):
+                expect(topic).to_equal(200)
+
+class HttpHandler(ContextHandler):
+
+    @classmethod
+    def url_regex(cls):
+        return '/hi/(?P<name>[^/]+)'
+
+    def get(self, **kw):
+        self.write("Hello %s!" % kw["name"])
+
+    def head(self, **kw):
+        self.write("Hello %s!" % kw["name"])


### PR DESCRIPTION
Using the CUSTOM_HANDLERS configuration, this optional handler make possible remove the original and resultants images from the respective storages.

To remove an original image a DELETE must be done to a signed url following the pattern
/original/<delete hash>/<url containing the original image>

To remove a resultant image a DELETE must be done to a signed url following the pattern
/result/<delete hash>/<url of result image>

The delete_hash is obtained using the security_key to sign a url composed by the desired delete type and the target url, which is the same as the previous examples just removing the "/<delete_hash>"
