### PR TITLE
custom max age by url

### DIFF
--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -104,7 +104,8 @@ class RequestParameters:
                  unsafe=False,
                  hash=None,
                  accepts_webp=False,
-                 request=None):
+                 request=None,
+                 max_age=None):
 
         self.debug = bool(debug)
         self.meta = bool(meta)
@@ -162,6 +163,7 @@ class RequestParameters:
         self.format = None
         self.accepts_webp = accepts_webp
         self.max_bytes = None
+        self.max_age = self.int_or_0(max_age)
 
         if request:
             if request.query:

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -181,7 +181,10 @@ class BaseHandler(tornado.web.RequestHandler):
         if context.config.AUTO_WEBP and not context.request.engine.is_multiple() and context.request.engine.extension != '.webp':
             self.set_header('Vary', 'Accept')
 
-        max_age = self.context.config.MAX_AGE
+        max_age = self.context.request.max_age
+        if not max_age:
+            max_age = self.context.config.MAX_AGE
+
         if context.request.prevent_result_storage or context.request.detection_error:
             max_age = self.context.config.MAX_AGE_TEMP_IMAGE
 

--- a/thumbor/url.py
+++ b/thumbor/url.py
@@ -25,6 +25,7 @@ class Url(object):
     valign = r'(?:(?P<valign>top|bottom|middle)/)?'
     smart = r'(?:(?P<smart>smart)/)?'
     filters = r'(?:filters:(?P<filters>.+?\))/)?'
+    max_age = r'(?:age:(?P<max_age>\d+)/)?'
     image = r'(?P<image>.+)'
 
     compiled_regex = None
@@ -45,6 +46,7 @@ class Url(object):
         reg.append(cls.valign)
         reg.append(cls.smart)
         reg.append(cls.filters)
+        reg.append(cls.max_age)
         reg.append(cls.image)
 
         return ''.join(reg)
@@ -109,7 +111,8 @@ class Url(object):
                          crop_top=None,
                          crop_right=None,
                          crop_bottom=None,
-                         filters=None):
+                         filters=None,
+                         max_age=None):
 
         url = []
 
@@ -161,6 +164,9 @@ class Url(object):
 
         if filters:
             url.append('filters:%s' % filters)
+
+        if max_age:
+            url.append('age:%s' % max_age)
 
         return '/'.join(url)
 

--- a/thumbor/url_composer.py
+++ b/thumbor/url_composer.py
@@ -39,6 +39,7 @@ def main(arguments=None):
     parser.add_option('-a', '--halign', dest='halign', default='center', help='The horizontal alignment to use for cropping [default: %default].')
     parser.add_option('-i', '--valign', dest='valign', default='middle', help='The vertical alignment to use for cropping [default: %default].')
     parser.add_option('', '--filters', dest='filters', default='', help='Filters to be applied to the image, e.g. brightness(10) [default: %default].')
+    parser.add_option('-x', '--expires', dest='max_age', type='int', default=0, help='The optional max age for the image override the server value [default: %default].')
     parser.add_option('-o', '--old-format', dest='old', action='store_true', default=False, help='Indicates that thumbor should generate old-format urls [default: %default].')
 
     parser.add_option('-c', '--crop', dest='crop', default=None, help='The coordinates of the points to manual cropping in the format leftxtop:rightxbottom (100x200:400x500) [default: %default].')
@@ -116,7 +117,8 @@ def main(arguments=None):
             crop_top=crop_top,
             crop_right=crop_right,
             crop_bottom=crop_bottom,
-            filters=parsed_options.filters
+            filters=parsed_options.filters,
+            max_age=parsed_options.max_age
         )
 
         url = '%s/%s' % (url, image_url)


### PR DESCRIPTION
Add a way to make possible configure a max age value to be used on result image that override the server default configuration.

The value must be set as a common operation.
For instance, /unsafe/40:30/age:60/image.jpg will produce an image of 40x30 pixels with 60 seconds of max age.

This option gives flexibility to the user set different max age values without lose the security, since the new option will be encrypted during the signing process also.
