### PR TITLE
[feature] id max lenth should be an option

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -94,6 +94,7 @@ Config.define('SECURITY_KEY', 'MY_SECURE_KEY', 'The security key thumbor uses to
 Config.define('ALLOW_UNSAFE_URL', True, 'Indicates if the /unsafe URL should be available', 'Security')
 Config.define('ALLOW_OLD_URLS', True, 'Indicates if encrypted (old style) URLs should be allowed', 'Security')
 Config.define('ENABLE_ETAGS', True, 'Enables automatically generated etags', 'HTTP')
+Config.define('MAX_ID_LENGTH', 32, 'Set maximum id length for images when stored', 'Storage')
 
 
 # FILE LOADER OPTIONS

--- a/thumbor/handlers/image_resource.py
+++ b/thumbor/handlers/image_resource.py
@@ -20,7 +20,7 @@ from thumbor.engines import BaseEngine
 class ImageResourceHandler(ImageApiHandler):
 
     def check_resource(self, id):
-        id = id[:32]
+        id = id[:self.context.config.MAX_ID_LENGTH]
         # Check if image exists
         if self.context.modules.storage.exists(id):
             body = self.context.modules.storage.get(id)
@@ -39,7 +39,7 @@ class ImageResourceHandler(ImageApiHandler):
             self._error(404, 'Image not found at the given URL')
 
     def put(self, id):
-        id = id[:32]
+        id = id[:self.context.config.MAX_ID_LENGTH]
         # Check if image overwriting is allowed
         if not self.context.config.UPLOAD_PUT_ALLOWED:
             self._error(405, 'Unable to modify an uploaded image')
@@ -51,7 +51,7 @@ class ImageResourceHandler(ImageApiHandler):
             self.set_status(204)
 
     def delete(self, id):
-        id = id[:32]
+        id = id[:self.context.config.MAX_ID_LENGTH]
         # Check if image deleting is allowed
         if not self.context.config.UPLOAD_DELETE_ALLOWED:
             self._error(405, 'Unable to delete an uploaded image')

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -27,8 +27,8 @@ class ImagingHandler(ContextHandler):
 
     def check_image(self, kw):
         # Check if an image with an uuid exists in storage
-        if self.context.modules.storage.exists(kw['image'][:32]):
-            kw['image'] = kw['image'][:32]
+        if self.context.modules.storage.exists(kw['image'][:self.context.config.MAX_ID_LENGTH]):
+            kw['image'] = kw['image'][:self.context.config.MAX_ID_LENGTH]
 
         url = self.request.uri
 


### PR DESCRIPTION
We use plain uuid with dash '-' but thumbor truncate it as non dash uuid length (32 char)
This is a new config entry to allow changes: MAX_ID_LENGTH