### PR TITLE
[log] add logging configuration capabilities

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -16,6 +16,7 @@ from derpconf.config import Config
 
 from thumbor import __version__
 
+Config.define('THUMBOR_LOG_CONFIG', None, 'Logging configuration as json', 'Logging')
 Config.define(
     'THUMBOR_LOG_FORMAT', '%(asctime)s %(name)s:%(levelname)s %(message)s',
     'Log Format to be used by thumbor when writing log messages.', 'Logging')

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -9,7 +9,7 @@
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
 import sys
-import logging
+import logging, logging.config
 import os
 import socket
 from os.path import expanduser, dirname
@@ -42,11 +42,14 @@ def main(arguments=None):
 
     config = Config.load(server_parameters.config_path, conf_name='thumbor.conf', lookup_paths=lookup_paths)
 
-    logging.basicConfig(
-        level=getattr(logging, server_parameters.log_level.upper()),
-        format=config.THUMBOR_LOG_FORMAT,
-        datefmt=config.THUMBOR_LOG_DATE_FORMAT
-    )
+    if (config.THUMBOR_LOG_CONFIG and config.THUMBOR_LOG_CONFIG != '') :
+      logging.config.dictConfig(config.THUMBOR_LOG_CONFIG)
+    else:
+      logging.basicConfig(
+          level=getattr(logging, server_parameters.log_level.upper()),
+          format=config.THUMBOR_LOG_FORMAT,
+          datefmt=config.THUMBOR_LOG_DATE_FORMAT
+      )
 
     importer = Importer(config)
     importer.import_modules()


### PR DESCRIPTION
This permit a custom log policy declared in thumbor.conf
Much more flexible than proposed in #377
Full python logging capabilities is so available and extendable without new change on Thumbor code base.
https://docs.python.org/2/library/logging.config.html
log in a file, in syslog, tcp, udp, HTTP endpoint or even custom sink is now available ...

Here to write in a file : /var/log/thumbor.log 
```python
THUMBOR_LOG_CONFIG = {
              'version': 1,
              'disable_existing_loggers': False,
              'formatters': {
                'standard': {
                  'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
                },
              },
              'handlers': {
                'info_file_handler': {
                  'class': 'logging.FileHandler',
                  'level': 'DEBUG',
                  'formatter': 'standard',
                  'filename': '/var/log/thumbor.log',
                  'encoding': 'utf8'
                }
              },
              'root': {
                'handlers': ['info_file_handler'],
                'level': 'DEBUG'
              }
            }
```
Here is some how-to  http://victorlin.me/posts/2012/08/26/good-logging-practice-in-python

Even thumbor.error_handlers is not usefull anymore. you can write your own handler out of Thumbor and use it in configuration.

if THUMBOR_LOG_CONFIG is defined, THUMBOR_LOG_FORMAT, THUMBOR_LOG_DATE_FORMAT configs and -l parameter are not  used any more.

:warning: I don't know how to tests this as vows tests only applies at most in thumbor.app module not thumbor.server.
May I have some help on this point ? 