### PR TITLE
[mime] mimetype should be mimetypes... and thumbor must handle Bad Content-Type from client

### DIFF
--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -57,23 +57,23 @@ class BaseEngine(object):
 
     @classmethod
     def get_mimetype(cls, buffer):
-        extension = None
+        mime = None
 
         #magic number detection
         if buffer.startswith('GIF8'):
-            extension = '.gif'
+            mime = 'image/gif'
         elif buffer.startswith('\x89PNG\r\n\x1a\n'):
-            extension = '.png'
+            mime = 'image/png'
         elif buffer.startswith('\xff\xd8'):
-            extension = '.jpg'
+            mime = 'image/jpeg'
         elif buffer.startswith('WEBP', 8):
-            extension = '.webp'
+            mime = 'image/webp'
         elif buffer.startswith('\x00\x00\x00 ftyp'):
-            extension = '.mp4'
+            mime = 'video/mp4'
         elif buffer.startswith('\x1aE\xdf\xa3'):
-            extension = '.webm'
+            mime = 'video/webm'
 
-        return extension
+        return mime
 
     def wrap(self, multiple_engine):
         for method_name in ['resize', 'crop', 'flip_vertically', 'flip_horizontally']:
@@ -87,7 +87,7 @@ class BaseEngine(object):
         return self.multiple_engine.frame_engines
 
     def load(self, buffer, extension):
-        self.extension = self.get_mimetype(buffer)
+        self.extension = extension 
         imageOrFrames = self.create_image(buffer)
 
         if self.context.config.ALLOW_ANIMATED_GIFS and isinstance(imageOrFrames, (list, tuple)):

--- a/thumbor/engines/gif.py
+++ b/thumbor/engines/gif.py
@@ -42,7 +42,7 @@ class Engine(PILEngine):
         self.frame_count = int(count.groups()[0])
 
     def load(self, buffer, extension):
-        self.extension = self.get_mimetype(buffer)
+        self.extension = extension
         self.buffer= buffer
         self.operations = []
         self.update_image_info()

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -36,6 +36,15 @@ CONTENT_TYPE = {
     '.webm': 'video/webm',
 }
 
+EXTENSION = {
+    'image/jpeg': '.jpg',
+    'image/gif':  '.gif',
+    'image/png':  '.png',
+    'image/webp': '.webp',
+    'video/mp4':  '.mp4',
+    'video/webm': '.webm',
+}
+
 HTTP_DATE_FMT = "%a, %d %b %Y %H:%M:%S GMT"
 
 
@@ -68,7 +77,7 @@ class BaseHandler(tornado.web.RequestHandler):
 
             if result is not None:
                 mime = BaseEngine.get_mimetype(result)
-                if mime == '.gif' and self.context.config.USE_GIFSICLE_ENGINE:
+                if mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
                     self.context.request.engine = GifEngine(self.context)
                     self.context.request.engine.load(result, '.gif')
                 else:
@@ -161,7 +170,7 @@ class BaseHandler(tornado.web.RequestHandler):
 
     def define_image_type(self, context, result):
         if result is not None:
-            image_extension = BaseEngine.get_mimetype(result)
+            image_extension = EXTENSION.get(BaseEngine.get_mimetype(result),'.jpg')
         else:
             image_extension = context.request.format
             if image_extension is not None:
@@ -339,7 +348,7 @@ class BaseHandler(tornado.web.RequestHandler):
         if buffer is not None:
             self.context.statsd_client.incr('storage.hit')
             mime = BaseEngine.get_mimetype(buffer)
-            if mime == '.gif' and self.context.config.USE_GIFSICLE_ENGINE:
+            if mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
                 self.context.request.engine = GifEngine(self.context)
             else:
                 self.context.request.engine = self.context.modules.engine
@@ -359,7 +368,7 @@ class BaseHandler(tornado.web.RequestHandler):
                 try:
                     mime = BaseEngine.get_mimetype(buffer)
 
-                    if mime == '.gif' and self.context.config.USE_GIFSICLE_ENGINE:
+                    if mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
                         self.context.request.engine = GifEngine(self.context)
                     else:
                         self.context.request.engine = self.context.modules.engine
@@ -419,7 +428,7 @@ class ImageApiHandler(ContextHandler):
         conf = self.context.config
         mime = BaseEngine.get_mimetype(body)
 
-        if mime == '.gif' and self.context.config.USE_GIFSICLE_ENGINE:
+        if mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
             engine = GifEngine(self.context)
         else:
             engine = self.context.modules.engine

--- a/thumbor/handlers/upload.py
+++ b/thumbor/handlers/upload.py
@@ -42,9 +42,13 @@ class ImageUploadHandler(ImageApiHandler):
             # Use the default filename for the uploaded images
             if not filename:
                 content_type = self.request.headers.get('Content-Type', BaseEngine.get_mimetype(body))
-                extension = mimetypes.guess_extension(content_type, False)
+                extension = mimetypes.guess_extension(content_type.split(';',1)[0], False)
+                if extension is None: # Content-Type is unknown, try with body
+                    extension = mimetypes.guess_extension(BaseEngine.get_mimetype(body), False)
                 if extension == '.jpe':
-                    extension = '.jpg'  # Hack because mimetypes return .jpe by default
+                     extension = '.jpg'  # Hack because mimetypes return .jpe by default
+                if extension is None: # Even body is unknown, return an empty string to be contat
+                    extension = ''
                 filename = self.context.config.UPLOAD_DEFAULT_FILENAME + extension
 
             # Build image id based on a random uuid (32 characters)


### PR DESCRIPTION
From time to time, client try to upload image with : 
```Content-Type: image/jpeg;charset=UTF-8```
This result in 500 error : 
```
cannot concatenate 'str' and 'NoneType' objects
<type 'exceptions.TypeError'>
File "/usr/lib/python2.7/dist-packages/tornado/web.py", line 1021,
  in _execute getattr(self, self.request.method.lower())(*args, **kwargs) 
File "/usr/lib/python2.7/dist-packages/thumbor/handlers/upload.py", line 48, 
  in post filename = self.context.config.UPLOAD_DEFAULT_FILENAME + extension 
```
Method engine.get_mimetype() was used sometime to get mime and other to get extension.
I choose to fix it as it's named : return mime

Now GET /image should return correct Content-Type: 

BTW there is declared dependency on python-magic but used nowhere.
By the time I choose not using it to avoid new dependency regarding the few format supported.
Maybe we should use it now if not too heavy, as dependency already exists ?
This implies some refactoring to make the code base clearer.