### PR TITLE
Extracting the first frame of a GIF

### DIFF
--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -226,3 +226,6 @@ class BaseEngine(object):
 
     def strip_icc(self):
         pass
+
+    def extract_cover(self):
+        raise NotImplementedError()

--- a/thumbor/engines/gif.py
+++ b/thumbor/engines/gif.py
@@ -81,6 +81,12 @@ class Engine(PILEngine):
     def flip_horizontally(self):
         self.operations.append('--flip-horizontal')
 
+    def extract_cover(self):
+        arguments = '#0'
+        self.operations.append(arguments)
+        self.flush_operations()
+        self.update_image_info()
+
     def flush_operations(self):
         if not self.operations:
             return

--- a/thumbor/transformer.py
+++ b/thumbor/transformer.py
@@ -182,7 +182,7 @@ class Transformer(object):
         self.do_image_operations()
 
     def do_image_operations(self):
-        if '.gif' == self.context.request.engine.extension and 'cover' in self.context.request.filters:
+        if '.gif' == self.context.request.engine.extension and 'cover()' in self.context.request.filters:
             self.extract_cover()
 
         self.manual_crop()

--- a/thumbor/transformer.py
+++ b/thumbor/transformer.py
@@ -182,7 +182,7 @@ class Transformer(object):
         self.do_image_operations()
 
     def do_image_operations(self):
-        if '.gif' == self.context.request.extension and 'cover' in self.context.request.filters:
+        if '.gif' == self.context.request.engine.extension and 'cover' in self.context.request.filters:
             self.extract_cover()
 
         self.manual_crop()

--- a/thumbor/transformer.py
+++ b/thumbor/transformer.py
@@ -182,6 +182,9 @@ class Transformer(object):
         self.do_image_operations()
 
     def do_image_operations(self):
+        if '.gif' == self.context.request.extension and 'cover' in self.context.request.filters:
+            self.extract_cover()
+
         self.manual_crop()
         self.calculate_target_dimensions()
         self.adjust_focal_points()
@@ -197,6 +200,9 @@ class Transformer(object):
             self.flip()
 
         self.done_callback()
+
+    def extract_cover(self):
+        self.engine.extract_cover()
 
     def manual_crop(self):
         if self.context.request.should_crop:

--- a/vows/transformer_test_data.py
+++ b/vows/transformer_test_data.py
@@ -23,7 +23,8 @@ class MockEngine(object):
             'resize': [],
             'crop': [],
             'vertical_flip': 0,
-            'horizontal_flip': 0
+            'horizontal_flip': 0,
+            'cover': 0,
         }
         self.focal_points = None
 
@@ -57,6 +58,9 @@ class MockEngine(object):
 
     def focus(self, focal_points):
         self.focal_points = focal_points
+
+    def extract_cover(self):
+        self.calls['cover'] += 1
 
 
 class MockSyncDetector(BaseDetector):

--- a/vows/transformer_vows.py
+++ b/vows/transformer_vows.py
@@ -103,6 +103,34 @@ class TransformerVows(Vows.Context):
         def should_do_vertical_flip(self, topic):
             expect(self.engine.calls['vertical_flip']).to_equal(1)
 
+
+    class ExtractCover(Vows.Context):
+        @Vows.async_topic
+        def topic(self, callback):
+            data = TestData(
+                source_width=800, source_height=600,
+                target_width=-800, target_height=-600,
+                halign="right", valign="top",
+                focal_points=[],
+                crop_left=None, crop_top=None, crop_right=None, crop_bottom=None
+            )
+
+            ctx = data.to_context()
+            ctx.request.filters = 'cover()'
+            ctx.request.image = 'some.gif'
+            ctx.request.extension= 'GIF'
+            ctx.request.engine.extension = '.gif'
+            ctx.config.USE_GIFSICLE_ENGINE = True
+
+            self.engine = ctx.modules.engine
+
+            trans = Transformer(ctx)
+            trans.transform(callback)
+
+        def should_do_extract_cover(self, topic):
+            expect(self.engine.calls['cover']).to_equal(1)
+
+
     class ResizeCrop(Vows.Context):
         def topic(self):
             for item in TESTITEMS:


### PR DESCRIPTION
According to the issue number #357, we needed to deliver a GIF image as a static image. I did this using the first frame of the image, using Gifsicle. I didn't do it for PIL Engine, unfortunately it's not trivial as using Gifsicle.

I'm not pretty sure about the tests coverage. Is the content of this pull request ok? If isn't, someone could help me with this?

My very thanks to @guilhermef!