### PR TITLE
Add max clients setting

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -115,6 +115,9 @@ Config.define(
     'HTTP_LOADER_MAX_REDIRECTS', 5,
     'Indicates the number of redirects libcurl should follow when downloading an image', 'HTTP Loader')
 Config.define(
+    'HTTP_LOADER_MAX_CLIENTS', 10,
+     'The maximum number of simultaneous HTTP connections the loader can make before queuing', 'HTTP Loader')
+Config.define(
     'HTTP_LOADER_FORWARD_USER_AGENT', False,
     'Indicates whether thumbor should forward the user agent of the requesting user', 'HTTP Loader')
 Config.define(

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -58,7 +58,7 @@ def load(context, url, callback):
     using_proxy = context.config.HTTP_LOADER_PROXY_HOST and context.config.HTTP_LOADER_PROXY_PORT
     if using_proxy or context.config.HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT:
         tornado.httpclient.AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
-    client = tornado.httpclient.AsyncHTTPClient()
+    client = tornado.httpclient.AsyncHTTPClient(max_clients=context.config.HTTP_LOADER_MAX_CLIENTS)
 
     user_agent = None
     if context.config.HTTP_LOADER_FORWARD_USER_AGENT:


### PR DESCRIPTION
If you're making lots of big upstream requests, you can run out of async HTTP clients, causing lots of upstream HTTP request timeouts.  This makes a setting so it can be tweaked.