### PR TITLE
Add config entry to choose allowed image dimensions.

### DIFF
--- a/tests/fixtures/allow_dimensions_conf.py
+++ b/tests/fixtures/allow_dimensions_conf.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+# the domains that can have theyre images resized
+ALLOWED_SOURCES = ['s.glbimg.com', 'www.globo.com']
+
+# the max width of the resized image
+MAX_WIDTH = 1280
+
+# the max height of the resized image
+MAX_HEIGHT = 800
+
+ENGINE = 'thumbor.engines.pil'
+
+LOADER = 'thumbor.loaders.http_loader'
+
+STORAGE = 'thumbor.storages.file_storage'
+
+FILE_STORAGE_ROOT_PATH = "/tmp/thumbor/storage"
+
+# this is the security key used to encrypt/decrypt urls.
+# make sure this is unique and not well-known
+# This can be any string of up to 24 characters
+SECURITY_KEY = "MY_SECURE_KEY"
+
+# if you enable this, the unencryted URL will be available
+# to users.
+# IT IS VERY ADVISED TO SET THIS TO False TO STOP OVERLOADING
+# OF THE SERVER FROM MALICIOUS USERS
+ALLOW_UNSAFE_URL = True
+
+## Indicates whether thumbor should process certain images dimensions.
+## Defaults to: []
+ALLOW_DIMENSIONS = ['100x100', '300x600']

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -87,5 +87,22 @@ class MainHandlerFitInImagesTest(ImageTestCase):
         assert width == 200, width
         assert height == 151, height
 
+
+class MainHandlerAllowDimensions(AsyncHTTPTestCase):
+
+    def get_app(self):
+        return ThumborServiceApp(get_conf_path('allow_dimensions_conf.py'))
+
+    def test_allowed_dimension(self):
+        self.http_client.fetch(self.get_url('/unsafe/100x100/www.globo.com/media/globocom/img/sprite1.png'), self.stop)
+        response = self.wait(timeout=20)
+        self.assertEqual(200, response.code)
+
+    def test_not_allowed_dimension(self):
+        self.http_client.fetch(self.get_url('/unsafe/200x200/www.globo.com/media/globocom/img/sprite1.png'), self.stop)
+        response = self.wait(timeout=20)
+        self.assertEqual(404, response.code)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -75,7 +75,9 @@ Config.define(
 
 Config.define(
     'ALLOW_DIMENSIONS', [],
-    'Indicates whether thumbor should process certain images dimensions.', 'Imaging')
+    'Indicates whether thumbor should only process certain image dimensions. ' +
+    'It can be used to avoid url tampering that would overload the service. ' +
+    'If ALLOW_DIMENSIONS are set, filter will be forbiden.', 'Imaging')
 
 Config.define(
     'LOADER', 'thumbor.loaders.http_loader',

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -74,6 +74,10 @@ Config.define(
     'Indicates whether thumbor should enable blacklist functionality to prevent processing certain images.', 'Imaging')
 
 Config.define(
+    'ALLOW_DIMENSIONS', [],
+    'Indicates whether thumbor should process certain images dimensions.', 'Imaging')
+
+Config.define(
     'LOADER', 'thumbor.loaders.http_loader',
     'The loader thumbor should use to load the original image. This must be the full name of a python module ' +
     '(python must be able to import it)', 'Extensibility')

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -52,6 +52,9 @@ class ImagingHandler(ContextHandler):
             return
 
         if self.context.config.ALLOW_DIMENSIONS:
+            if kw['filters']:
+                self._error(403, 'Filters are not allowed when pre defined dimensions are set (option ALLOW_DIMENSIONS).')
+                return
             dimension = '%sx%s' % (kw['width'], kw['height'])
             if dimension not in self.context.config.ALLOW_DIMENSIONS:
                 self._error(404, 'Image not found for %s dimension' % dimension)

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -52,9 +52,9 @@ class ImagingHandler(ContextHandler):
             return
 
         if self.context.config.ALLOW_DIMENSIONS:
-            dimensions = '%sx%s' % (kw['width'], kw['height'])
-            if dimensions not in self.context.config.ALLOW_DIMENSIONS:
-                self._error(404, 'Image not found for %s dimentions' % dimensions)
+            dimension = '%sx%s' % (kw['width'], kw['height'])
+            if dimension not in self.context.config.ALLOW_DIMENSIONS:
+                self._error(404, 'Image not found for %s dimension' % dimension)
                 return
 
         if self.context.config.USE_BLACKLIST:

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -51,6 +51,12 @@ class ImagingHandler(ContextHandler):
             self._error(404, 'URL has unsafe but unsafe is not allowed by the config: %s' % url)
             return
 
+        if self.context.config.ALLOW_DIMENSIONS:
+            dimensions = '%sx%s' % (kw['width'], kw['height'])
+            if dimensions not in self.context.config.ALLOW_DIMENSIONS:
+                self._error(404, 'Image not found for %s dimentions' % dimensions)
+                return
+
         if self.context.config.USE_BLACKLIST:
             blacklist = self.get_blacklist_contents()
             if self.context.request.image_url in blacklist:


### PR DESCRIPTION
When ALLOW_DIMENSIONS is set as list of image dimensions (e.g ['100x100', '200x200']=] it will return 404 for all dimensions but the ones defined.
