### PR TITLE
Change optimizers to use subprocess.call instead of os.system

### DIFF
--- a/thumbor/optimizers/gifv.py
+++ b/thumbor/optimizers/gifv.py
@@ -8,7 +8,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
-import os
+import subprocess
 
 from thumbor.optimizers import BaseOptimizer
 
@@ -28,7 +28,7 @@ class Optimizer(BaseOptimizer):
             command_params,
             output_file,
         )
-        os.system(command)
+        subprocess.call(command, shell=True)
         self.context.request.format = format
 
     def set_format(self):

--- a/thumbor/optimizers/gifv.py
+++ b/thumbor/optimizers/gifv.py
@@ -8,6 +8,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
+import os
 import subprocess
 
 from thumbor.optimizers import BaseOptimizer
@@ -28,7 +29,8 @@ class Optimizer(BaseOptimizer):
             command_params,
             output_file,
         )
-        subprocess.call(command, shell=True)
+        with open(os.devnull) as null:
+            subprocess.call(command, shell=True, stdin=null)
         self.context.request.format = format
 
     def set_format(self):

--- a/thumbor/optimizers/jpegtran.py
+++ b/thumbor/optimizers/jpegtran.py
@@ -8,7 +8,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
-import os
+import subprocess
 
 from thumbor.optimizers import BaseOptimizer
 
@@ -25,4 +25,4 @@ class Optimizer(BaseOptimizer):
             output_file,
             input_file,
         )
-        os.system(command)
+        subprocess.call(command, shell=True)


### PR DESCRIPTION
os.system is deprecated and blocks the GIL.  Let's change the
optimizers to use subprocess.call instead.  This will fix the
optimizers blocking the IOLoop when using the thread pool, and also
helps eliminate a deprecated library from the codebase.