### PR TITLE
Add Last-Modified header handling.

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -373,13 +373,20 @@ class BaseHandler(tornado.web.RequestHandler):
         else:
             self.context.statsd_client.incr('storage.miss')
 
-            def handle_loader_loaded(buffer):
+            def handle_loader_loaded(response):
+                if response is None:
+                    callback(False, None)
+                    return
+
+                buffer = response.body
+
                 if buffer is None:
                     callback(False, None)
                     return
 
                 original_preserve = self.context.config.PRESERVE_EXIF_INFO
                 self.context.config.PRESERVE_EXIF_INFO = True
+                self.set_header('Last-Modified', response.headers['Last-Modified'])
 
                 try:
                     mime = BaseEngine.get_mimetype(buffer)

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -47,11 +47,14 @@ def return_contents(response, url, callback, context):
         logger.warn("ERROR retrieving image {0}: Empty response.".format(url))
         callback(None)
     else:
+        if not 'Last-Modified' in response.headers:
+            response.headers['Last-Modified'] = datetime.datetime.utcnow()
+
         if response.time_info:
           for x in response.time_info:
               context.statsd_client.timing('original_image.time_info.' + x, response.time_info[x] * 1000)
           context.statsd_client.timing('original_image.time_info.bytes_per_second', len(response.body) / response.time_info['total'])
-        callback(response.body)
+        callback(response)
 
 
 def load(context, url, callback):


### PR DESCRIPTION
This is not a Thumbor issue per se, but many people use it behind Nginx, and Nginx won't properly handle the ETag header if the response lacks a Last-Modified header. The result is that if a browser tries to revalidate an image, Nginx will send a 200 response instead of a 304.

This minor patch passes the Last-Modified header received from the origin if one is available or adds one with the current time otherwise.

Off course, the problem could be solved by forcing the header on Nginx itself, but doing it on Thumbor seemed more elegant, as we can respect what the origin has set.

Also, as I'm not acquainted to the code, the way I did it might not be the best one. Should you think this patch is worth but would like to take another approach, just let me know and I'll fix it.