### PR TITLE
Fix error log on load then store

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -96,11 +96,18 @@ class Engine(BaseEngine):
     def flip_horizontally(self):
         self.image = self.image.transpose(Image.FLIP_LEFT_RIGHT)
 
+    def get_default_extension(self):
+        #extension is not present => force JPEG or PNG
+        if self.image.mode in ['P', 'RGBA', 'LA']:
+           return '.png'
+        else:
+           return '.jpeg'
+
     def read(self, extension=None, quality=None):
+
         #returns image buffer in byte format.
         img_buffer = BytesIO()
-
-        ext = extension or self.extension
+        ext = extension or self.extension or get_default_extension()
 
         options = {
             'quality': quality
@@ -153,14 +160,10 @@ class Engine(BaseEngine):
             self.image.save(img_buffer, FORMATS[ext])
         except KeyError:
             logger.exception('Image format not found in PIL: %s' % ext)
-
-            #extension is not present or could not help determine format => force JPEG
-            if self.image.mode in ['P', 'RGBA', 'LA']:
-                self.image.format = FORMATS['.png']
-                self.image.save(img_buffer, FORMATS['.png'])
-            else:
-                self.image.format = FORMATS['.jpg']
-                self.image.save(img_buffer, FORMATS['.jpg'])
+            ext = get_default_extention()
+            #extension could not help determine format => use default
+            self.image.format = FORMATS[ext]
+            self.image.save(img_buffer, FORMATS[ext])
 
         results = img_buffer.getvalue()
         img_buffer.close()

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -383,6 +383,7 @@ class BaseHandler(tornado.web.RequestHandler):
 
                 try:
                     mime = BaseEngine.get_mimetype(buffer)
+                    extension = EXTENSION.get(mime,None)
 
                     if mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
                         self.context.request.engine = self.context.modules.gif_engine
@@ -396,7 +397,7 @@ class BaseHandler(tornado.web.RequestHandler):
                     is_mixed_no_file_storage = is_mixed_storage and isinstance(storage.file_storage, NoStorage)
 
                     if not (is_no_storage or is_mixed_no_file_storage):
-                        buffer = self.context.request.engine.read()
+                        buffer = self.context.request.engine.read(extension)
                         storage.put(url, buffer)
 
                     storage.put_crypto(url)

--- a/vows/fixtures/image
+++ b/vows/fixtures/image
@@ -1,0 +1,1 @@
+image.jpg

--- a/vows/handler_images_vows.py
+++ b/vows/handler_images_vows.py
@@ -33,7 +33,6 @@ class BaseContext(TornadoHTTPContext):
     def __init__(self, *args, **kw):
         super(BaseContext, self).__init__(*args, **kw)
 
-
 @Vows.batch
 class GetImage(BaseContext):
     def get_app(self):
@@ -62,6 +61,25 @@ class GetImage(BaseContext):
         def should_be_200(self, response):
             code, _ = response
             expect(code).to_equal(200)
+
+    class WithRegularImageiWithoutExtention(TornadoHTTPContext):
+        def topic(self):
+            response = self.get('/unsafe/smart/image')
+            return (response.code, response.headers)
+
+        def should_be_200(self, response):
+            code, _ = response
+            expect(code).to_equal(200)
+
+    class WithAbsentImage(TornadoHTTPContext):
+        def topic(self):
+            response = self.get('/unsafe/smart/imag')
+            return (response.code, response.headers)
+
+        def should_be_200(self, response):
+            code, _ = response
+            expect(code).to_equal(404)
+
 
     class WithUnicodeImage(BaseContext):
         def topic(self):


### PR DESCRIPTION
My thumbor Ids have no extension so this generate lots of ERROR logs.
This patch handle extension is None to prevent unnecessary flood in logs.
Excotic extentions still generate a log...

Tests are not really relevant in this case but increase coverage :) I don't know how to test if log is emitted (any idea ?)

Side note: looking a the code it seams to me we are always trying to determine mime and extension from modules to modules ... may this be centralized ?