### PR TITLE
engines.pil to invoke get_default_extension() on self.

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -107,7 +107,7 @@ class Engine(BaseEngine):
 
         #returns image buffer in byte format.
         img_buffer = BytesIO()
-        ext = extension or self.extension or get_default_extension()
+        ext = extension or self.extension or self.get_default_extension()
 
         options = {
             'quality': quality


### PR DESCRIPTION
This happens when image file extension was not determined, then PIL engine needs to invoke self.get_default_extension() on self.