### PR TITLE
jpegtran optimizer copy comments only

### DIFF
--- a/thumbor/optimizers/jpegtran.py
+++ b/thumbor/optimizers/jpegtran.py
@@ -19,7 +19,7 @@ class Optimizer(BaseOptimizer):
 
     def optimize(self, buffer, input_file, output_file):
         jpegtran_path = self.context.config.JPEGTRAN_PATH
-        command = '%s -copy all -optimize %s-outfile %s %s ' % (
+        command = '%s -copy comments -optimize %s-outfile %s %s ' % (
             jpegtran_path,
             '-progressive ' if self.context.config.PROGRESSIVE_JPEG else '',
             output_file,


### PR DESCRIPTION
Reduce file size by only copying markers that are essential for image display. This leaves out JFIF thumbnails, Exif data, and Photoshop settings, see http://linux.die.net/man/1/jpegtran