### PR TITLE
Https loader and strict https loader bugfix

### DIFF
--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -57,6 +57,10 @@ def return_contents(response, url, callback, context):
 
 @return_future
 def load(context, url, callback, normalize_url_func=_normalize_url):
+    load_sync(context, url, callback, normalize_url_func)
+
+
+def load_sync(context, url, callback, normalize_url_func):
     using_proxy = context.config.HTTP_LOADER_PROXY_HOST and context.config.HTTP_LOADER_PROXY_PORT
     if using_proxy or context.config.HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT:
         tornado.httpclient.AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")

--- a/thumbor/loaders/https_loader.py
+++ b/thumbor/loaders/https_loader.py
@@ -24,8 +24,9 @@ def return_contents(response, url, callback, context):
     return http_loader.return_contents(response, url, callback, context)
 
 
+@return_future
 def load(context, url, callback):
-    return http_loader.load(context, url, callback, normalize_url_func=_normalize_url)
+    return http_loader.load_sync(context, url, callback, normalize_url_func=_normalize_url)
 
 
 def encode(string):

--- a/thumbor/loaders/strict_https_loader.py
+++ b/thumbor/loaders/strict_https_loader.py
@@ -27,8 +27,9 @@ def return_contents(response, url, callback, context):
     return http_loader.return_contents(response, url, callback, context)
 
 
+@return_future
 def load(context, url, callback):
-    return http_loader.load(context, url, callback, normalize_url_func=_normalize_url)
+    return http_loader.load_sync(context, url, callback, normalize_url_func=_normalize_url)
 
 
 def encode(string):

--- a/vows/http_loader_vows.py
+++ b/vows/http_loader_vows.py
@@ -11,6 +11,7 @@
 from os.path import abspath, join, dirname
 
 from pyvows import Vows, expect
+from tornado.concurrent import Future
 from tornado_pyvows.context import TornadoHTTPContext
 import tornado.web
 
@@ -180,6 +181,22 @@ class HttpLoader(TornadoHTTPContext):
 
             def should_equal_hello(self, topic):
                 expect(topic.args[0]).to_equal('Hello')
+
+        class LoaderWithoutCallback(TornadoHTTPContext):
+            def topic(self):
+                url = self.get_url('/')
+                loader.http_client = self._http_client
+
+                config = Config()
+                config.ALLOWED_SOURCES = ['s.glbimg.com']
+                ctx = Context(None, config, None)
+
+                return loader.load, ctx, url
+
+            def should_be_callable_and_return_a_future(self, topic):
+                load, ctx, url = topic
+                future = load(ctx, url)
+                expect(isinstance(future, Future)).to_be_true()
 
 
 @Vows.batch

--- a/vows/https_loader_vows.py
+++ b/vows/https_loader_vows.py
@@ -11,6 +11,7 @@
 from os.path import abspath, join, dirname
 
 from pyvows import Vows, expect
+from tornado.concurrent import Future
 from tornado_pyvows.context import TornadoHTTPContext
 import tornado.web
 
@@ -187,6 +188,22 @@ class HttpsLoader(TornadoHTTPContext):
 
             def should_equal_hello(self, topic):
                 expect(topic.args[0]).to_equal('Hello')
+
+        class LoaderWithoutCallback(TornadoHTTPContext):
+            def topic(self):
+                url = self.get_url('/')
+                loader.http_client = self._http_client
+
+                config = Config()
+                config.ALLOWED_SOURCES = ['s.glbimg.com']
+                ctx = Context(None, config, None)
+
+                return loader.load, ctx, url
+
+            def should_be_callable_and_return_a_future(self, topic):
+                load, ctx, url = topic
+                future = load(ctx, url)
+                expect(isinstance(future, Future)).to_be_true()
 
 
 @Vows.batch

--- a/vows/strict_https_loader_vows.py
+++ b/vows/strict_https_loader_vows.py
@@ -11,6 +11,7 @@
 from os.path import abspath, join, dirname
 
 from pyvows import Vows, expect
+from tornado.concurrent import Future
 from tornado_pyvows.context import TornadoHTTPContext
 import tornado.web
 
@@ -212,3 +213,19 @@ class StrictHttpsLoader(TornadoHTTPContext):
 
             def should_equal_hello(self, topic):
                 expect(topic.args[0]).to_equal('Hello')
+
+        class LoaderWithoutCallback(TornadoHTTPContext):
+            def topic(self):
+                url = self.get_url('/')
+                loader.http_client = self._http_client
+
+                config = Config()
+                config.ALLOWED_SOURCES = ['s.glbimg.com']
+                ctx = Context(None, config, None)
+
+                return loader.load, ctx, url
+
+            def should_be_callable_and_return_a_future(self, topic):
+                load, ctx, url = topic
+                future = load(ctx, url)
+                expect(isinstance(future, Future)).to_be_true()


### PR DESCRIPTION
Sorry, I've accidentally made a mistake programming the https loaders. Here's the fix, including tests.

Explanation: [Here](https://github.com/thumbor/thumbor/blob/master/thumbor/handlers/__init__.py#L385) the loader is called without a callback. I've also written a test for the http loader.