### PR TITLE
[handler] fix image extension with query string

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -63,7 +63,7 @@ class BaseHandler(tornado.web.RequestHandler):
         req = self.context.request
         conf = self.context.config
 
-        req.extension = splitext(req.image_url)[-1].lower()
+        req.extension = splitext(req.image_url)[-1].lower().split('?')[0]
 
         should_store = self.context.config.RESULT_STORAGE_STORES_UNSAFE or not self.context.request.unsafe
         if self.context.modules.result_storage and should_store:


### PR DESCRIPTION
As we add querystring in image_url in context, handle fails on extracting extension correctly.
This generate lots of errors  in pil engine : 
```
2015-06-25 11:46:50 root:DEBUG thumbor running at 0.0.0.0:8890
2015-06-25 11:47:34 thumbor:DEBUG STATSD: servers..storage.hit:1|c
2015-06-25 11:47:34 thumbor:DEBUG No image format specified. Retrieving from the image extension: .png?ts=1.
2015-06-25 11:47:34 thumbor:DEBUG Content Type of image/jpeg detected.
2015-06-25 11:47:34 thumbor:ERROR Image format not found in PIL: .png?ts=1
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/thumbor/engines/pil.py", line 157, in read
    self.image.save(img_buffer, FORMATS[ext], **options)
KeyError: '.png?ts=1'
2015-06-25 11:47:34 tornado.access:INFO 200 GET /WYSBJzp_kBliGjGNuvoosW6LKOk=/60x60/default/avatar-m-140x185.png?ts=1 (10.69.69.44) 30.02ms
```