### PR TITLE
fix webp with max_bytes filter and there's no quality defined

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -184,8 +184,8 @@ class BaseHandler(tornado.web.RequestHandler):
 
         quality = self.context.request.quality
         if quality is None:
-            if image_extension == '.webp':
-                quality = self.context.config.get('WEBP_QUALITY', self.context.config.QUALITY)
+            if image_extension == '.webp' and self.context.config.WEBP_QUALITY is not None:
+                quality = self.context.config.get('WEBP_QUALITY')
             else:
                 quality = self.context.config.QUALITY
         results = context.request.engine.read(image_extension, quality)


### PR DESCRIPTION
The default of 'WEBP_QUALITY' is 'None', with max_bytes filter results in the following error:

```
2015-07-11 16:40:23 thumbor:DEBUG STATSD: storage.hit:1|c
2015-07-11 16:40:23 thumbor:DEBUG Image format set by AUTO_WEBP as .webp.
2015-07-11 16:40:23 thumbor:DEBUG Content Type of image/webp detected.
2015-07-11 16:40:30 tornado.application:ERROR Future exception was never retrieved: Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/tornado-4.2-py2.7-macosx-10.10-x86_64.egg/tornado/gen.py", line 879, in run
    yielded = self.gen.send(value)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/handlers/__init__.py", line 108, in get_image
    self.filters_runner.apply_filters(thumbor.filters.PHASE_AFTER_LOAD, transform)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/filters/__init__.py", line 81, in apply_filters
    callback()
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/handlers/__init__.py", line 106, in transform
    Transformer(self.context).transform(after_transform_cb)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/transformer.py", line 89, in transform
    self.smart_detect()
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/transformer.py", line 124, in smart_detect
    self.do_image_operations()
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/transformer.py", line 217, in do_image_operations
    callback = inner
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/context.py", line 281, in queue
    self._execute_in_foreground(operation, callback)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/context.py", line 270, in _execute_in_foreground
    callback(result)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/transformer.py", line 213, in inner
    self.done_callback()
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/handlers/__init__.py", line 148, in after_transform
    self.filters_runner.apply_filters(thumbor.filters.PHASE_POST_TRANSFORM, finish_callback)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/filters/__init__.py", line 91, in apply_filters
    exec_one_filter()
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/filters/__init__.py", line 90, in exec_one_filter
    f.run(exec_one_filter)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/filters/__init__.py", line 201, in run
    callback()
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/filters/__init__.py", line 86, in exec_one_filter
    callback()
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/handlers/__init__.py", line 248, in finish_request
    callback=inner,
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/context.py", line 281, in queue
    self._execute_in_foreground(operation, callback)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/context.py", line 269, in _execute_in_foreground
    result.set_result(operation())
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/handlers/__init__.py", line 198, in _load_results
    context.request.max_bytes
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/thumbor-5.0.4-py2.7-macosx-10.10-x86_64.egg/thumbor/handlers/__init__.py", line 296, in reload_to_fit_in_kb
    quality = int(quality * 0.75)
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'

```