### PR TITLE
allow to specify jpg-subsampling for Pillow

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -40,6 +40,8 @@ Config.define('MIN_HEIGHT', 1, "Min width in pixels for images read or generated
 Config.define('ALLOWED_SOURCES', [], "Allowed domains for the http loader to download. These are regular expressions.", 'Imaging')
 Config.define('QUALITY', 80, 'Quality index used for generated JPEG images', 'Imaging')
 Config.define('PROGRESSIVE_JPEG', True, 'Exports JPEG images with the `progressive` flag set.', 'Imaging')
+Config.define('PILLOW_JPEG_SUBSAMPLING', None,
+    'Specify subsampling behavior for Pillow (see `subsampling` in http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#jpeg).', 'Imaging')
 Config.define('WEBP_QUALITY', None, 'Quality index used for generated WebP images. If not set (None) the same level of JPEG quality will be used.', 'Imaging')
 Config.define('AUTO_WEBP', False, 'Specifies whether WebP format should be used automatically if the request accepts it (via Accept header)', 'Imaging')
 Config.define('MAX_AGE', 24 * 60 * 60, 'Max AGE sent as a header for the image served by thumbor in seconds', 'Imaging')

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -129,6 +129,8 @@ class Engine(BaseEngine):
                     quantization = getattr(self.image, 'quantization', None)
                     if quality is None and quantization and 2 <= len(quantization) <= 4:
                         options['quality'] = 'keep'
+                    if self.context.config.PILLOW_JPEG_SUBSAMPLING:
+                        options['subsampling'] = int(self.context.config.PILLOW_JPEG_SUBSAMPLING)
 
         if options['quality'] is None:
             options['quality'] = self.context.config.QUALITY

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -129,8 +129,8 @@ class Engine(BaseEngine):
                     quantization = getattr(self.image, 'quantization', None)
                     if quality is None and quantization and 2 <= len(quantization) <= 4:
                         options['quality'] = 'keep'
-                    if self.context.config.PILLOW_JPEG_SUBSAMPLING:
-                        options['subsampling'] = int(self.context.config.PILLOW_JPEG_SUBSAMPLING)
+            if self.context.config.PILLOW_JPEG_SUBSAMPLING:
+                options['subsampling'] = int(self.context.config.PILLOW_JPEG_SUBSAMPLING)
 
         if options['quality'] is None:
             options['quality'] = self.context.config.QUALITY


### PR DESCRIPTION
I added an option to specify the subsampling for jpeg images in pilbox. The default behaviour remains unchanged, it just allows you to specify if desired.

Without this certain images have noticable color changes and lose detail. I attached an example here.

<img width="222" alt="pillow_default" src="https://cloud.githubusercontent.com/assets/120468/8944050/87d901da-357e-11e5-811b-52cb50714e95.png">
<img width="222" alt="subsampling_4_4_4" src="https://cloud.githubusercontent.com/assets/120468/8944085/aeeba020-357e-11e5-9bf5-97f2a7283ae0.png">

