### PR TITLE
Modular url signer

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -328,6 +328,14 @@ Config.define(
 Config.define('ERROR_FILE_LOGGER', None, 'File of error log as json', 'Errors')
 Config.define('ERROR_FILE_NAME_USE_CONTEXT', False, 'File of error log name is parametrized with context attribute', 'Errors')
 
+# SIGNER MODULE
+Config.define(
+    'URL_SIGNER', 'thumbor.url_signers.base64_hmac_sha1',
+    'The url signer thumbor should use to verify url signatures.' +
+    'This must be the full name of a python module ' +
+    '(python must be able to import it)', 'Extensibility'
+)
+
 
 def generate_config():
     config.generate_config()

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -244,6 +244,7 @@ class ContextImporter:
         self.detectors = importer.detectors
         self.filters = importer.filters
         self.optimizers = importer.optimizers
+        self.url_signer = importer.url_signer
 
 
 class ThreadPool(object):

--- a/thumbor/crypto.py
+++ b/thumbor/crypto.py
@@ -13,7 +13,7 @@ import hashlib
 
 from Crypto.Cipher import AES
 
-# Import the Signer class to support backward-compability
+# Import the Signer class to support backward-compatibility
 # and existing documentation
 from thumbor.url_signers.base64_hmac_sha1 import UrlSigner as Signer
 from thumbor.url import Url

--- a/thumbor/crypto.py
+++ b/thumbor/crypto.py
@@ -10,10 +10,12 @@
 
 import base64
 import hashlib
-import hmac
 
 from Crypto.Cipher import AES
 
+# Import the Signer class to support backward-compability
+# and existing documentation
+from thumbor.url_signers.base64_hmac_sha1 import UrlSigner as Signer
 from thumbor.url import Url
 
 
@@ -116,17 +118,3 @@ class Cryptor(object):
         del result['image']
 
         return result
-
-
-class Signer:
-    def __init__(self, security_key):
-        if isinstance(security_key, unicode):
-            security_key = security_key.encode('utf-8')
-        self.security_key = security_key
-
-    def validate(self, actual_signature, url):
-        url_signature = self.signature(url)
-        return url_signature == actual_signature
-
-    def signature(self, url):
-        return base64.urlsafe_b64encode(hmac.new(self.security_key, unicode(url).encode('utf-8'), hashlib.sha1).digest())

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -10,7 +10,7 @@
 
 from thumbor.handlers import ContextHandler
 from thumbor.context import RequestParameters
-from thumbor.crypto import Cryptor, Signer
+from thumbor.crypto import Cryptor
 from thumbor.utils import logger
 from thumbor.url import Url
 import tornado.gen as gen
@@ -62,7 +62,7 @@ class ImagingHandler(ContextHandler):
 
         url_signature = self.context.request.hash
         if url_signature:
-            signer = Signer(self.context.server.security_key)
+            signer = self.context.modules.url_signer(self.context.server.security_key)
 
             url_to_validate = Url.encode_url(url).replace('/%s/' % self.context.request.hash, '')
             valid = signer.validate(url_signature, url_to_validate)
@@ -71,7 +71,7 @@ class ImagingHandler(ContextHandler):
                 # Retrieves security key for this image if it has been seen before
                 security_key = yield gen.maybe_future(self.context.modules.storage.get_crypto(self.context.request.image_url))
                 if security_key is not None:
-                    signer = Signer(security_key)
+                    signer = self.context.modules.url_signer(security_key)
                     valid = signer.validate(url_signature, url_to_validate)
 
             if not valid:

--- a/thumbor/importer.py
+++ b/thumbor/importer.py
@@ -18,6 +18,7 @@ class Importer:
         self.engine = None
         self.gif_engine = None
         self.loader = None
+        self.url_signer = None
         self.upload_photo_storage = None
         self.storage = None
         self.result_storage = None
@@ -38,7 +39,8 @@ class Importer:
 
     def import_modules(self):
         self.config.validates_presence_of(
-            'ENGINE', 'GIF_ENGINE', 'LOADER', 'STORAGE', 'DETECTORS', 'FILTERS'
+            'ENGINE', 'GIF_ENGINE', 'LOADER', 'STORAGE', 'DETECTORS',
+            'FILTERS', 'URL_SIGNER'
         )
 
         self.import_item('ENGINE', 'Engine')
@@ -48,6 +50,7 @@ class Importer:
         self.import_item('DETECTORS', 'Detector', is_multiple=True)
         self.import_item('FILTERS', 'Filter', is_multiple=True, ignore_errors=True)
         self.import_item('OPTIMIZERS', 'Optimizer', is_multiple=True)
+        self.import_item('URL_SIGNER', 'UrlSigner')
 
         if self.config.RESULT_STORAGE:
             self.import_item('RESULT_STORAGE', 'Storage')

--- a/thumbor/url.py
+++ b/thumbor/url.py
@@ -14,7 +14,7 @@ from urllib import quote
 
 class Url(object):
 
-    unsafe_or_hash = r'(?:(?:(?P<unsafe>unsafe)|(?P<hash>[^/]{28,}?))/)?'
+    unsafe_or_hash = r'(?:(?:(?P<unsafe>unsafe)|(?P<hash>.+?))/)?'
     debug = '(?:(?P<debug>debug)/)?'
     meta = '(?:(?P<meta>meta)/)?'
     trim = '(?:(?P<trim>trim(?::(?:top-left|bottom-right))?(?::\d+)?)/)?'

--- a/thumbor/url_signers/__init__.py
+++ b/thumbor/url_signers/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+
+class BaseUrlSigner(object):
+    def __init__(self, security_key):
+        if isinstance(security_key, unicode):
+            security_key = security_key.encode('utf-8')
+        self.security_key = security_key
+
+    def validate(self, actual_signature, url):
+        url_signature = self.signature(url)
+        return url_signature == actual_signature
+
+    def signature(self, url):
+        raise NotImplementedError()

--- a/thumbor/url_signers/base64_hmac_sha1.py
+++ b/thumbor/url_signers/base64_hmac_sha1.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+import base64
+import hashlib
+import hmac
+from thumbor.url_signers import BaseUrlSigner
+
+
+class UrlSigner(BaseUrlSigner):
+    """Validate urls and sign them using base64 hmac-sha1
+    """
+
+    def signature(self, url):
+        return base64.urlsafe_b64encode(
+            hmac.new(
+                self.security_key, unicode(url).encode('utf-8'), hashlib.sha1
+            ).digest()
+        )

--- a/vows/base64_hmac_sha1_url_signer_vows.py
+++ b/vows/base64_hmac_sha1_url_signer_vows.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+import hashlib
+import base64
+import hmac
+from pyvows import Vows, expect
+from thumbor.url_signers.base64_hmac_sha1 import UrlSigner
+
+
+@Vows.batch
+class Base64HmacSha1UrlSignerVows(Vows.Context):
+    def topic(self):
+        return UrlSigner(security_key="something")
+
+    def should_be_signer_instance(self, topic):
+        expect(topic).to_be_instance_of(UrlSigner)
+
+    def should_have_security_key(self, topic):
+        expect(topic.security_key).to_equal('something')
+
+    class Sign(Vows.Context):
+        def topic(self, signer):
+            url = '10x11:12x13/-300x-300/center/middle/smart/some/image.jpg'
+            expected = base64.urlsafe_b64encode(
+                hmac.new(
+                    'something', unicode(url).encode('utf-8'), hashlib.sha1
+                ).digest()
+            )
+            return (signer.signature(url), expected)
+
+        def should_equal_encrypted_string(self, test_data):
+            topic, expected = test_data
+            expect(topic).to_equal(expected)

--- a/vows/config_vows.py
+++ b/vows/config_vows.py
@@ -23,6 +23,7 @@ TEST_DATA = (
     ('STORAGE', STORAGE_DEFAULT_VALUE),
     ('ENGINE', 'thumbor.engines.pil'),
     ('GIF_ENGINE', 'thumbor.engines.gif'),
+    ('URL_SIGNER', 'thumbor.url_signers.base64_hmac_sha1'),
     ('ALLOW_UNSAFE_URL', True),
     ('FILE_LOADER_ROOT_PATH', '/tmp'),
     ('STORAGE_EXPIRATION_SECONDS', 60 * 60 * 24 * 30),

--- a/vows/crypto_vows.py
+++ b/vows/crypto_vows.py
@@ -10,7 +10,6 @@
 
 import hashlib
 import base64
-import hmac
 import copy
 
 from pyvows import Vows, expect
@@ -126,28 +125,6 @@ class CryptoVows(Vows.Context):
             def should_return_empty(self, topic):
                 wrong, right = topic
                 expect(wrong['image_hash']).not_to_equal(right['image_hash'])
-
-
-@Vows.batch
-class SignerVows(Vows.Context):
-    def topic(self):
-        return Signer(security_key="something")
-
-    def should_be_signer_instance(self, topic):
-        expect(topic).to_be_instance_of(Signer)
-
-    def should_have_security_key(self, topic):
-        expect(topic.security_key).to_equal('something')
-
-    class Sign(Vows.Context):
-        def topic(self, signer):
-            url = '10x11:12x13/-300x-300/center/middle/smart/some/image.jpg'
-            expected = base64.urlsafe_b64encode(hmac.new('something', unicode(url).encode('utf-8'), hashlib.sha1).digest())
-            return (signer.signature(url), expected)
-
-        def should_equal_encrypted_string(self, test_data):
-            topic, expected = test_data
-            expect(topic).to_equal(expected)
 
 
 BASE_IMAGE_URL = 'my.domain.com/some/image/url.jpg'

--- a/vows/url_vows.py
+++ b/vows/url_vows.py
@@ -99,7 +99,7 @@ class UrlVows(Vows.Context):
             return Url.regex()
 
         def should_contain_unsafe_or_hash(self, topic):
-            expect(topic).to_include('(?:(?:(?P<unsafe>unsafe)|(?P<hash>[^/]{28,}?))/)?')
+            expect(topic).to_include('(?:(?:(?P<unsafe>unsafe)|(?P<hash>.+?))/)?')
 
         def should_contain_meta(self, topic):
             expect(topic).to_include('(?:(?P<meta>meta)/)?')


### PR DESCRIPTION
Implements https://github.com/thumbor/thumbor/issues/522

- `context.modules.url_signer` now provides pluggable url signing and validation
- Introduces the `URL_SIGNER` configuration value. Defaults to the original hmac-sha1 url signer.