### PR TITLE
Fixes #529 - cache poisioning issues with returning 404 when an image…

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -8,6 +8,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
+import sys
 import functools
 import datetime
 import traceback
@@ -92,7 +93,7 @@ class BaseHandler(tornado.web.RequestHandler):
                 error=e
             )
 
-            self.context.log_exception(e)
+            self.log_exception(*sys.exc_info())
 
             if 'cannot identify image file' in e.message:
                 logger.warning(msg)
@@ -106,7 +107,7 @@ class BaseHandler(tornado.web.RequestHandler):
 
         if engine is None:
             if buffer is None:
-                self._error(404)
+                self._error(504)
                 return
 
             engine = self.context.request.engine

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -36,7 +36,7 @@ class ImagingHandler(ContextHandler):
         url = self.request.uri
 
         if not self.validate(kw['image']):
-            self._error(404, 'No original image was specified in the given URL')
+            self._error(400, 'No original image was specified in the given URL')
             return
 
         kw['request'] = self.request
@@ -47,17 +47,17 @@ class ImagingHandler(ContextHandler):
         has_both = self.context.request.unsafe and self.context.request.hash
 
         if has_none or has_both:
-            self._error(404, 'URL does not have hash or unsafe, or has both: %s' % url)
+            self._error(400, 'URL does not have hash or unsafe, or has both: %s' % url)
             return
 
         if self.context.request.unsafe and not self.context.config.ALLOW_UNSAFE_URL:
-            self._error(404, 'URL has unsafe but unsafe is not allowed by the config: %s' % url)
+            self._error(400, 'URL has unsafe but unsafe is not allowed by the config: %s' % url)
             return
 
         if self.context.config.USE_BLACKLIST:
             blacklist = yield self.get_blacklist_contents()
             if self.context.request.image_url in blacklist:
-                self._error(404, 'Source image url has been blacklisted: %s' % self.context.request.image_url )
+                self._error(400, 'Source image url has been blacklisted: %s' % self.context.request.image_url )
                 return
 
         url_signature = self.context.request.hash
@@ -93,7 +93,7 @@ class ImagingHandler(ContextHandler):
                     is_valid = False
 
                 if not is_valid:
-                    self._error(404, 'Malformed URL: %s' % url)
+                    self._error(400, 'Malformed URL: %s' % url)
                     return
 
         self.execute_image_operations()

--- a/vows/blacklist_vows.py
+++ b/vows/blacklist_vows.py
@@ -92,5 +92,5 @@ class BlacklistIntegration(BaseContext):
                 response = self.get('/unsafe/image.jpg')
                 return response.code
 
-            def should_return_200(self, topic):
-                expect(topic).to_equal(404)
+            def should_return_bad_request(self, topic):
+                expect(topic).to_equal(400)

--- a/vows/handler_images_vows.py
+++ b/vows/handler_images_vows.py
@@ -64,7 +64,7 @@ class GetImage(BaseContext):
             code, _ = response
             expect(code).to_equal(200)
 
-    class WithRegularImageiWithoutExtention(TornadoHTTPContext):
+    class WithRegularImageWithoutExtention(TornadoHTTPContext):
         def topic(self):
             response = self.get('/unsafe/smart/image')
             return (response.code, response.headers)
@@ -78,9 +78,9 @@ class GetImage(BaseContext):
             response = self.get('/unsafe/smart/imag')
             return (response.code, response.headers)
 
-        def should_be_200(self, response):
+        def should_be_gateway_timeout(self, response):
             code, _ = response
-            expect(code).to_equal(404)
+            expect(code).to_equal(504)
 
     class WithUnicodeImage(BaseContext):
         def topic(self):
@@ -105,18 +105,18 @@ class GetImage(BaseContext):
             response = self.get('/alabama1_ap620%C3%A9.jpg')
             return (response.code, response.headers)
 
-        def should_be_404(self, response):
+        def should_be_bad_request(self, response):
             code, _ = response
-            expect(code).to_equal(404)
+            expect(code).to_equal(400)
 
     class WithoutImage(TornadoHTTPContext):
         def topic(self):
             response = self.get('/unsafe/')
             return (response.code, response.headers)
 
-        def should_be_404(self, response):
+        def should_be_bad_request(self, response):
             code, _ = response
-            expect(code).to_equal(404)
+            expect(code).to_equal(400)
 
     class WithUTF8UrlEncodedOmageNameUsingEncodedUrl(TornadoHTTPContext):
         def topic(self):
@@ -204,9 +204,9 @@ class GetImageWithoutUnsafe(BaseContext):
             response = self.get('/unsafe/smart/image.jpg')
             return (response.code, response.headers)
 
-        def should_be_404(self, response):
+        def should_be_bad_request(self, response):
             code, _ = response
-            expect(code).to_equal(404)
+            expect(code).to_equal(400)
 
 
 @Vows.batch
@@ -241,9 +241,9 @@ class GetImageWithOLDFormat(BaseContext):
             response = self.get('/27m-vYMKohY6nvEt_D3Zwo7apVq63MS8TP-m1j3BXPGTftnrReTOEoScq1xMXe7h/alabama1_ap620é.jpg')
             return (response.code, response.headers)
 
-        def should_be_404(self, response):
+        def should_be_bad_request(self, response):
             code, _ = response
-            expect(code).to_equal(404)
+            expect(code).to_equal(400)
 
 
 @Vows.batch


### PR DESCRIPTION
… could not be loaded properly.

This also likely fixes the issue with hanging errors. The call was being made to context.log_error and should be self.log_error(*sys.exc_info()).

/cc @masom @bgentry #529