### PR TITLE
Adds a jpeg2000 optimizer to thumbor

### DIFF
--- a/thumbor/optimizers/j2k.py
+++ b/thumbor/optimizers/j2k.py
@@ -16,13 +16,14 @@ from thumbor.optimizers import BaseOptimizer
 class Optimizer(BaseOptimizer):
 
     def should_run(self, image_extension, buffer):
-        return 'j2k' in self.context.request.filters
+        return 'jpg' in image_extension or 'jpeg' in image_extension and 'j2k' in self.context.request.filters
 
     def optimize(self, buffer, input_file, output_file):
+        imagemagick_path = self.context.config.IMAGEMAGICK_PATH
         command = '%s %s -quality %s j2k:%s' % (
-            '/usr/local/bin/convert',
+            imagemagick_path,
             input_file,
-            self.context.config.J2K_QUALITY or '100',
+            self.context.config.J2K_QUALITY or '80',
             output_file,
         )
         subprocess.call(command, shell=True)

--- a/thumbor/optimizers/j2k.py
+++ b/thumbor/optimizers/j2k.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+import os
+import subprocess
+
+from thumbor.optimizers import BaseOptimizer
+
+class Optimizer(BaseOptimizer):
+
+    def should_run(self, image_extension, buffer):
+        return 'j2k' in self.context.request.filters
+
+    def optimize(self, buffer, input_file, output_file):
+        command = '%s %s -quality %s j2k:%s' % (
+            '/usr/local/bin/convert',
+            input_file,
+            self.context.config.J2K_QUALITY or '100',
+            output_file,
+        )
+        subprocess.call(command, shell=True)

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -29,6 +29,7 @@
 # imaging engines and works only on jpeg images
 #QUALITY = 85
 #WEBP_QUALITY = 80
+# J2K_QUALITY = 41
 
 # Automatically converts images to WebP if Accepts header present
 #AUTO_WEBP = False
@@ -190,9 +191,10 @@ ALLOW_UNSAFE_URL = True
     ## 'thumbor.filters.redeye',
 #]
 
-#OPTIMIZERS = [
-    #'thumbor.optimizers.jpegtran',
-    #'thumbor.optimizers.gifv',
-#]
+OPTIMIZERS = [
+    # 'thumbor.optimizers.jpegtran',
+    # 'thumbor.optimizers.gifv',
+    # 'thumbor.optimizers.j2k',
+]
 
 #JPEGTRAN_PATH = '/usr/local/bin/jpegtran'

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -198,3 +198,4 @@ OPTIMIZERS = [
 ]
 
 #JPEGTRAN_PATH = '/usr/local/bin/jpegtran'
+# IMAGEMAGICK_PATH = '/usr/local/bin/convert'


### PR DESCRIPTION
So, as is, this works. And I feel decent about it. But it's shelling out to imagemagick which aligns well with the other optimizers. However, I believe PIL could also create jpeg2000 images directly. Open to feedback.

To try it out, uncomment the j2k optimizer and the imagemagick path in the config. Adjust j2k quality in config if you wish, I saw pretty good results at 41. And request an image from thumbor, throwing in j2k to a format filter. Something like this: `http://localhost:8888/unsafe/0x200/filters:format(j2k)/http://cdn0.vox-cdn.com/uploads/chorus_image/image/47144834/Screen_Shot_2015-09-09_at_8.55.52_PM.0.0.png`

You can test that in Safari.