### PR TITLE
Adds a pngquant optimizer to thumbor

### DIFF
--- a/thumbor/optimizers/pngquant.py
+++ b/thumbor/optimizers/pngquant.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/globocom/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+import os
+import subprocess
+
+from thumbor.optimizers import BaseOptimizer
+
+class Optimizer(BaseOptimizer):
+
+    def should_run(self, image_extension, buffer):
+        return 'png' in image_extension
+
+    def optimize(self, buffer, input_file, output_file):
+        pngquant_path = self.context.config.PNGQUANT_PATH
+        # cat %s  | %s --speed=1 --nofs --quality=%s - > %s
+        command = 'cat %s  | %s --speed=1 --quality=%s - > %s' % (
+            input_file,
+            pngquant_path,
+            self.context.config.PNGQUANT_QUALITY or '80',
+            output_file,
+        )
+        print(command)
+        subprocess.call(command, shell=True)

--- a/thumbor/optimizers/pngquant.py
+++ b/thumbor/optimizers/pngquant.py
@@ -27,5 +27,4 @@ class Optimizer(BaseOptimizer):
             self.context.config.PNGQUANT_QUALITY or '80',
             output_file,
         )
-        print(command)
         subprocess.call(command, shell=True)

--- a/thumbor/optimizers/pngquant.py
+++ b/thumbor/optimizers/pngquant.py
@@ -20,7 +20,6 @@ class Optimizer(BaseOptimizer):
 
     def optimize(self, buffer, input_file, output_file):
         pngquant_path = self.context.config.PNGQUANT_PATH
-        # cat %s  | %s --speed=1 --nofs --quality=%s - > %s
         command = 'cat %s  | %s --speed=1 --quality=%s - > %s' % (
             input_file,
             pngquant_path,

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -29,6 +29,7 @@
 # imaging engines and works only on jpeg images
 #QUALITY = 85
 #WEBP_QUALITY = 80
+# PNGQUANT_QUALITY = '40-100'
 
 # Automatically converts images to WebP if Accepts header present
 #AUTO_WEBP = False
@@ -190,9 +191,11 @@ ALLOW_UNSAFE_URL = True
     ## 'thumbor.filters.redeye',
 #]
 
-#OPTIMIZERS = [
-    #'thumbor.optimizers.jpegtran',
-    #'thumbor.optimizers.gifv',
-#]
+OPTIMIZERS = [
+    # 'thumbor.optimizers.jpegtran',
+    # 'thumbor.optimizers.gifv',
+    # 'thumbor.optimizers.pngquant',
+]
 
 #JPEGTRAN_PATH = '/usr/local/bin/jpegtran'
+# PNGQUANT_PATH = '/usr/local/bin/pngquant'


### PR DESCRIPTION
Really straight forward pngquant optimizer for PNG's. You must have pngquant installed (use version 2).

Uncomment and adjust preferred quality setting. Uncomment pngquant optimizer. And now all PNG's will pass through pngquant.