### PR TITLE
Set content type based on mime

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -241,9 +241,9 @@ class BaseHandler(tornado.web.RequestHandler):
             )
         if not context.request.meta:
             results = self.optimize(context, image_extension, results)
-        if context.request.format:
-            # An optimizer might have modified the image format.
-            content_type = CONTENT_TYPE.get('.%s' % context.request.format, content_type)
+        # An optimizer might have modified the image format.
+        content_type = BaseEngine.get_mimetype(results)
+
         return results, content_type
 
     def _process_result_from_storage(self, result):
@@ -281,7 +281,7 @@ class BaseHandler(tornado.web.RequestHandler):
             context.config.RESULT_STORAGE_STORES_UNSAFE or not context.request.unsafe)
 
         def inner(future):
-            results, content_type = (future.result()[0], BaseEngine.get_mimetype(future.result()[0]))
+            results, content_type = future.result()
             self._write_results_to_client(context, results, content_type)
             if should_store:
                 self._store_results(context, results)

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -281,7 +281,7 @@ class BaseHandler(tornado.web.RequestHandler):
             context.config.RESULT_STORAGE_STORES_UNSAFE or not context.request.unsafe)
 
         def inner(future):
-            results, content_type = future.result()
+            results, content_type = (future.result()[0], BaseEngine.get_mimetype(future.result()[0]))
             self._write_results_to_client(context, results, content_type)
             if should_store:
                 self._store_results(context, results)


### PR DESCRIPTION
This PR will set the `Content-Type` header based on the actual MIME type of whatever is returned after all processing. This will help greatly with a new optimizer I'm working on that sometimes returns JPEG's when you request a PNG's source image and apply the optimizer - if the source PNG doesn't contain any transparent pixels. Should also remove the burden of setting the correct MIME type from future plugins. Only caveat is that they must be defined in the `BaseEngine` class's `get_mimetype` method.

It's somewhat ugly code but seems to work. Open to suggestions, otherwise here it is.