### PR TITLE
Adds the jp2 aka jpeg2000 MIME type

### DIFF
--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -69,6 +69,8 @@ class BaseEngine(object):
             mime = 'image/jpeg'
         elif buffer.startswith('WEBP', 8):
             mime = 'image/webp'
+        elif buffer.startswith('\x00\x00\x00\x0c'):
+            mime = 'image/jp2'
         elif buffer.startswith('\x00\x00\x00 ftyp'):
             mime = 'video/mp4'
         elif buffer.startswith('\x1aE\xdf\xa3'):


### PR DESCRIPTION
Really straight forward.

See the RFC MIME spec http://www.rfc-editor.org/rfc/rfc3745.txt or consult your own source.

Alternatively, test locally from thumbor dir, do something like this:
```
(thumbor) ~/Projects/voxmedia/thumbor $ python
from thumbor.engines import BaseEngine
buffer = open('/Users/jason/Desktop/fromverge-small.jp2').read()
BaseEngine.get_mimetype(buffer)
'image/jp2'
```