### PR TITLE
clean up PILLOW_JPEG-options

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -32,14 +32,15 @@ Config.define('MIN_HEIGHT', 1, "Min width in pixels for images read or generated
 Config.define('ALLOWED_SOURCES', [], "Allowed domains for the http loader to download. These are regular expressions.", 'Imaging')
 Config.define('QUALITY', 80, 'Quality index used for generated JPEG images', 'Imaging')
 Config.define('PROGRESSIVE_JPEG', True, 'Exports JPEG images with the `progressive` flag set.', 'Imaging')
+
 Config.define('PILLOW_JPEG_SUBSAMPLING', None,
-              'Specify subsampling behavior for Pillow (see `subsampling` in '
-              'http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#jpeg).', 'Imaging')
-Config.define(
-    'PILLOW_COPY_JPEG_SETTINGS',
-    False,
-    'If True, use qtables and subsampling from orginal JPG file. Useful if you want to keep jpg quality as identical as '
-    'possible to original file. Will ignore QUALITY and PILLOW_JPEG_SUBSAMPLING.', 'Imaging')
+    'Specify subsampling behavior for Pillow (see `subsampling` in http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#jpeg). '
+    'Be careful to use int for 0,1,2 and string for "4:4:4" notation. '
+    'Will ignore `quality`. Using `keep` will copy the original file\'s subsampling.', 'Imaging')
+Config.define('PILLOW_JPEG_QTABLES', None,
+    'Specify quantization tables for Pillow (see `qtables` in http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#jpeg). '
+    'Will ignore `quality`. Using `keep` will copy the original file\'s qtables.', 'Imaging')
+
 Config.define('WEBP_QUALITY', None, 'Quality index used for generated WebP images. If not set (None) the same level of '
               'JPEG quality will be used.', 'Imaging')
 Config.define('AUTO_WEBP', False, 'Specifies whether WebP format should be used automatically if the request accepts it '

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -136,17 +136,23 @@ class Engine(BaseEngine):
                 self.image = self.image.convert('RGB')
             else:
 
-                quantization = self.qtables
-                subsampling = self.subsampling
-                copy_jpg_settings = self.context.config.PILLOW_COPY_JPEG_SETTINGS
+                subsampling_config = self.context.config.PILLOW_JPEG_SUBSAMPLING
+                qtables_config = self.context.config.PILLOW_JPEG_QTABLES
 
-                if copy_jpg_settings and (subsampling is not None) and quantization and 2 <= len(quantization) <= 4:
+                if subsampling_config is not None or qtables_config is not None:
                     options['quality'] = 0  # can't use 'keep' here as Pillow would try to extract qtables/subsampling and fail
-                    options['qtables'] = quantization
-                    options['subsampling'] = subsampling
+                    orig_subsampling = self.subsampling
+                    orig_qtables = self.qtables
 
-            if self.context.config.PILLOW_JPEG_SUBSAMPLING:
-                options['subsampling'] = int(self.context.config.PILLOW_JPEG_SUBSAMPLING)
+                    if (subsampling_config == 'keep' or subsampling_config is None) and (orig_subsampling is not None):
+                        options['subsampling'] = orig_subsampling
+                    else:
+                        options['subsampling'] = subsampling_config
+
+                    if (qtables_config == 'keep' or qtables_config is None) and (orig_qtables and 2 <= len(orig_qtables) <= 4):
+                        options['qtables'] = orig_qtables
+                    else:
+                        options['qtables'] = qtables_config
 
         if options['quality'] is None:
             options['quality'] = self.context.config.QUALITY


### PR DESCRIPTION
I was not happy with the confusing options for PIL-JPEG settings PILLOW_JPEG_SUBSAMPLING (but not PILLOW_JPEG_QTABLES), and PILLOW_COPY_JPEG_SETTINGS (which overrides both QUALITY and PILLOW_JPEG_SUBSAMPLING).

So i tried to clean it up:
* allows explicit setting or keeping for both subsampling and qtables (PILLOW_JPEG_SUBSAMPLING, PILLOW_JPEG_QTABLES)

* removes PILLOW_COPY_JPEG_SETTINGS, as it can now be achieved by setting both SUBSAMPLING and QTABLES to 'keep'

