### PR TITLE
Add DELETE functionality to imaging handler

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -115,6 +115,7 @@ Config.define('ALLOW_UNSAFE_URL', True, 'Indicates if the /unsafe URL should be 
 Config.define('ALLOW_OLD_URLS', True, 'Indicates if encrypted (old style) URLs should be allowed', 'Security')
 Config.define('ENABLE_ETAGS', True, 'Enables automatically generated etags', 'HTTP')
 Config.define('MAX_ID_LENGTH', 32, 'Set maximum id length for images when stored', 'Storage')
+Config.define('ALLOW_DELETE', False, 'Allow image deletion', 'Storage')
 
 # METRICS OPTIONS
 Config.define('STATSD_HOST', None, 'Host to send statsd instrumentation to', 'Metrics')

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -79,12 +79,29 @@ class ImagingHandler(ContextHandler):
                 self._error(400, 'Malformed URL: %s' % url)
                 return
 
-        self.execute_image_operations()
-
     @tornado.web.asynchronous
     def get(self, **kw):
         self.check_image(kw)
+        self.execute_image_operations()
 
     @tornado.web.asynchronous
     def head(self, **kw):
         self.check_image(kw)
+        self.execute_image_operations()
+
+    @tornado.web.asynchronous
+    @tornado.gen.coroutine
+    def delete(self, **kw):
+        # Check if image deleting is allowed
+        if not self.context.config.ALLOW_DELETE:
+            self._error(405, 'Unable to delete an image')
+            return
+
+        self.check_image(kw)
+        exists = yield gen.maybe_future(self.context.modules.storage.exists(self.context.request.image_url))
+
+        if exists:
+            self.context.modules.storage.remove(self.context.request.image_url)
+            self.set_status(204)
+        else:
+            self._error(404, 'Image not found at the given URL')


### PR DESCRIPTION
Deletion is currently only available to images uploaded via POST, it makes sense to make it available for originals fetched through GET.