### PR TITLE
Re-encode URL before validating HMAC to work around bad clients

### DIFF
--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -65,7 +65,7 @@ class ImagingHandler(ContextHandler):
         if url_signature:
             signer = self.context.modules.url_signer(self.context.server.security_key)
 
-            url_to_validate = Url.encode_url(url).replace('/%s/' % self.context.request.hash, '')
+            url_to_validate = Url.reencode_url(url).replace('/%s/' % self.context.request.hash, '')
             valid = signer.validate(url_signature, url_to_validate)
 
             if not valid and self.context.config.STORES_CRYPTO_KEY_FOR_EACH_IMAGE:


### PR DESCRIPTION
As discussed on #598 this is an incomplete patch for the issue.

It's good enough for us for now so we will probably use this anyway but has issues noted in #598 that prevent this from being merged as it is. Lack of tests is one glaring issue.

It's shared as a PR for discussion.