### PR TITLE
Exceptions might happen inside engine.load

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -147,7 +147,11 @@ class BaseHandler(tornado.web.RequestHandler):
                 return
 
             engine = self.context.request.engine
-            engine.load(buffer, self.context.request.extension)
+            try:
+                engine.load(buffer, self.context.request.extension)
+            except Exception:
+                self._error(504)
+                return
 
         def transform():
             self.normalize_crops(normalized, req, engine)


### PR DESCRIPTION
The example use case I'm running into is a failing subprocess command
happening in the engine's create_image method. If that happens, there
is no way to proceed further with the thumbnailing.