### PR TITLE
Re-read storage value to allow for override

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -495,6 +495,11 @@ class BaseHandler(tornado.web.RequestHandler):
             self.context.request.engine.load(fetch_result.buffer, extension)
 
             fetch_result.normalized = self.context.request.engine.normalize()
+
+            # Allows engine or loader to override storage on the fly for the purpose of
+            # marking a specific file as unstoreable
+            storage = self.context.modules.storage
+
             is_no_storage = isinstance(storage, NoStorage)
             is_mixed_storage = isinstance(storage, MixedStorage)
             is_mixed_no_file_storage = is_mixed_storage and isinstance(storage.file_storage, NoStorage)


### PR DESCRIPTION
The use case I need this for is when a custom loader determines
that a specific kind of content (eg. videos of a certain size) shouldn't
be cached. By simply overriding the context's storage value, it can disable
storage of the original for that request.