### PR TITLE
WIP - Media Object

### DIFF
--- a/requirements
+++ b/requirements
@@ -1,6 +1,6 @@
+cython
+gifsicle
 libcurl4-openssl-dev
-python-numpy
-python-opencv
 libopencv-dev
 libjpeg-dev
 libpng-dev
@@ -9,11 +9,10 @@ libass-dev
 libvpx1
 libvpx-dev
 libwebp-dev
-webp
-gifsicle
-memcached
 libmemcache-dev
 libmemcached-dev
+memcached
 python-numpy
+python-opencv
 python-scipy
-cython
+webp

--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -23,7 +23,7 @@ from mock import Mock, patch
 from thumbor.config import Config
 from thumbor.importer import Importer
 from thumbor.context import Context, ServerParameters
-from thumbor.handlers import FetchResult, BaseHandler
+from thumbor.handlers import BaseHandler
 from thumbor.storages.file_storage import Storage as FileStorage
 from thumbor.storages.no_storage import Storage as NoStorage
 from thumbor.media import Media
@@ -38,30 +38,6 @@ from tests.fixtures.images import (
     animated_image,
     not_so_animated_image,
 )
-
-
-class FetchResultTestCase(PythonTestCase):
-    def test_can_create_default_fetch_result(self):
-        result = FetchResult()
-        expect(result.normalized).to_be_false()
-        expect(result.media).to_be_null()
-        expect(result.engine).to_be_null()
-        expect(result.successful).to_be_false()
-
-    def test_can_create_fetch_result(self):
-        buffer_mock = Mock()
-        engine_mock = Mock()
-        result = FetchResult(
-            normalized=True,
-            media=Media(buffer_mock),
-            engine=engine_mock,
-            successful=True
-        )
-        expect(result.normalized).to_be_true()
-        expect(result.media.buffer).to_equal(buffer_mock)
-        expect(result.engine).to_equal(engine_mock)
-        expect(result.successful).to_be_true()
-
 
 class ErrorHandler(BaseHandler):
     def get(self):

--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -741,15 +741,9 @@ class StorageOverride(BaseImagingTestCase):
         Engine.load = load_override
         FileStorage.put = put_override
 
-        response = self.fetch('/unsafe/smart/image.jpg')
-
-        expect(response.code).to_equal(200)
-
-        Engine.load = old_load
-        FileStorage.put = old_put
-
         try:
             response = self.fetch('/unsafe/smart/image.jpg')
-            expect(response.code).to_equal(504)
+            expect(response.code).to_equal(200)
         finally:
+            FileStorage.put = old_put
             Engine.load = old_load

--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -706,10 +706,11 @@ class EngineLoadException(BaseImagingTestCase):
 
         Engine.load = load_override
 
-        response = self.fetch('/unsafe/smart/image.jpg')
-        expect(response.code).to_equal(504)
-
-        Engine.load = old_load
+        try:
+            response = self.fetch('/unsafe/smart/image.jpg')
+            expect(response.code).to_equal(504)
+        finally:
+            Engine.load = old_load
 
 
 class StorageOverride(BaseImagingTestCase):
@@ -746,3 +747,9 @@ class StorageOverride(BaseImagingTestCase):
 
         Engine.load = old_load
         FileStorage.put = old_put
+
+        try:
+            response = self.fetch('/unsafe/smart/image.jpg')
+            expect(response.code).to_equal(504)
+        finally:
+            Engine.load = old_load

--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -26,6 +26,7 @@ from thumbor.context import Context, ServerParameters
 from thumbor.handlers import FetchResult, BaseHandler
 from thumbor.storages.file_storage import Storage as FileStorage
 from thumbor.storages.no_storage import Storage as NoStorage
+from thumbor.media import Media
 from thumbor.utils import which
 from tests.base import TestCase, PythonTestCase
 from thumbor.engines.pil import Engine
@@ -43,27 +44,23 @@ class FetchResultTestCase(PythonTestCase):
     def test_can_create_default_fetch_result(self):
         result = FetchResult()
         expect(result.normalized).to_be_false()
-        expect(result.buffer).to_be_null()
+        expect(result.media).to_be_null()
         expect(result.engine).to_be_null()
         expect(result.successful).to_be_false()
-        expect(result.loader_error).to_be_null()
 
     def test_can_create_fetch_result(self):
         buffer_mock = Mock()
         engine_mock = Mock()
-        error_mock = Mock()
         result = FetchResult(
             normalized=True,
-            buffer=buffer_mock,
+            media=Media(buffer_mock),
             engine=engine_mock,
-            successful=True,
-            loader_error=error_mock,
+            successful=True
         )
         expect(result.normalized).to_be_true()
-        expect(result.buffer).to_equal(buffer_mock)
+        expect(result.media.buffer).to_equal(buffer_mock)
         expect(result.engine).to_equal(engine_mock)
         expect(result.successful).to_be_true()
-        expect(result.loader_error).to_equal(error_mock)
 
 
 class ErrorHandler(BaseHandler):

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -16,7 +16,7 @@ from preggy import expect
 from thumbor.context import Context
 from thumbor.config import Config
 from thumbor.loaders.file_loader import load
-from thumbor.loaders import LoaderResult
+from thumbor.media import Media
 
 STORAGE_PATH = abspath(join(dirname(__file__), '../fixtures/images/'))
 
@@ -33,18 +33,18 @@ class FileLoaderTestCase(TestCase):
 
     def test_should_load_file(self):
         result = self.load_file('image.jpg')
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal(open(join(STORAGE_PATH, 'image.jpg')).read())
-        expect(result.successful).to_be_true()
+        expect(result.is_valid).to_be_true()
 
     def test_should_fail_when_inexistent_file(self):
         result = self.load_file('image_NOT.jpg')
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal(None)
-        expect(result.successful).to_be_false()
+        expect(result.is_valid).to_be_false()
 
     def test_should_fail_when_outside_root_path(self):
         result = self.load_file('../__init__.py')
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal(None)
-        expect(result.successful).to_be_false()
+        expect(result.is_valid).to_be_false()

--- a/tests/loaders/test_http_loader.py
+++ b/tests/loaders/test_http_loader.py
@@ -19,6 +19,7 @@ from tornado.concurrent import Future
 import thumbor.loaders.http_loader as loader
 from thumbor.context import Context
 from thumbor.config import Config
+from thumbor.media import Media
 from thumbor.loaders import LoaderResult
 
 
@@ -69,9 +70,9 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_be_null()
-        expect(result.successful).to_be_false()
+        expect(result.is_valid).to_be_false()
 
     def test_return_body_if_valid(self):
         response_mock = ResponseMock(body='body', code=200)
@@ -79,7 +80,7 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal('body')
 
     def test_return_upstream_error_on_body_none(self):
@@ -88,10 +89,10 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_be_null()
-        expect(result.successful).to_be_false()
-        expect(result.error).to_equal(LoaderResult.ERROR_UPSTREAM)
+        expect(result.is_valid).to_be_false()
+        expect(result.errors).to_include(LoaderResult.ERROR_UPSTREAM)
 
     def test_return_upstream_error_on_body_empty(self):
         response_mock = ResponseMock(body='', code=200)
@@ -99,10 +100,10 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_be_null()
-        expect(result.successful).to_be_false()
-        expect(result.error).to_equal(LoaderResult.ERROR_UPSTREAM)
+        expect(result.is_valid).to_be_false()
+        expect(result.errors).to_include(LoaderResult.ERROR_UPSTREAM)
 
 
 class ValidateUrlTestCase(PythonTestCase):
@@ -181,9 +182,9 @@ class HttpLoaderTestCase(TestCase):
 
         loader.load(ctx, url, self.stop)
         result = self.wait()
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal('Hello')
-        expect(result.successful).to_be_true()
+        expect(result.is_valid).to_be_true()
 
     def test_load_with_curl(self):
         url = self.get_url('/')
@@ -193,9 +194,9 @@ class HttpLoaderTestCase(TestCase):
 
         loader.load(ctx, url, self.stop)
         result = self.wait()
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal('Hello')
-        expect(result.successful).to_be_true()
+        expect(result.is_valid).to_be_true()
 
     def test_should_return_a_future(self):
         url = self.get_url('/')
@@ -223,7 +224,7 @@ class HttpLoaderWithUserAgentForwardingTestCase(TestCase):
 
         loader.load(ctx, url, self.stop)
         result = self.wait()
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal('test-user-agent')
 
     def test_load_with_default_user_agent(self):
@@ -235,5 +236,5 @@ class HttpLoaderWithUserAgentForwardingTestCase(TestCase):
 
         loader.load(ctx, url, self.stop)
         result = self.wait()
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal('DEFAULT_USER_AGENT')

--- a/tests/loaders/test_https_loader.py
+++ b/tests/loaders/test_https_loader.py
@@ -20,6 +20,7 @@ from tornado.concurrent import Future
 import thumbor.loaders.https_loader as loader
 from thumbor.context import Context
 from thumbor.config import Config
+from thumbor.media import Media
 from thumbor.loaders import LoaderResult
 
 
@@ -70,9 +71,9 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_be_null()
-        expect(result.successful).to_be_false()
+        expect(result.is_valid).to_be_false()
 
     def test_return_body_if_valid(self):
         response_mock = ResponseMock(body='body', code=200)
@@ -80,7 +81,7 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal('body')
 
     def test_return_upstream_error_on_body_none(self):
@@ -89,10 +90,10 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_be_null()
-        expect(result.successful).to_be_false()
-        expect(result.error).to_equal(LoaderResult.ERROR_UPSTREAM)
+        expect(result.is_valid).to_be_false()
+        expect(result.errors).to_include(LoaderResult.ERROR_UPSTREAM)
 
     def test_return_upstream_error_on_body_empty(self):
         response_mock = ResponseMock(body='', code=200)
@@ -100,10 +101,10 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_be_null()
-        expect(result.successful).to_be_false()
-        expect(result.error).to_equal(LoaderResult.ERROR_UPSTREAM)
+        expect(result.is_valid).to_be_false()
+        expect(result.errors).to_include(LoaderResult.ERROR_UPSTREAM)
 
 
 class ValidateUrlTestCase(PythonTestCase):
@@ -174,9 +175,9 @@ class HttpsLoaderTestCase(TestCase):
 
         loader.load(ctx, url, self.stop)
         result = self.wait()
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal('Hello')
-        expect(result.successful).to_be_true()
+        expect(result.is_valid).to_be_true()
 
     def test_load_with_curl(self):
         url = self.get_url('/')
@@ -186,9 +187,9 @@ class HttpsLoaderTestCase(TestCase):
 
         loader.load(ctx, url, self.stop)
         result = self.wait()
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal('Hello')
-        expect(result.successful).to_be_true()
+        expect(result.is_valid).to_be_true()
 
     def test_should_return_a_future(self):
         url = self.get_url('/')
@@ -216,7 +217,7 @@ class HttpLoaderWithUserAgentForwardingTestCase(TestCase):
 
         loader.load(ctx, url, self.stop)
         result = self.wait()
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal('test-user-agent')
 
     def test_load_with_default_user_agent(self):
@@ -228,5 +229,5 @@ class HttpLoaderWithUserAgentForwardingTestCase(TestCase):
 
         loader.load(ctx, url, self.stop)
         result = self.wait()
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal('DEFAULT_USER_AGENT')

--- a/tests/loaders/test_strict_https_loader.py
+++ b/tests/loaders/test_strict_https_loader.py
@@ -19,6 +19,7 @@ from tests.base import PythonTestCase
 import thumbor.loaders.strict_https_loader as loader
 from thumbor.context import Context
 from thumbor.config import Config
+from thumbor.media import Media
 from thumbor.loaders import LoaderResult
 
 
@@ -69,9 +70,9 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_be_null()
-        expect(result.successful).to_be_false()
+        expect(result.is_valid).to_be_false()
 
     def test_return_body_if_valid(self):
         response_mock = ResponseMock(body='body', code=200)
@@ -79,7 +80,7 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_equal('body')
 
     def test_return_upstream_error_on_body_none(self):
@@ -88,10 +89,10 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_be_null()
-        expect(result.successful).to_be_false()
-        expect(result.error).to_equal(LoaderResult.ERROR_UPSTREAM)
+        expect(result.is_valid).to_be_false()
+        expect(result.errors).to_include(LoaderResult.ERROR_UPSTREAM)
 
     def test_return_upstream_error_on_body_empty(self):
         response_mock = ResponseMock(body='', code=200)
@@ -99,10 +100,10 @@ class ReturnContentTestCase(PythonTestCase):
         ctx = Context(None, None, None)
         loader.return_contents(response_mock, 'some-url', callback_mock, ctx)
         result = callback_mock.call_args[0][0]
-        expect(result).to_be_instance_of(LoaderResult)
+        expect(result).to_be_instance_of(Media)
         expect(result.buffer).to_be_null()
-        expect(result.successful).to_be_false()
-        expect(result.error).to_equal(LoaderResult.ERROR_UPSTREAM)
+        expect(result.is_valid).to_be_false()
+        expect(result.errors).to_include(LoaderResult.ERROR_UPSTREAM)
 
 
 class ValidateUrlTestCase(PythonTestCase):

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+from __future__ import unicode_literals,absolute_import
+from unittest import TestCase
+import hashlib
+import copy
+import mock
+
+from preggy import expect
+
+from thumbor.media import Media
+from thumbor.result_storages import ResultStorageResult
+
+
+class MediaTestCase(TestCase):
+    def setUp(self, *args, **kwargs):
+        super(MediaTestCase, self).setUp(*args, **kwargs)
+        self.buffer_mock = b''
+
+
+    def test_can_create_empty_media_object(self):
+        media = Media()
+        expect(media.normalized).to_be_false()
+        expect(media.buffer).to_be_null()
+        expect(media.engine).to_be_null()
+        expect(media.successful).to_be_false()
+
+    def test_can_create_media_object(self):
+        result = Media(self.buffer_mock)
+        expect(result.buffer).to_equal(self.buffer_mock)
+        expect(result.is_valid).to_be_true()
+
+    def test_can_create_media_from_result(self):
+        loader_result = ResultStorageResult(buffer=self.buffer_mock)
+        loader_result.metadata['ContentType'] = 'image/gif'
+        media = Media.from_result(loader_result)
+        expect(media.buffer).to_equal(self.buffer_mock)
+        expect(media.mime).to_equal('image/gif')
+
+    def test_can_create_media_from_unknown_result(self):
+        loader_result = ResultStorageResult(buffer=self.buffer_mock)
+        media = Media.from_result(loader_result)
+        expect(media.buffer).to_equal(self.buffer_mock)
+        expect(media.mime).to_equal('')
+
+        # Try a valid buffer
+        loader_result = ResultStorageResult(buffer=b'\x00\x00\x00\x0ctest')
+        media = Media.from_result(loader_result)
+        expect(media.mime).to_equal('image/jp2')
+
+

--- a/thumbor/filters/watermark.py
+++ b/thumbor/filters/watermark.py
@@ -11,7 +11,6 @@
 from os.path import splitext
 from thumbor.ext.filters import _alpha
 from thumbor.filters import BaseFilter, filter_method
-from thumbor.loaders import LoaderResult
 from thumbor.media import Media
 import tornado.gen
 import math
@@ -97,14 +96,7 @@ class Filter(BaseFilter):
         self.callback()
 
     def on_fetch_done(self, result):
-        media = None
-        # TODO if result.successful is False how can the error be handled?
-        if isinstance(result, Media):
-            media = result
-        elif isinstance(result, LoaderResult):
-            media = Media(result.buffer)
-        else:
-            media = Media(result)
+        media = Media.from_result(result)
 
         self.watermark_engine.load(media.buffer, self.extension)
 

--- a/thumbor/filters/watermark.py
+++ b/thumbor/filters/watermark.py
@@ -12,6 +12,7 @@ from os.path import splitext
 from thumbor.ext.filters import _alpha
 from thumbor.filters import BaseFilter, filter_method
 from thumbor.loaders import LoaderResult
+from thumbor.media import Media
 import tornado.gen
 import math
 
@@ -19,8 +20,8 @@ import math
 class Filter(BaseFilter):
     regex = r'(?:watermark\((?P<url>.*?),(?P<x>(?:-?\d+)|center|repeat),(?P<y>(?:-?\d+)|center|repeat),(?P<alpha>[\d]*?)\))'
 
-    def on_image_ready(self, buffer):
-        self.watermark_engine.load(buffer, self.extension)
+    def on_image_ready(self, media):
+        self.watermark_engine.load(media.buffer, self.extension)
         self.watermark_engine.enable_alpha()
 
         mode, data = self.watermark_engine.image_data_as_rgb()
@@ -34,78 +35,89 @@ class Filter(BaseFilter):
         mos_y = self.y == 'repeat'
         center_x = self.x == 'center'
         center_y = self.y == 'center'
-        if not center_x and not mos_x :
+        if not center_x and not mos_x:
             inv_x = self.x[0] == '-'
             x = int(self.x)
-        if not center_y and not mos_y :
+        if not center_y and not mos_y:
             inv_y = self.y[0] == '-'
             y = int(self.y)
 
         sz = self.engine.size
         watermark_sz = self.watermark_engine.size
-        
-        if not mos_x :
+
+        if not mos_x:
             repeat_x = (1, 0)
-            if center_x :
-                x = (sz[0] - watermark_sz[0]) /2
+            if center_x:
+                x = (sz[0] - watermark_sz[0]) / 2
             elif inv_x:
                 x = (sz[0] - watermark_sz[0]) + x
-        else :
+        else:
             repeat_x = divmod(sz[0], watermark_sz[0])
-            if sz[0] * 1.0 / watermark_sz[0]  < 2 :
+            if sz[0] * 1.0 / watermark_sz[0] < 2:
                 repeat_x = (math.ceil(sz[0] * 1.0 / watermark_sz[0]), 10)
                 space_x = 10
-        if not mos_y :
+        if not mos_y:
             repeat_y = (1, 0)
-            if center_y :
-                y = (sz[1] - watermark_sz[1]) /2
+            if center_y:
+                y = (sz[1] - watermark_sz[1]) / 2
             elif inv_y:
                 y = (sz[1] - watermark_sz[1]) + y
-        else :
+        else:
             repeat_y = divmod(sz[1], watermark_sz[1])
-            if sz[1] * 1.0 / watermark_sz[1] < 2 :
+            if sz[1] * 1.0 / watermark_sz[1] < 2:
                 repeat_y = (math.ceil(sz[1] * 1.0 / watermark_sz[1]), 10)
                 space_y = 10
 
-        if not mos_x and not mos_y :
+        if not mos_x and not mos_y:
             self.engine.paste(self.watermark_engine, (x, y), merge=True)
-        elif mos_x and mos_y :
-            if (repeat_x[0] * repeat_y[0]) > 100 :
+        elif mos_x and mos_y:
+            if (repeat_x[0] * repeat_y[0]) > 100:
                 tmpRepeatX = min(6, repeat_x[0])
                 tmpRepeatY = min(6, repeat_y[0])
                 repeat_x = (tmpRepeatX, sz[0] - tmpRepeatX * watermark_sz[0])
                 repeat_y = (tmpRepeatY, sz[1] - tmpRepeatY * watermark_sz[1])
             space_x = repeat_x[1] / (max(repeat_x[0], 2) - 1)
             space_y = repeat_y[1] / (max(repeat_y[0], 2) - 1)
-            for i in range(int(repeat_x[0])) :
+            for i in range(int(repeat_x[0])):
                 x = i * space_x + i * watermark_sz[0]
-                for j in range(int(repeat_y[0])) :
+                for j in range(int(repeat_y[0])):
                     y = j * space_y + j * watermark_sz[1]
                     self.engine.paste(self.watermark_engine, (x, y), merge=True)
-        elif mos_x :
+        elif mos_x:
             space_x = repeat_x[1] / (max(repeat_x[0], 2) - 1)
-            for i in range(int(repeat_x[0])) :
+            for i in range(int(repeat_x[0])):
                 x = i * space_x + i * watermark_sz[0]
                 self.engine.paste(self.watermark_engine, (x, y), merge=True)
-        else :
+        else:
             space_y = repeat_y[1] / (max(repeat_y[0], 2) - 1)
-            for j in range(int(repeat_y[0])) :
+            for j in range(int(repeat_y[0])):
                 y = j * space_y + j * watermark_sz[1]
                 self.engine.paste(self.watermark_engine, (x, y), merge=True)
 
         self.callback()
 
     def on_fetch_done(self, result):
+        media = None
         # TODO if result.successful is False how can the error be handled?
-        if isinstance(result, LoaderResult):
-            buffer = result.buffer
+        if isinstance(result, Media):
+            media = result
+        elif isinstance(result, LoaderResult):
+            media = Media(result.buffer)
         else:
-            buffer = result
+            media = Media(result)
 
-        self.watermark_engine.load(buffer, self.extension)
-        self.storage.put(self.url, self.watermark_engine.read())
+        self.watermark_engine.load(media.buffer, self.extension)
+
+        media.buffer = self.watermark_engine.read()
+
+        if self.storage.is_media_aware:
+            self.storage.put(self.url, media)
+        else:
+            self.storage.put(self.url, media.buffer)
+
         self.storage.put_crypto(self.url)
-        self.on_image_ready(buffer)
+
+        self.on_image_ready(media)
 
     @filter_method(BaseFilter.String, r'(?:-?\d+)|center|repeat', r'(?:-?\d+)|center|repeat', BaseFilter.PositiveNumber, async=True)
     @tornado.gen.coroutine
@@ -119,8 +131,15 @@ class Filter(BaseFilter):
         self.watermark_engine = self.context.modules.engine.__class__(self.context)
         self.storage = self.context.modules.storage
 
-        buffer = yield tornado.gen.maybe_future(self.storage.get(self.url))
-        if buffer is not None:
-            self.on_image_ready(buffer)
+        result = yield tornado.gen.maybe_future(self.storage.get(self.url))
+
+        media = None
+        if isinstance(result, Media):
+            media = result
+        elif media is not None:
+            media = Media(buffer)
+
+        if media:
+            self.on_image_ready(media)
         else:
             self.context.modules.loader.load(self.context, self.url, self.on_fetch_done)

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -264,13 +264,13 @@ class BaseHandler(tornado.web.RequestHandler):
         media = Media(context.request.engine.read(image_extension, quality))
 
         if context.request.max_bytes is not None:
-            media = Media(self.reload_to_fit_in_kb(
+            media.buffer = self.reload_to_fit_in_kb(
                 context.request.engine,
                 media.buffer,
                 image_extension,
                 quality,
                 context.request.max_bytes
-            ))
+            )
 
         if not context.request.meta:
             media = self.optimize(context, media)
@@ -278,27 +278,27 @@ class BaseHandler(tornado.web.RequestHandler):
         return media
 
     @gen.coroutine
-    def _process_result_from_storage(self, result):
+    def _process_media_from_storage(self, media):
         if self.context.config.SEND_IF_MODIFIED_LAST_MODIFIED_HEADERS:
             # Handle If-Modified-Since & Last-Modified header
             try:
-                if isinstance(result, ResultStorageResult):
-                    result_last_modified = result.last_modified
+                if media.last_modified:
+                    last_modified = result.last_modified
                 else:
-                    result_last_modified = yield gen.maybe_future(self.context.modules.result_storage.last_updated())
+                    last_modified = yield gen.maybe_future(self.context.modules.result_storage.last_updated())
 
-                if result_last_modified:
+                if last_modified:
                     if 'If-Modified-Since' in self.request.headers:
                         date_modified_since = datetime.datetime.strptime(
                             self.request.headers['If-Modified-Since'], HTTP_DATE_FMT
                         ).replace(tzinfo=pytz.utc)
 
-                        if result_last_modified <= date_modified_since:
+                        if last_modified <= date_modified_since:
                             self.set_status(304)
                             self.finish()
                             return
 
-                    self.set_header('Last-Modified', result_last_modified.strftime(HTTP_DATE_FMT))
+                    self.set_header('Last-Modified', last_modified.strftime(HTTP_DATE_FMT))
             except NotImplementedError:
                 logger.warn('last_updated method is not supported by your result storage service, hence If-Modified-Since & '
                             'Last-Updated headers support is disabled.')
@@ -307,9 +307,6 @@ class BaseHandler(tornado.web.RequestHandler):
     def finish_request(self, context, media_from_storage=None):
         if media_from_storage is not None:
             self._process_result_from_storage(media_from_storage)
-
-            self.define_image_type(context, media_from_storage)
-
             self._write_media_to_client(context, media_from_storage)
             return
 
@@ -344,6 +341,7 @@ class BaseHandler(tornado.web.RequestHandler):
             self.set_header('Cache-Control', 'max-age=' + str(max_age) + ',public')
             self.set_header('Expires', datetime.datetime.utcnow() + datetime.timedelta(seconds=max_age))
 
+        logger.debug('mime {mime}'.format(mime=media.mime))
         self.set_header('Server', 'Thumbor/%s' % __version__)
         self.set_header('Content-Type', media.mime)
 

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -559,9 +559,10 @@ class BaseHandler(tornado.web.RequestHandler):
         filename = 'blacklist.txt'
 
         exists = yield gen.maybe_future(self.context.modules.storage.exists(filename))
+
         if exists:
-            blacklist = yield gen.maybe_future(self.context.modules.storage.get(filename))
-            raise tornado.gen.Return(blacklist)
+            result = yield gen.maybe_future(self.context.modules.storage.get(filename))
+            raise tornado.gen.Return(Media.from_result(result).buffer)
         else:
             raise tornado.gen.Return("")
 

--- a/thumbor/handlers/blacklist.py
+++ b/thumbor/handlers/blacklist.py
@@ -9,6 +9,7 @@
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
 from thumbor.handlers import ContextHandler
+from thumbor.media import Media
 from thumbor.utils import logger
 import tornado
 
@@ -18,17 +19,31 @@ class BlacklistHandler(ContextHandler):
     @tornado.web.asynchronous
     @tornado.gen.coroutine
     def get(self):
-        blacklist = yield self.get_blacklist_contents()
+        result = yield self.get_blacklist_contents()
 
-        self.write(blacklist)
+        blacklist = None
+
+        if isinstance(result, Media):
+            blacklist = result.buffer
+        else:
+            blacklist = result
+
         self.set_header('Content-Type', 'text/plain')
         self.set_status(200)
 
     @tornado.web.asynchronous
     @tornado.gen.coroutine
     def put(self):
-        blacklist = yield self.get_blacklist_contents()
+        result = yield self.get_blacklist_contents()
+
+        blacklist = None
+
+        if isinstance(result, Media):
+            blacklist = result.buffer
+        else:
+            blacklist = result
+
         blacklist += self.request.query + "\n"
         logger.debug('Adding to blacklist: %s' % self.request.query)
-        self.context.modules.storage.put('blacklist.txt', blacklist)
+        self.context.modules.storage.put('blacklist.txt', Media(blacklist))
         self.set_status(200)

--- a/thumbor/handlers/blacklist.py
+++ b/thumbor/handlers/blacklist.py
@@ -19,30 +19,16 @@ class BlacklistHandler(ContextHandler):
     @tornado.web.asynchronous
     @tornado.gen.coroutine
     def get(self):
-        result = yield self.get_blacklist_contents()
-
-        blacklist = None
-
-        if isinstance(result, Media):
-            blacklist = result.buffer
-        else:
-            blacklist = result
+        blacklist = yield self.get_blacklist_contents()
 
         self.set_header('Content-Type', 'text/plain')
         self.set_status(200)
+        self.write(blacklist)
 
     @tornado.web.asynchronous
     @tornado.gen.coroutine
     def put(self):
-        result = yield self.get_blacklist_contents()
-
-        blacklist = None
-
-        if isinstance(result, Media):
-            blacklist = result.buffer
-        else:
-            blacklist = result
-
+        blacklist = yield self.get_blacklist_contents()
         blacklist += self.request.query + "\n"
         logger.debug('Adding to blacklist: %s' % self.request.query)
         self.context.modules.storage.put('blacklist.txt', Media(blacklist))

--- a/thumbor/handlers/image_resource.py
+++ b/thumbor/handlers/image_resource.py
@@ -15,11 +15,12 @@ from thumbor.media import Media
 import tornado.gen as gen
 import tornado.web
 
-##
-# Handler to retrieve or modify existing images
-# This handler support GET, PUT and DELETE method to manipulate existing images
-##
+
 class ImageResourceHandler(ImageApiHandler):
+    """
+    Handler to retrieve or modify existing images
+    This handler support GET, PUT and DELETE method to manipulate existing images
+    """
 
     @gen.coroutine
     def check_resource(self, id):

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -29,7 +29,8 @@ class ImagingHandler(ContextHandler):
     def check_image(self, kw):
         if self.context.config.MAX_ID_LENGTH > 0:
             # Check if an image with an uuid exists in storage
-            exists = yield gen.maybe_future(self.context.modules.storage.exists(kw['image'][:self.context.config.MAX_ID_LENGTH]))
+            exists = yield gen.maybe_future(self.context.modules.storage.exists(
+                    kw['image'][:self.context.config.MAX_ID_LENGTH]))
             if exists:
                 kw['image'] = kw['image'][:self.context.config.MAX_ID_LENGTH]
 

--- a/thumbor/handlers/upload.py
+++ b/thumbor/handlers/upload.py
@@ -13,6 +13,8 @@ import mimetypes
 
 from thumbor.handlers import ImageApiHandler
 from thumbor.engines import BaseEngine
+from thumbor.media import Media
+import tornado
 
 
 ##
@@ -54,7 +56,7 @@ class ImageUploadHandler(ImageApiHandler):
 
             # Build image id based on a random uuid (32 characters)
             image_id = str(uuid.uuid4().hex)
-            self.write_file(image_id, body)
+            self.write_file(image_id, Media(body))
             self.set_status(201)
             self.set_header('Location', self.location(image_id, filename))
 
@@ -67,3 +69,4 @@ class ImageUploadHandler(ImageApiHandler):
     def location(self, image_id, filename):
         base_uri = self.request.uri
         return '%s/%s/%s' % (base_uri, image_id, filename)
+

--- a/thumbor/loaders/__init__.py
+++ b/thumbor/loaders/__init__.py
@@ -8,6 +8,8 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
+import warnings
+
 
 class LoaderResult(object):
 
@@ -15,7 +17,7 @@ class LoaderResult(object):
     ERROR_UPSTREAM = 'upstream'
     ERROR_TIMEOUT = 'timeout'
 
-    def __init__(self, buffer=None, successful=True, error=None, metadata=dict()):
+    def __init__(self, buffer=None, successful=True, error=None, metadata=None):
         '''
         :param buffer: The media buffer
 
@@ -28,8 +30,10 @@ class LoaderResult(object):
         :param metadata: Dictionary of metadata about the buffer
         :type metadata: dict
         '''
-
+        warnings.warn('The LoaderResult class is deprecated. '
+                      'Use the Media class instead.',
+                      DeprecationWarning, stacklevel=2)
         self.buffer = buffer
         self.successful = successful
         self.error = error
-        self.metadata = metadata
+        self.metadata = metadata or dict()

--- a/thumbor/loaders/file_loader.py
+++ b/thumbor/loaders/file_loader.py
@@ -12,6 +12,7 @@ from . import LoaderResult
 from datetime import datetime
 from os import fstat
 from os.path import join, exists, abspath
+from thumbor.media import Media
 from tornado.concurrent import return_future
 
 
@@ -21,22 +22,20 @@ def load(context, path, callback):
     file_path = abspath(file_path)
     inside_root_path = file_path.startswith(context.config.FILE_LOADER_ROOT_PATH)
 
-    result = LoaderResult()
+    media = Media()
 
     if inside_root_path and exists(file_path):
 
         with open(file_path, 'r') as f:
             stats = fstat(f.fileno())
 
-            result.successful = True
-            result.buffer = f.read()
-
-            result.metadata.update(
+            media.buffer = f.read()
+            media.metadata.update(
                 size=stats.st_size,
                 updated_at=datetime.utcfromtimestamp(stats.st_mtime)
             )
     else:
-        result.error = LoaderResult.ERROR_NOT_FOUND
-        result.successful = False
+        media.errors.append(LoaderResult.ERROR_NOT_FOUND)
+        media.is_valid = False
 
-    callback(result)
+    callback(media)

--- a/thumbor/loaders/file_loader.py
+++ b/thumbor/loaders/file_loader.py
@@ -30,9 +30,9 @@ def load(context, path, callback):
             stats = fstat(f.fileno())
 
             media.buffer = f.read()
-            media.metadata.update(
-                updated_at=datetime.utcfromtimestamp(stats.st_mtime)
-            )
+            media.metadata.update({
+                'LastModified': datetime.utcfromtimestamp(stats.st_mtime)
+            })
     else:
         media.errors.append(LoaderResult.ERROR_NOT_FOUND)
 

--- a/thumbor/loaders/file_loader.py
+++ b/thumbor/loaders/file_loader.py
@@ -18,11 +18,21 @@ from tornado.concurrent import return_future
 
 @return_future
 def load(context, path, callback):
+    """
+    Loads an image file from the file system
+    :param context:
+    :type context:
+    :param path: absolute path to the image
+    :type path: basestring
+    :param callback: callback function is called with a Media instance as argument
+    :type callback: function
+    """
     file_path = join(context.config.FILE_LOADER_ROOT_PATH.rstrip('/'), path.lstrip('/'))
     file_path = abspath(file_path)
     inside_root_path = file_path.startswith(context.config.FILE_LOADER_ROOT_PATH)
 
     media = Media()
+    media._info['creator'] = __name__
 
     if inside_root_path and exists(file_path):
 
@@ -31,8 +41,9 @@ def load(context, path, callback):
 
             media.buffer = f.read()
             media.metadata.update({
-                'LastModified': datetime.utcfromtimestamp(stats.st_mtime)
+                'LastModified': datetime.utcfromtimestamp(stats.st_mtime),
             })
+
     else:
         media.errors.append(LoaderResult.ERROR_NOT_FOUND)
 

--- a/thumbor/loaders/file_loader.py
+++ b/thumbor/loaders/file_loader.py
@@ -31,11 +31,9 @@ def load(context, path, callback):
 
             media.buffer = f.read()
             media.metadata.update(
-                size=stats.st_size,
                 updated_at=datetime.utcfromtimestamp(stats.st_mtime)
             )
     else:
         media.errors.append(LoaderResult.ERROR_NOT_FOUND)
-        media.is_valid = False
 
     callback(media)

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -59,13 +59,11 @@ def validate(context, url, normalize_url_func=_normalize_url):
 
 
 def return_contents(response, url, callback, context):
+    context.metrics.incr('original_image.status.' + str(response.code))
 
     media = Media()
 
-    context.metrics.incr('original_image.status.' + str(response.code))
     if response.error:
-        media.is_valid = False
-
         if response.code == 599:
             # Return a Gateway Timeout status downstream if upstream times out
             media.errors.append(LoaderResult.ERROR_TIMEOUT)
@@ -75,7 +73,6 @@ def return_contents(response, url, callback, context):
         logger.warn("ERROR retrieving image {0}: {1}".format(url, str(response.error)))
 
     elif response.body is None or len(response.body) == 0:
-        media.is_valid = False
         media.errors.append(LoaderResult.ERROR_UPSTREAM)
 
         logger.warn("ERROR retrieving image {0}: Empty response.".format(url))

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -16,6 +16,7 @@ from urlparse import urlparse
 import tornado.httpclient
 
 from . import LoaderResult
+from thumbor.media import Media
 from thumbor.utils import logger
 from tornado.concurrent import return_future
 
@@ -58,22 +59,24 @@ def validate(context, url, normalize_url_func=_normalize_url):
 
 
 def return_contents(response, url, callback, context):
-    result = LoaderResult()
+
+    media = Media()
 
     context.metrics.incr('original_image.status.' + str(response.code))
     if response.error:
-        result.successful = False
+        media.is_valid = False
+
         if response.code == 599:
             # Return a Gateway Timeout status downstream if upstream times out
-            result.error = LoaderResult.ERROR_TIMEOUT
+            media.errors.append(LoaderResult.ERROR_TIMEOUT)
         else:
-            result.error = LoaderResult.ERROR_NOT_FOUND
+            media.errors.append(LoaderResult.ERROR_NOT_FOUND)
 
         logger.warn("ERROR retrieving image {0}: {1}".format(url, str(response.error)))
 
     elif response.body is None or len(response.body) == 0:
-        result.successful = False
-        result.error = LoaderResult.ERROR_UPSTREAM
+        media.is_valid = False
+        media.errors.append(LoaderResult.ERROR_UPSTREAM)
 
         logger.warn("ERROR retrieving image {0}: Empty response.".format(url))
     else:
@@ -81,9 +84,10 @@ def return_contents(response, url, callback, context):
             for x in response.time_info:
                 context.metrics.timing('original_image.time_info.' + x, response.time_info[x] * 1000)
             context.metrics.timing('original_image.time_info.bytes_per_second', len(response.body) / response.time_info['total'])
-        result.buffer = response.body
 
-    callback(result)
+        media.buffer = response.body
+
+    callback(media)
 
 
 @return_future
@@ -95,12 +99,14 @@ def load_sync(context, url, callback, normalize_url_func):
     using_proxy = context.config.HTTP_LOADER_PROXY_HOST and context.config.HTTP_LOADER_PROXY_PORT
     if using_proxy or context.config.HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT:
         tornado.httpclient.AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
+
     client = tornado.httpclient.AsyncHTTPClient(max_clients=context.config.HTTP_LOADER_MAX_CLIENTS)
 
     user_agent = None
     if context.config.HTTP_LOADER_FORWARD_USER_AGENT:
         if 'User-Agent' in context.request_handler.request.headers:
             user_agent = context.request_handler.request.headers['User-Agent']
+
     if user_agent is None:
         user_agent = context.config.HTTP_LOADER_DEFAULT_USER_AGENT
 

--- a/thumbor/media.py
+++ b/thumbor/media.py
@@ -1,6 +1,8 @@
 # -*- coding: utf8 -*-
 
 from thumbor.engines import BaseEngine
+from thumbor.loaders import LoaderResult
+from thumbor.result_storages import ResultStorageResult
 
 class Media(object):
     def __init__(self, buffer=None, is_valid=True, metadata={}, errors=[]):
@@ -8,6 +10,30 @@ class Media(object):
         self.metadata = metadata
         self.errors = errors
         self.is_valid = True
+
+    @classmethod
+    def from_result(self, result):
+
+        if isinstance(result, Media):
+            media = result
+        elif isinstance(result, LoaderResult):
+            media = Media(result.buffer, result.successful)
+
+            if not media.is_valid:
+                media.errors.push(result.error)
+
+        elif isinstance(result, ResultStorageResult):
+            media = Media(result.buffer, result.successful)
+
+            if not media.is_valid:
+                media.errors.push(result.error)
+        else:
+            media = Media(result)
+
+        if not media.buffer:
+            media.is_valid = False
+
+        return media
 
     @property
     def content_type(self):

--- a/thumbor/media.py
+++ b/thumbor/media.py
@@ -79,4 +79,7 @@ class Media(object):
         return mime
 
     def __len__(self):
-        return len(self.buffer)
+        if self.is_valid:
+            return len(self.buffer)
+        else:
+            return 0

--- a/thumbor/media.py
+++ b/thumbor/media.py
@@ -5,11 +5,10 @@ from thumbor.result_storages import ResultStorageResult
 from thumbor.utils import logger, EXTENSION
 
 class Media(object):
-    def __init__(self, buffer=None, is_valid=True, metadata={}, errors=[]):
+    def __init__(self, buffer=None, metadata={}, errors=[]):
         self.buffer = buffer
         self.metadata = metadata
         self.errors = errors
-        self.is_valid = True
 
     @classmethod
     def from_result(self, result):
@@ -19,24 +18,25 @@ class Media(object):
         if isinstance(result, Media):
             media = result
 
-        elif isinstance(result, LoaderResult):
-            media = Media(result.buffer, result.successful)
-
-            if not media.is_valid:
-                media.errors.push(result.error)
-
-        elif isinstance(result, ResultStorageResult):
-            media = Media(result.buffer, result.successful)
+        elif isinstance(result, LoaderResult) or isinstance(result, ResultStorageResult):
+            media = Media(result.buffer)
 
             if not media.is_valid:
                 media.errors.push(result.error)
         else:
             media = Media(result)
 
-        if not media.buffer:
-            media.is_valid = False
-
         return media
+
+    @property
+    def is_valid(self):
+        if not self.buffer:
+            return False
+
+        if self.errors:
+            return False
+
+        return True
 
     @property
     def last_modified(self):

--- a/thumbor/media.py
+++ b/thumbor/media.py
@@ -1,48 +1,85 @@
 # -*- coding: utf8 -*-
-
+from __future__ import unicode_literals, absolute_import
 from thumbor.loaders import LoaderResult
-from thumbor.result_storages import ResultStorageResult
 from thumbor.utils import logger, EXTENSION
 
+
 class Media(object):
-    def __init__(self, buffer=None, metadata={}, errors=[]):
+    """
+    This object holds the image and its metadata.
+    """
+    def __init__(self, buffer=None, metadata=None, mimetype=None, errors=None):
+        """
+        Constructor
+        :param buffer: The image buffer. (Also buffer for JSON result)
+        :type buffer: Binary String
+        :param metadata: All metadata for the media file. (Not just EXIF)
+        :type metadata: dict
+        :param mimetype: Mime-Type of the buffer content
+        :type mimetype: String
+        :param errors: List of errors that occured when loading or processing media
+        :type errors: Array of Strings
+        """
         self.buffer = buffer
-        self.metadata = metadata
-        self.errors = errors
+        self.metadata = metadata or {}
+        self.errors = errors or []
+        self._mimetype = mimetype
+        # store debug and tracing information
+        self._info = {
+            'creator': 'unknown',
+            'changed_by': []
+        }
+        self.engine = None  # is this really necessary?
+        self.normalized = False
+        self.successful = False
 
     @classmethod
     def from_result(self, result):
+        """
+        Compatibility Factory. Creates a Media instance from a Result.
+        This should only be necessary for 3rd party storages.
+        :param result: The Result instance
+        :type result: Result
+        :return: Media instance
+        :rtype: Media
+        """
 
-        media = None
-
+        # If this is already a Media instance, pass it on.
         if isinstance(result, Media):
-            media = result
+            return result
 
-        elif isinstance(result, LoaderResult) or isinstance(result, ResultStorageResult):
-            media = Media(result.buffer)
+        elif isinstance(result, LoaderResult):
+            # try to get the mimetype from the Result
+            mime = getattr(result, 'mime', None)
+            media = Media(result.buffer, mimetype=mime)
+            media._info['creator'] = '{}.{}'.format(
+                result.__module__, result.__class__.__name__)
 
             if not media.is_valid:
-                media.errors.push(result.error)
-        else:
-            media = Media(result)
+                media.errors.append(result.error)
+            return media
 
-        return media
+        else:
+            raise AttributeError('Media.from_result should be called with a '
+                                 'Result instance as first argument.')
 
     @property
     def is_valid(self):
-        if not self.buffer:
+        if self.buffer is None:
+            logger.debug('Media objects contains no buffer.')
             return False
 
         if self.errors:
+            logger.debug('Media objects contains errors.')
             return False
 
         return True
 
     @property
     def last_modified(self):
-        '''
+        """
         Retrieves last_updated metadata if available
-        '''
+        """
         return self.metadata.get('LastModified', None)
 
     @property
@@ -51,35 +88,53 @@ class Media(object):
 
     @property
     def mime(self):
-        mime = None
+        if self._mimetype:
+            return self._mimetype
 
+        mime = ''
+
+        if not self.buffer:
+            return mime
         # magic number detection
-        if self.buffer.startswith('GIF8'):
+        if self.buffer.startswith(b'GIF8'):
             mime = 'image/gif'
-        elif self.buffer.startswith('\x89PNG\r\n\x1a\n'):
+        elif self.buffer.startswith(b'\x89PNG\r\n\x1a\n'):
             mime = 'image/png'
-        elif self.buffer.startswith('\xff\xd8'):
+        elif self.buffer.startswith(b'\xff\xd8'):
             mime = 'image/jpeg'
-        elif self.buffer.startswith('WEBP', 8):
+        elif self.buffer.startswith(b'WEBP', 8):
             mime = 'image/webp'
-        elif self.buffer.startswith('\x00\x00\x00\x0c'):
+        elif self.buffer.startswith(b'\x00\x00\x00\x0c'):
             mime = 'image/jp2'
-        elif self.buffer.startswith('\x00\x00\x00 ftyp'):
+        elif self.buffer.startswith(b'\x00\x00\x00 ftyp'):
             mime = 'video/mp4'
-        elif self.buffer.startswith('\x1aE\xdf\xa3'):
+        elif self.buffer.startswith(b'\x1aE\xdf\xa3'):
             mime = 'video/webm'
 
         if not mime:
             logger.debug(
-                '[Media] Unknown mime type for header: {header}'.format(
+                b'[Media] Unknown mime type for header: {header}'.format(
                     header=self.buffer[0:10]
                 )
             )
+        else:
+            self._mimetype = mime
 
         return mime
+
+    @mime.setter
+    def mime(self, value):
+        if self._mimetype is not None and value != self._mimetype:
+            logger.debug('Changed mimetype from {} to {}'
+                         .format(self._mimetype, value))
+        self._mimetype = value
 
     def __len__(self):
         if self.is_valid:
             return len(self.buffer)
         else:
             return 0
+
+    @property
+    def is_image(self):
+        return self.buffer and self.mime and self.mime.startswith('image/')

--- a/thumbor/media.py
+++ b/thumbor/media.py
@@ -1,0 +1,31 @@
+# -*- coding: utf8 -*-
+
+from thumbor.engines import BaseEngine
+
+class Media(object):
+    def __init__(self, buffer=None, is_valid=True, metadata={}, errors=[]):
+        self.buffer = buffer
+        self.metadata = metadata
+        self.errors = errors
+        self.is_valid = True
+
+    @property
+    def content_type(self):
+        return self.metadata.get('ContentType', None)
+
+    @property
+    def last_modified(self):
+        '''
+        Retrieves last_updated metadata if available
+        '''
+        return self.metadata.get('LastModified', None)
+
+    @property
+    def mime(self):
+        '''
+        Retrieves mime metadata if available
+        '''
+        return self.metadata['ContentType'] if 'ContentType' in self.metadata else BaseEngine.get_mimetype(self.buffer)
+
+    def __len__(self):
+        return self.metadata['ContentLength'] if 'ContentLength' in self.metadata else len(self.buffer)

--- a/thumbor/media.py
+++ b/thumbor/media.py
@@ -1,6 +1,5 @@
 # -*- coding: utf8 -*-
 
-from thumbor.engines import BaseEngine
 from thumbor.loaders import LoaderResult
 from thumbor.result_storages import ResultStorageResult
 
@@ -14,8 +13,11 @@ class Media(object):
     @classmethod
     def from_result(self, result):
 
+        media = None
+
         if isinstance(result, Media):
             media = result
+
         elif isinstance(result, LoaderResult):
             media = Media(result.buffer, result.successful)
 
@@ -37,7 +39,7 @@ class Media(object):
 
     @property
     def content_type(self):
-        return self.metadata.get('ContentType', None)
+        return self.mime
 
     @property
     def last_modified(self):
@@ -51,7 +53,7 @@ class Media(object):
         '''
         Retrieves mime metadata if available
         '''
-        return self.metadata['ContentType'] if 'ContentType' in self.metadata else BaseEngine.get_mimetype(self.buffer)
+        return self.metadata.get('ContentType')
 
     def __len__(self):
-        return self.metadata['ContentLength'] if 'ContentLength' in self.metadata else len(self.buffer)
+        return len(self.buffer)

--- a/thumbor/optimizers/__init__.py
+++ b/thumbor/optimizers/__init__.py
@@ -48,9 +48,6 @@ class BaseOptimizer(object):
                 self.optimize(media, ifile.name, ofile.name)
 
                 media.buffer = self._read_output_file(ofile)
-
-                if not media.buffer:
-                    media.is_valid = False
             else:
                 self.optimize(media.buffer, ifile.name, ofile.name)
                 return self._read_output_file(ofile)

--- a/thumbor/optimizers/__init__.py
+++ b/thumbor/optimizers/__init__.py
@@ -29,7 +29,7 @@ class BaseOptimizer(object):
             should_run = self.should_run(media)
         else:
             should_run = self.should_run(
-                media.metadata.get('FileExtension', ''),
+                media.file_extension,
                 media.buffer
             )
 

--- a/thumbor/optimizers/__init__.py
+++ b/thumbor/optimizers/__init__.py
@@ -14,28 +14,52 @@ from tempfile import NamedTemporaryFile
 
 
 class BaseOptimizer(object):
+    is_media_aware = False
+
     def __init__(self, context):
         self.context = context
 
-    def should_run(self, image_extension, buffer):
+    def should_run(self, media_or_image_extension, buffer=None):
         return True
 
-    def run_optimizer(self, image_extension, buffer):
-        if not self.should_run(image_extension, buffer):
-            return buffer
+    def run_optimizer(self, media):
+
+        should_run = True
+        if self.is_media_aware:
+            should_run = self.should_run(media)
+        else:
+            should_run = self.should_run(
+                media.metadata.get('FileExtension', ''),
+                media.buffer
+            )
+
+        if not should_run:
+            return False
 
         ifile = NamedTemporaryFile(delete=False)
         ofile = NamedTemporaryFile(delete=False)
+
         try:
-            ifile.write(buffer)
+            ifile.write(media.buffer)
             ifile.close()
             ofile.close()
 
-            self.optimize(buffer, ifile.name, ofile.name)
+            if self.is_media_aware:
+                self.optimize(media, ifile.name, ofile.name)
 
-            ofile = open(ofile.name, 'rb')  # reopen with file thats been changed with the optimizer
-            return ofile.read()
+                media.buffer = self._read_output_file(ofile)
 
+                if not media.buffer:
+                    media.is_valid = False
+            else:
+                self.optimize(media.buffer, ifile.name, ofile.name)
+                return self._read_output_file(ofile)
         finally:
             os.unlink(ifile.name)
             os.unlink(ofile.name)
+
+    def _read_output_file(self, output_file):
+        buffer = None
+        with open(output_file.name, 'rb') as result_file:
+            buffer = result_file.read()
+        return buffer

--- a/thumbor/optimizers/gifv.py
+++ b/thumbor/optimizers/gifv.py
@@ -12,14 +12,16 @@ import os
 import subprocess
 
 from thumbor.optimizers import BaseOptimizer
-
+from thumbor.utils import logger
 
 class Optimizer(BaseOptimizer):
 
     is_media_aware = True
 
     def should_run(self, media):
-        extension = media.metadata.get('FileExtension', '')
+        extension = media.file_extension
+        logger.debug('gifv extension %s' % extension)
+
         return 'gif' in extension and 'gifv' in self.context.request.filters
 
     def optimize(self, media, input_file, output_file):

--- a/thumbor/optimizers/jpegtran.py
+++ b/thumbor/optimizers/jpegtran.py
@@ -15,10 +15,13 @@ from thumbor.optimizers import BaseOptimizer
 
 class Optimizer(BaseOptimizer):
 
-    def should_run(self, image_extension, buffer):
-        return 'jpg' in image_extension or 'jpeg' in image_extension
+    is_media_aware = True
 
-    def optimize(self, buffer, input_file, output_file):
+    def should_run(self, media):
+        extension = media.metadata.get('FileExtension', '')
+        return 'jpg' in extension or 'jpeg' in extension
+
+    def optimize(self, media, input_file, output_file):
         jpegtran_path = self.context.config.JPEGTRAN_PATH
         command = '%s -copy comments -optimize %s-outfile %s %s ' % (
             jpegtran_path,

--- a/thumbor/result_storages/__init__.py
+++ b/thumbor/result_storages/__init__.py
@@ -47,8 +47,7 @@ class BaseStorage(object):
     def put(self, bytes):
         raise NotImplementedError()
 
-    @return_future
-    def get(self, callback):
+    def get(self):
         raise NotImplementedError()
 
     def last_updated(self):

--- a/thumbor/result_storages/__init__.py
+++ b/thumbor/result_storages/__init__.py
@@ -38,6 +38,9 @@ class ResultStorageResult(LoaderResult):
 
 
 class BaseStorage(object):
+
+    is_media_aware = False
+
     def __init__(self, context):
         self.context = context
 

--- a/thumbor/result_storages/__init__.py
+++ b/thumbor/result_storages/__init__.py
@@ -10,13 +10,16 @@
 
 import os
 from os.path import exists
-from tornado.concurrent import return_future
 
 from thumbor.loaders import LoaderResult
 from thumbor.engines import BaseEngine
 
 
 class ResultStorageResult(LoaderResult):
+
+    def __init__(self, *args, **kwargs):
+        super(ResultStorageResult, self).__init__(*args, **kwargs)
+
     @property
     def last_modified(self):
         '''

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -16,25 +16,28 @@ import pytz
 from os.path import exists, dirname, join, getmtime, abspath
 
 from thumbor.engines import BaseEngine
+from thumbor.media import Media
 from thumbor.result_storages import BaseStorage
 from thumbor.utils import logger, deprecated
 from tornado.concurrent import return_future
 
-from . import ResultStorageResult
-
 
 class Storage(BaseStorage):
+    is_media_aware = True
+
     PATH_FORMAT_VERSION = 'v2'
 
     @property
     def is_auto_webp(self):
         return self.context.config.AUTO_WEBP and self.context.request.accepts_webp
 
-    def put(self, bytes):
+    def put(self, media):
         file_abspath = self.normalize_path(self.context.request.url)
+
         if not self.validate_path(file_abspath):
             logger.warn("[RESULT_STORAGE] unable to write outside root path: %s" % file_abspath)
             return
+
         temp_abspath = "%s.%s" % (file_abspath, str(uuid4()).replace('-', ''))
         file_dir_abspath = dirname(file_abspath)
         logger.debug("[RESULT_STORAGE] putting at %s (%s)" % (file_abspath, file_dir_abspath))
@@ -42,7 +45,7 @@ class Storage(BaseStorage):
         self.ensure_dir(file_dir_abspath)
 
         with open(temp_abspath, 'w') as _file:
-            _file.write(bytes)
+            _file.write(media.buffer)
 
         move(temp_abspath, file_abspath)
 
@@ -50,19 +53,22 @@ class Storage(BaseStorage):
     def get(self, callback):
         path = self.context.request.url
         file_abspath = self.normalize_path(path)
+
         if not self.validate_path(file_abspath):
             logger.warn("[RESULT_STORAGE] unable to read from outside root path: %s" % file_abspath)
-            return None
+            callback(None)
+
         logger.debug("[RESULT_STORAGE] getting from %s" % file_abspath)
 
         if not exists(file_abspath) or self.is_expired(file_abspath):
             logger.debug("[RESULT_STORAGE] image not found at %s" % file_abspath)
             callback(None)
         else:
+            buffer = None
             with open(file_abspath, 'r') as f:
                 buffer = f.read()
 
-            result = ResultStorageResult(
+            result = Media(
                 buffer=buffer,
                 metadata={
                     'LastModified':  datetime.fromtimestamp(getmtime(file_abspath)).replace(tzinfo=pytz.utc),

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -15,7 +15,6 @@ import pytz
 
 from os.path import exists, dirname, join, getmtime, abspath
 
-from thumbor.engines import BaseEngine
 from thumbor.media import Media
 from thumbor.result_storages import BaseStorage
 from thumbor.utils import logger, deprecated
@@ -72,8 +71,6 @@ class Storage(BaseStorage):
                 buffer=buffer,
                 metadata={
                     'LastModified':  datetime.fromtimestamp(getmtime(file_abspath)).replace(tzinfo=pytz.utc),
-                    'ContentLength': len(buffer),
-                    'ContentType':   BaseEngine.get_mimetype(buffer)
                 }
             )
 

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from uuid import uuid4
 from shutil import move
 import pytz
-
+import os
 from os.path import exists, dirname, join, getmtime, abspath
 
 from thumbor.media import Media
@@ -64,16 +64,20 @@ class Storage(BaseStorage):
             callback(None)
         else:
             buffer = None
+            stats = None
+
             with open(file_abspath, 'r') as f:
                 buffer = f.read()
+                stats = os.fstat(f.fileno())
 
             result = Media(
                 buffer=buffer,
                 metadata={
-                    'LastModified':  datetime.fromtimestamp(getmtime(file_abspath)).replace(tzinfo=pytz.utc),
+                    'LastModified': datetime.utcfromtimestamp(stats.st_mtime),
                 }
             )
-
+            result._info['creator'] = '{}.{}'.format(
+                __name__, self.__class__.__name__)
             callback(result)
 
     def validate_path(self, path):

--- a/thumbor/storages/__init__.py
+++ b/thumbor/storages/__init__.py
@@ -14,10 +14,12 @@ from tornado.concurrent import return_future
 
 
 class BaseStorage(object):
+    is_media_aware = False
+
     def __init__(self, context):
         self.context = context
 
-    def put(self, path, bytes):
+    def put(self, path, media):
         '''
         :returns: Nothing. This method is expected to be asynchronous.
         :rtype: None

--- a/thumbor/storages/mixed_storage.py
+++ b/thumbor/storages/mixed_storage.py
@@ -13,6 +13,8 @@ from tornado import gen
 
 
 class Storage(BaseStorage):
+    is_media_aware = True
+
     def __init__(self, context, file_storage=None, crypto_storage=None, detector_storage=None):
         BaseStorage.__init__(self, context)
 

--- a/thumbor/storages/no_storage.py
+++ b/thumbor/storages/no_storage.py
@@ -14,7 +14,9 @@ from tornado.concurrent import return_future
 
 class Storage(BaseStorage):
 
-    def put(self, path, bytes):
+    is_media_aware = False
+
+    def put(self, path, media):
         return path
 
     def put_crypto(self, path):

--- a/thumbor/utils.py
+++ b/thumbor/utils.py
@@ -30,6 +30,8 @@ EXTENSION = {
     'image/webp': '.webp',
     'video/mp4': '.mp4',
     'video/webm': '.webm',
+    'application/json': '.json',
+    'text/javascript': '.js',
 }
 
 

--- a/vows/file_storage_vows.py
+++ b/vows/file_storage_vows.py
@@ -18,6 +18,7 @@ import thumbor.storages.file_storage as Storage
 from thumbor.storages.file_storage import Storage as FileStorage
 from thumbor.context import Context
 from thumbor.config import Config
+from thumbor.media import Media
 from fixtures.storage_fixture import IMAGE_URL, SAME_IMAGE_URL, IMAGE_BYTES, get_server
 
 
@@ -37,7 +38,7 @@ class FileStorageVows(Vows.Context):
         def topic(self):
             config = Config(FILE_STORAGE_ROOT_PATH="/tmp/thumbor/file_storage/")
             storage = FileStorage(Context(config=config, server=get_server('ACME-SEC')))
-            storage.put(IMAGE_URL % 1, IMAGE_BYTES)
+            storage.put(IMAGE_URL % 1, Media(IMAGE_BYTES))
             return storage.get(IMAGE_URL % 1)
 
         def should_be_in_catalog(self, topic):
@@ -56,8 +57,8 @@ class FileStorageVows(Vows.Context):
             try:
                 storage = Storage.Storage(Context(config=config, server=get_server('ACME-SEC')))
 
-                storage.put(SAME_IMAGE_URL % 998, IMAGE_BYTES)
-                storage.put(SAME_IMAGE_URL % 999, IMAGE_BYTES)
+                storage.put(SAME_IMAGE_URL % 998, Media(IMAGE_BYTES))
+                storage.put(SAME_IMAGE_URL % 999, Media(IMAGE_BYTES))
             finally:
                 Storage.storages.exists = old_exists
 
@@ -72,7 +73,7 @@ class FileStorageVows(Vows.Context):
             config = Config(FILE_STORAGE_ROOT_PATH="/tmp/thumbor/file_storage/")
             storage = FileStorage(Context(config=config, server=get_server('ACME-SEC')))
 
-            storage.put(IMAGE_URL % 2, IMAGE_BYTES)
+            storage.put(IMAGE_URL % 2, Media(IMAGE_BYTES))
             return storage.get(IMAGE_URL % 2)
 
         def should_not_be_null(self, topic):
@@ -80,14 +81,14 @@ class FileStorageVows(Vows.Context):
             expect(topic.exception()).not_to_be_an_error()
 
         def should_have_proper_bytes(self, topic):
-            expect(topic.result()).to_equal(IMAGE_BYTES)
+            expect(topic.result().buffer).to_equal(IMAGE_BYTES)
 
     class CannotGetExpiredImage(Vows.Context):
         def topic(self):
             config = Config(FILE_STORAGE_ROOT_PATH="/tmp/thumbor/file_storage/", STORAGE_EXPIRATION_SECONDS=-1)
             storage = FileStorage(Context(config=config, server=get_server('ACME-SEC')))
 
-            storage.put(IMAGE_URL % 2, IMAGE_BYTES)
+            storage.put(IMAGE_URL % 2, Media(IMAGE_BYTES))
             return storage.get(IMAGE_URL % 2)
 
         def should_be_null(self, topic):
@@ -99,7 +100,7 @@ class FileStorageVows(Vows.Context):
             config = Config(FILE_STORAGE_ROOT_PATH="/tmp/thumbor/file_storage/", STORAGE_EXPIRATION_SECONDS=None)
             storage = FileStorage(Context(config=config, server=get_server('ACME-SEC')))
 
-            storage.put(IMAGE_URL % 2, IMAGE_BYTES)
+            storage.put(IMAGE_URL % 2, Media(IMAGE_BYTES))
             return storage.get(IMAGE_URL % 2)
 
         def should_be_null(self, topic):
@@ -113,7 +114,7 @@ class FileStorageVows(Vows.Context):
             def topic(self):
                 config = Config(FILE_STORAGE_ROOT_PATH="/tmp/thumbor/file_storage/", STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True)
                 storage = FileStorage(Context(config=config, server=get_server('')))
-                storage.put(IMAGE_URL % 3, IMAGE_BYTES)
+                storage.put(IMAGE_URL % 3, Media(IMAGE_BYTES))
                 storage.put_crypto(IMAGE_URL % 3)
 
             def should_be_an_error(self, topic):
@@ -135,7 +136,7 @@ class FileStorageVows(Vows.Context):
             def topic(self):
                 config = Config(FILE_STORAGE_ROOT_PATH="/tmp/thumbor/file_storage/")
                 storage = FileStorage(Context(config=config, server=get_server('ACME-SEC')))
-                storage.put(IMAGE_URL % 5, IMAGE_BYTES)
+                storage.put(IMAGE_URL % 5, Media(IMAGE_BYTES))
                 storage.put_crypto(IMAGE_URL % 5)
                 return storage.get_crypto(IMAGE_URL % 5)
 
@@ -147,7 +148,7 @@ class FileStorageVows(Vows.Context):
                 config = Config(FILE_STORAGE_ROOT_PATH="/tmp/thumbor/file_storage/", STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True)
                 storage = FileStorage(Context(config=config, server=get_server('ACME-SEC')))
 
-                storage.put(IMAGE_URL % 6, IMAGE_BYTES)
+                storage.put(IMAGE_URL % 6, Media(IMAGE_BYTES))
                 storage.put_crypto(IMAGE_URL % 6)
                 return storage.get_crypto(IMAGE_URL % 6)
 
@@ -163,7 +164,7 @@ class FileStorageVows(Vows.Context):
             def topic(self):
                 config = Config(FILE_STORAGE_ROOT_PATH="/tmp/thumbor/file_storage/")
                 storage = FileStorage(Context(config=config, server=get_server('ACME-SEC')))
-                storage.put(IMAGE_URL % 7, IMAGE_BYTES)
+                storage.put(IMAGE_URL % 7, Media(IMAGE_BYTES))
                 storage.put_detector_data(IMAGE_URL % 7, 'some-data')
                 return storage.get_detector_data(IMAGE_URL % 7)
 

--- a/vows/result_storages_file_storage_vows.py
+++ b/vows/result_storages_file_storage_vows.py
@@ -60,7 +60,8 @@ class ResultStoragesFileStorageVows(Vows.Context):
     class GetResultStorageResult(Vows.Context):
         @Vows.async_topic
         def topic(self, callback):
-            config = Config(RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=STORAGE_PATH)
+            config = Config(RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=STORAGE_PATH,
+                            STORAGE_EXPIRATION_SECONDS=100)
             context = Context(config=config)
             context.request = RequestParameters(url='image.jpg')
             fs = FileStorage(context)
@@ -70,6 +71,7 @@ class ResultStoragesFileStorageVows(Vows.Context):
             result = topic.args[0]
             expect(result).to_be_instance_of(Media)
             expect(result.is_valid).to_equal(True)
+            expect(isinstance(result.metadata, dict)).to_be_true()
+            expect(result.metadata.get('LastModified')).not_to_be_null()
             expect(len(result)).to_equal(IMAGE_LEN)
-            expect(len(result)).to_equal(result.metadata['ContentLength'])
             expect(result.last_modified).to_be_instance_of(datetime)

--- a/vows/result_storages_file_storage_vows.py
+++ b/vows/result_storages_file_storage_vows.py
@@ -16,7 +16,7 @@ from pyvows import Vows, expect
 
 from thumbor.context import Context, RequestParameters
 from thumbor.config import Config
-from thumbor.result_storages import ResultStorageResult
+from thumbor.media import Media
 from thumbor.result_storages.file_storage import Storage as FileStorage
 
 TEST_HTTP_PATH = 'http://example.com/path/to/a.jpg'
@@ -68,8 +68,8 @@ class ResultStoragesFileStorageVows(Vows.Context):
 
         def check_has_image(self, topic):
             result = topic.args[0]
-            expect(result).to_be_instance_of(ResultStorageResult)
-            expect(result.successful).to_equal(True)
+            expect(result).to_be_instance_of(Media)
+            expect(result.is_valid).to_equal(True)
             expect(len(result)).to_equal(IMAGE_LEN)
             expect(len(result)).to_equal(result.metadata['ContentLength'])
             expect(result.last_modified).to_be_instance_of(datetime)


### PR DESCRIPTION
This is a work in progress on refactoring buffers into a Media object.
- Deprecate `LoaderResult` and `ResultStorageResult` in favour of `Media`
- Pass the `Media` object instead of `buffer` to most `BaseHandler` methods.
- Backward compatible change by introducing `is_media_aware` class property on `storages` and `result_storages`
#### TODO
- [ ] Update optimizers to receive a `Media` object if they support it.
- [ ] Fix borked tests
