### PR TITLE
Media object

### DIFF
--- a/requirements
+++ b/requirements
@@ -1,6 +1,6 @@
+cython
+gifsicle
 libcurl4-openssl-dev
-python-numpy
-python-opencv
 libopencv-dev
 libjpeg-dev
 libpng-dev
@@ -9,11 +9,10 @@ libass-dev
 libvpx1
 libvpx-dev
 libwebp-dev
-webp
-gifsicle
-memcached
 libmemcache-dev
 libmemcached-dev
+memcached
 python-numpy
+python-opencv
 python-scipy
-cython
+webp

--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -23,7 +23,7 @@ from mock import Mock, patch
 from thumbor.config import Config
 from thumbor.importer import Importer
 from thumbor.context import Context, ServerParameters
-from thumbor.handlers import FetchResult, BaseHandler
+from thumbor.handlers import BaseHandler
 from thumbor.storages.file_storage import Storage as FileStorage
 from thumbor.storages.no_storage import Storage as NoStorage
 from thumbor.media import Media
@@ -40,27 +40,19 @@ from tests.fixtures.images import (
 )
 
 
-class FetchResultTestCase(PythonTestCase):
+class MediaTestCase(PythonTestCase):
     def test_can_create_default_fetch_result(self):
-        result = FetchResult()
-        expect(result.normalized).to_be_false()
-        expect(result.media).to_be_null()
-        expect(result.engine).to_be_null()
-        expect(result.successful).to_be_false()
+        media = Media()
+        expect(media.normalized).to_be_false()
+        expect(media.buffer).to_be_null()
+        expect(media.engine).to_be_null()
+        expect(media.successful).to_be_false()
 
-    def test_can_create_fetch_result(self):
+    def test_can_create_media_object(self):
         buffer_mock = Mock()
-        engine_mock = Mock()
-        result = FetchResult(
-            normalized=True,
-            media=Media(buffer_mock),
-            engine=engine_mock,
-            successful=True
-        )
-        expect(result.normalized).to_be_true()
-        expect(result.media.buffer).to_equal(buffer_mock)
-        expect(result.engine).to_equal(engine_mock)
-        expect(result.successful).to_be_true()
+        result = Media(buffer_mock)
+        expect(result.buffer).to_equal(buffer_mock)
+        expect(result.is_valid).to_be_true()
 
 
 class ErrorHandler(BaseHandler):

--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -39,22 +39,6 @@ from tests.fixtures.images import (
     not_so_animated_image,
 )
 
-
-class MediaTestCase(PythonTestCase):
-    def test_can_create_default_fetch_result(self):
-        media = Media()
-        expect(media.normalized).to_be_false()
-        expect(media.buffer).to_be_null()
-        expect(media.engine).to_be_null()
-        expect(media.successful).to_be_false()
-
-    def test_can_create_media_object(self):
-        buffer_mock = Mock()
-        result = Media(buffer_mock)
-        expect(result.buffer).to_equal(buffer_mock)
-        expect(result.is_valid).to_be_true()
-
-
 class ErrorHandler(BaseHandler):
     def get(self):
         self._error(403)

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+from __future__ import unicode_literals,absolute_import
+from unittest import TestCase
+import hashlib
+import copy
+import mock
+
+from preggy import expect
+
+from thumbor.media import Media
+from thumbor.result_storages import ResultStorageResult
+
+
+class MediaTestCase(TestCase):
+    def setUp(self, *args, **kwargs):
+        super(MediaTestCase, self).setUp(*args, **kwargs)
+        self.buffer_mock = b''
+
+
+    def test_can_create_empty_media_object(self):
+        media = Media()
+        expect(media.normalized).to_be_false()
+        expect(media.buffer).to_be_null()
+        expect(media.engine).to_be_null()
+        expect(media.successful).to_be_false()
+
+    def test_can_create_media_object(self):
+        result = Media(self.buffer_mock)
+        expect(result.buffer).to_equal(self.buffer_mock)
+        expect(result.is_valid).to_be_true()
+
+    def test_can_create_media_from_result(self):
+        loader_result = ResultStorageResult(buffer=self.buffer_mock)
+        loader_result.metadata['ContentType'] = 'image/gif'
+        media = Media.from_result(loader_result)
+        expect(media.buffer).to_equal(self.buffer_mock)
+        expect(media.mime).to_equal('image/gif')
+
+    def test_can_create_media_from_unknown_result(self):
+        loader_result = ResultStorageResult(buffer=self.buffer_mock)
+        media = Media.from_result(loader_result)
+        expect(media.buffer).to_equal(self.buffer_mock)
+        expect(media.mime).to_equal('')
+
+        # Try a valid buffer
+        loader_result = ResultStorageResult(buffer=b'\x00\x00\x00\x0ctest')
+        media = Media.from_result(loader_result)
+        expect(media.mime).to_equal('image/jp2')
+
+

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -252,7 +252,7 @@ class BaseHandler(tornado.web.RequestHandler):
             context.request.meta_callback = context.config.META_CALLBACK_NAME \
                     or self.request.arguments.get('callback', [None])[0]
 
-        logger.debug('Metadata requested. Serving content type of %s.'
+            logger.debug('Metadata requested. Serving content type of %s.'
                      % content_type)
 
         if content_type:
@@ -496,7 +496,6 @@ class BaseHandler(tornado.web.RequestHandler):
             storage_result = yield gen.maybe_future(storage.get(url))
 
             if storage_result is not None:
-                self.release_url_lock(url)
 
                 media = Media.from_result(storage_result)
 
@@ -517,7 +516,6 @@ class BaseHandler(tornado.web.RequestHandler):
             else:  # storage_result is None
                 self.context.metrics.incr('storage.miss')
 
-            # FIXME: Diese Zeile knallt noch.
             loader_result = yield self.context.modules.loader.load(self.context, url)
             media = Media.from_result(loader_result)
 

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -237,6 +237,9 @@ class BaseHandler(tornado.web.RequestHandler):
             elif self.is_webp(context):
                 image_extension = '.webp'
                 logger.debug('Image format set by AUTO_WEBP as %s.' % image_extension)
+            else:
+                image_extension = context.request.extension
+                logger.debug('No image format specified. Retrieving from the image extension: %s.' % image_extension)
 
             content_type = CONTENT_TYPE.get(image_extension, CONTENT_TYPE['.jpg'])
 
@@ -272,7 +275,7 @@ class BaseHandler(tornado.web.RequestHandler):
 
         try:
             result = context.request.engine.read(image_extension, quality)
-            media = Media.from_result(result)
+            media = Media.from_result(result, content_type)
         except Exception as e:
             logger.error(e)
             self._error(500)

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -111,7 +111,6 @@ class BaseHandler(tornado.web.RequestHandler):
 
     @gen.coroutine  # NOQA
     def get_image(self):
-        media = 'Hallo'
 
         try:
             media = yield self._fetch(

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -13,6 +13,7 @@ import functools
 import datetime
 import pytz
 import traceback
+import warnings
 
 import tornado.web
 import tornado.gen as gen
@@ -35,8 +36,10 @@ HTTP_DATE_FMT = "%a, %d %b %Y %H:%M:%S GMT"
 
 
 class FetchResult(object):
-
     def __init__(self, normalized=False, media=None, engine=None, successful=False):
+        warnings.warn('The FetchResult class is deprecated. '
+                      'Use the Media class instead.',
+                      DeprecationWarning, stacklevel=2)
         self.normalized = normalized
         self.engine = engine
         self.media = media
@@ -70,27 +73,29 @@ class BaseHandler(tornado.web.RequestHandler):
 
             self.context.metrics.timing('result_storage.incoming_time', (finish - start).total_seconds() * 1000)
 
-            media = Media.from_result(result)
+            if result is not None:
+                media = Media.from_result(result)
 
-            if media.is_valid:
-                self.context.metrics.incr('result_storage.hit')
-                self.context.metrics.incr('result_storage.bytes_read', len(result))
+                if media.is_valid:
+                    self.context.metrics.incr('result_storage.hit')
+                    self.context.metrics.incr('result_storage.bytes_read', len(result))
 
-                if media.mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
-                    self.context.request.engine = self.context.modules.gif_engine
-                else:
-                    self.context.request.engine = self.context.modules.engine
+                    if media.mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
+                        self.context.request.engine = self.context.modules.gif_engine
+                    else:
+                        self.context.request.engine = self.context.modules.engine
 
-                self.context.request.engine.load(media.buffer, media.file_extension)
+                    if media.is_image:
+                        self.context.request.engine.load(media.buffer, media.file_extension)
 
-                logger.debug('[RESULT_STORAGE] image found: {url} {extension} {mime}'.format(
-                    url=req.url,
-                    extension=media.file_extension,
-                    mime=media.mime
-                ))
+                    logger.debug('[RESULT_STORAGE] image found: {url} {extension} {mime}'.format(
+                        url=req.url,
+                        extension=media.file_extension,
+                        mime=media.mime
+                    ))
 
-                self.finish_request(self.context, media)
-                return
+                    self.finish_request(self.context, media)
+                    return
             else:
                 self.context.metrics.incr('result_storage.miss')
 
@@ -106,10 +111,10 @@ class BaseHandler(tornado.web.RequestHandler):
 
     @gen.coroutine  # NOQA
     def get_image(self):
-        fetch_result = None
+        media = 'Hallo'
 
         try:
-            fetch_result = yield self._fetch(
+            media = yield self._fetch(
                 self.context.request.image_url
             )
         except Exception as e:
@@ -128,25 +133,25 @@ class BaseHandler(tornado.web.RequestHandler):
                 self._error(500)
             return
 
-        if not fetch_result.media.is_valid:
-            if LoaderResult.ERROR_NOT_FOUND in fetch_result.media.errors:
+        if not media.is_valid:
+            if LoaderResult.ERROR_NOT_FOUND in media.errors:
                 self._error(404)
                 return
-            elif LoaderResult.ERROR_UPSTREAM in fetch_result.media.errors:
+            elif LoaderResult.ERROR_UPSTREAM in media.errors:
                 # Return a Bad Gateway status if the error came from upstream
                 self._error(502)
                 return
-            elif LoaderResult.ERROR_TIMEOUT in fetch_result.media.errors:
+            elif LoaderResult.ERROR_TIMEOUT in media.errors:
                 # Return a Gateway Timeout status if upstream timed out (i.e. 599)
                 self._error(504)
                 return
             else:
+                logger.error('[BaseHandler] Media is invalid')
                 self._error(500)
                 return
 
-        normalized = fetch_result.normalized
-        media = fetch_result.media
-        engine = fetch_result.engine
+        normalized = media.normalized
+        engine = media.engine
         req = self.context.request
 
         if engine is None:
@@ -154,6 +159,7 @@ class BaseHandler(tornado.web.RequestHandler):
                 self._error(504)
                 return
 
+            # TODO: Maybe this is sufficient (it is at least redundant)
             engine = self.context.request.engine
 
             try:
@@ -244,12 +250,15 @@ class BaseHandler(tornado.web.RequestHandler):
             content_type = CONTENT_TYPE.get(image_extension, CONTENT_TYPE['.jpg'])
 
         if context.request.meta:
-            context.request.meta_callback = context.config.META_CALLBACK_NAME or self.request.arguments.get('callback', [None])[0]
-            content_type = 'text/javascript' if context.request.meta_callback else 'application/json'
-            logger.debug('Metadata requested. Serving content type of %s.' % content_type)
+            context.request.meta_callback = context.config.META_CALLBACK_NAME \
+                    or self.request.arguments.get('callback', [None])[0]
+
+        logger.debug('Metadata requested. Serving content type of %s.'
+                     % content_type)
 
         if content_type:
-            logger.debug('Content Type of {mime} detected with extension {extension}.'.format(
+            logger.debug('Content Type of {mime} detected '
+                         'with extension {extension}.'.format(
                 mime=content_type,
                 extension=image_extension
             ))
@@ -261,13 +270,11 @@ class BaseHandler(tornado.web.RequestHandler):
 
         quality = self.context.request.quality
         if quality is None:
-            if image_extension == '.webp' and self.context.config.WEBP_QUALITY is not None:
+            if image_extension == '.webp' and \
+                            self.context.config.WEBP_QUALITY is not None:
                 quality = self.context.config.get('WEBP_QUALITY')
             else:
                 quality = self.context.config.QUALITY
-
-
-        media = None
 
         logger.debug('Reading image as {extension}'.format(
             extension=image_extension
@@ -275,9 +282,10 @@ class BaseHandler(tornado.web.RequestHandler):
 
         try:
             result = context.request.engine.read(image_extension, quality)
-            media = Media.from_result(result, content_type)
+            media = Media(result, mimetype=content_type)
         except Exception as e:
-            logger.error(e)
+            # logger.error(e)
+            logger.exception('BaseHandler:_load_media failed:')
             self._error(500)
             return
 
@@ -303,7 +311,8 @@ class BaseHandler(tornado.web.RequestHandler):
                 if media.last_modified:
                     last_modified = media.last_modified
                 else:
-                    last_modified = yield gen.maybe_future(self.context.modules.result_storage.last_updated())
+                    last_modified = yield gen.maybe_future(
+                            self.context.modules.result_storage.last_updated())
 
                 if last_modified:
                     if 'If-Modified-Since' in self.request.headers:
@@ -355,6 +364,10 @@ class BaseHandler(tornado.web.RequestHandler):
 
         if context.request.prevent_result_storage or context.request.detection_error:
             max_age = context.config.MAX_AGE_TEMP_IMAGE
+
+        if context.request.meta:
+            media.mime = 'text/javascript' if getattr(
+                    context.request, 'meta_callback', None) else 'application/json'
 
         if max_age:
             self.set_header('Cache-Control', 'max-age=' + str(max_age) + ',public')
@@ -475,7 +488,6 @@ class BaseHandler(tornado.web.RequestHandler):
 
     @gen.coroutine
     def _fetch(self, url):
-        fetch_result = FetchResult()
 
         storage = self.context.modules.storage
 
@@ -484,53 +496,57 @@ class BaseHandler(tornado.web.RequestHandler):
         try:
             storage_result = yield gen.maybe_future(storage.get(url))
 
-            fetch_result.media = Media.from_result(storage_result)
+            if storage_result is not None:
+                self.release_url_lock(url)
 
-            if fetch_result.media.is_valid:
-                self.context.metrics.incr('storage.hit')
-                self.context.metrics.incr('storage.bytes_read', len(fetch_result.media))
+                media = Media.from_result(storage_result)
 
-                fetch_result.successful = True
+                if media.is_valid:
+                    self.context.metrics.incr('storage.hit')
+                    self.context.metrics.incr('storage.bytes_read', len(media))
 
-                if fetch_result.media.mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
-                    self.context.request.engine = self.context.modules.gif_engine
-                else:
-                    self.context.request.engine = self.context.modules.engine
+                    media.successful = True
 
-                self.context.request.extension = fetch_result.media.file_extension
+                    if media.mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
+                        self.context.request.engine = self.context.modules.gif_engine
+                    else:
+                        self.context.request.engine = self.context.modules.engine
 
-                raise gen.Return(fetch_result)
-            else:
+                    self.context.request.extension = media.file_extension
+
+                raise gen.Return(media)
+            else:  # storage_result is None
                 self.context.metrics.incr('storage.miss')
 
-                loader_result = yield self.context.modules.loader.load(self.context, url)
-                fetch_result.media = Media.from_result(loader_result)
+            # FIXME: Diese Zeile knallt noch.
+            loader_result = yield self.context.modules.loader.load(self.context, url)
+            media = Media.from_result(loader_result)
 
-                self.context.metrics.incr('loader.hit')
         finally:
             self.release_url_lock(url)
 
-        if not fetch_result.media.is_valid:
-            fetch_result.successful = False
-            raise gen.Return(fetch_result)
+        self.context.metrics.incr('loader.hit')
+        if isinstance(media, Media) and not media.is_valid:
+            media.successful = False
+            raise gen.Return(media)
 
-        fetch_result.successful = True
+        media.successful = True
 
         original_preserve = self.context.config.PRESERVE_EXIF_INFO
         self.context.config.PRESERVE_EXIF_INFO = True
 
-        if fetch_result.media.mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
+        if media.mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
             self.context.request.engine = self.context.modules.gif_engine
         else:
             self.context.request.engine = self.context.modules.engine
 
-        self.context.request.extension = fetch_result.media.file_extension
+        self.context.request.extension = media.file_extension
 
         try:
             logger.debug('527 engine load called')
-            self.context.request.engine.load(fetch_result.media.buffer, fetch_result.media.file_extension)
+            self.context.request.engine.load(media.buffer, media.file_extension)
 
-            fetch_result.normalized = self.context.request.engine.normalize()
+            media.normalized = self.context.request.engine.normalize()
 
             # Allows engine or loader to override storage on the fly for the purpose of
             # marking a specific file as unstoreable
@@ -541,24 +557,24 @@ class BaseHandler(tornado.web.RequestHandler):
             is_mixed_no_file_storage = is_mixed_storage and isinstance(storage.file_storage, NoStorage)
 
             if not (is_no_storage or is_mixed_no_file_storage):
-                fetch_result.media.buffer = self.context.request.engine.read(fetch_result.media.file_extension)
+                media.buffer = self.context.request.engine.read(media.file_extension)
 
                 if storage.is_media_aware:
-                    storage.put(url, fetch_result.media)
+                    storage.put(url, media)
                 else:
-                    storage.put(url, fetch_result.media.buffer)
+                    storage.put(url, media.buffer)
 
             storage.put_crypto(url)
-        except Exception as e:
-            logger.error(e)
+        except Exception:
+            logger.exception('Fetch failed:')
             self._error(500)
             return
         finally:
             self.context.config.PRESERVE_EXIF_INFO = original_preserve
 
-        fetch_result.engine = self.context.request.engine
+        media.engine = self.context.request.engine
 
-        raise gen.Return(fetch_result)
+        raise gen.Return(media)
 
     @gen.coroutine
     def get_blacklist_contents(self):
@@ -574,7 +590,7 @@ class BaseHandler(tornado.web.RequestHandler):
 
     @gen.coroutine
     def acquire_url_lock(self, url):
-        if not url in BaseHandler.url_locks:
+        if url not in BaseHandler.url_locks:
             BaseHandler.url_locks[url] = Condition()
         else:
             yield BaseHandler.url_locks[url].wait()
@@ -588,6 +604,7 @@ class BaseHandler(tornado.web.RequestHandler):
 
 
 class ContextHandler(BaseHandler):
+
     def initialize(self, context):
         self.context = Context(
             server=context.server,
@@ -612,10 +629,10 @@ class ContextHandler(BaseHandler):
             logger.error('ERROR: %s' % "".join(msg))
 
 
-##
-# Base handler for Image API operations
-##
 class ImageApiHandler(ContextHandler):
+    """
+    Base handler for Image API operations
+    """
 
     def validate(self, body):
         conf = self.context.config

--- a/thumbor/handlers/image_resource.py
+++ b/thumbor/handlers/image_resource.py
@@ -15,11 +15,12 @@ from thumbor.media import Media
 import tornado.gen as gen
 import tornado.web
 
-##
-# Handler to retrieve or modify existing images
-# This handler support GET, PUT and DELETE method to manipulate existing images
-##
+
 class ImageResourceHandler(ImageApiHandler):
+    """
+    Handler to retrieve or modify existing images
+    This handler support GET, PUT and DELETE method to manipulate existing images
+    """
 
     @gen.coroutine
     def check_resource(self, id):

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -29,7 +29,8 @@ class ImagingHandler(ContextHandler):
     def check_image(self, kw):
         if self.context.config.MAX_ID_LENGTH > 0:
             # Check if an image with an uuid exists in storage
-            exists = yield gen.maybe_future(self.context.modules.storage.exists(kw['image'][:self.context.config.MAX_ID_LENGTH]))
+            exists = yield gen.maybe_future(self.context.modules.storage.exists(
+                    kw['image'][:self.context.config.MAX_ID_LENGTH]))
             if exists:
                 kw['image'] = kw['image'][:self.context.config.MAX_ID_LENGTH]
 

--- a/thumbor/loaders/__init__.py
+++ b/thumbor/loaders/__init__.py
@@ -8,6 +8,8 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com timehome@corp.globo.com
 
+import warnings
+
 
 class LoaderResult(object):
 
@@ -15,7 +17,7 @@ class LoaderResult(object):
     ERROR_UPSTREAM = 'upstream'
     ERROR_TIMEOUT = 'timeout'
 
-    def __init__(self, buffer=None, successful=True, error=None, metadata=dict()):
+    def __init__(self, buffer=None, successful=True, error=None, metadata=None):
         '''
         :param buffer: The media buffer
 
@@ -28,8 +30,10 @@ class LoaderResult(object):
         :param metadata: Dictionary of metadata about the buffer
         :type metadata: dict
         '''
-
+        warnings.warn('The LoaderResult class is deprecated. '
+                      'Use the Media class instead.',
+                      DeprecationWarning, stacklevel=2)
         self.buffer = buffer
         self.successful = successful
         self.error = error
-        self.metadata = metadata
+        self.metadata = metadata or dict()

--- a/thumbor/loaders/file_loader.py
+++ b/thumbor/loaders/file_loader.py
@@ -42,7 +42,6 @@ def load(context, path, callback):
             media.buffer = f.read()
             media.metadata.update({
                 'LastModified': datetime.utcfromtimestamp(stats.st_mtime),
-                'ContentLength': stats.st_size
             })
 
     else:

--- a/thumbor/loaders/file_loader.py
+++ b/thumbor/loaders/file_loader.py
@@ -18,11 +18,21 @@ from tornado.concurrent import return_future
 
 @return_future
 def load(context, path, callback):
+    """
+    Loads an image file from the file system
+    :param context:
+    :type context:
+    :param path: absolute path to the image
+    :type path: basestring
+    :param callback: callback function is called with a Media instance as argument
+    :type callback: function
+    """
     file_path = join(context.config.FILE_LOADER_ROOT_PATH.rstrip('/'), path.lstrip('/'))
     file_path = abspath(file_path)
     inside_root_path = file_path.startswith(context.config.FILE_LOADER_ROOT_PATH)
 
     media = Media()
+    media._info['creator'] = __name__
 
     if inside_root_path and exists(file_path):
 
@@ -31,8 +41,10 @@ def load(context, path, callback):
 
             media.buffer = f.read()
             media.metadata.update({
-                'LastModified': datetime.utcfromtimestamp(stats.st_mtime)
+                'LastModified': datetime.utcfromtimestamp(stats.st_mtime),
+                'ContentLength': stats.st_size
             })
+
     else:
         media.errors.append(LoaderResult.ERROR_NOT_FOUND)
 

--- a/thumbor/media.py
+++ b/thumbor/media.py
@@ -50,7 +50,7 @@ class Media(object):
 
         elif isinstance(result, LoaderResult):
             # try to get the mimetype from the Result
-            mime = result.get('mime')
+            mime = getattr(result, 'mime', None)
             media = Media(result.buffer, mimetype=mime)
             media._info['creator'] = '{}.{}'.format(
                 result.__module__, result.__class__.__name__)

--- a/thumbor/media.py
+++ b/thumbor/media.py
@@ -5,14 +5,17 @@ from thumbor.result_storages import ResultStorageResult
 from thumbor.utils import logger, EXTENSION
 
 class Media(object):
-    def __init__(self, buffer=None, metadata=None, errors=None):
+    """
+    This object holds the image and its meta data.
+    """
+    def __init__(self, buffer=None, metadata=None, mimetype=None, errors=None):
         self.buffer = buffer
         self.metadata = metadata or {}
         self.errors = errors or []
+        self._mimetype = mimetype
 
     @classmethod
-    def from_result(self, result):
-
+    def from_result(self, result, mimetype=None):
         media = None
 
         if isinstance(result, Media):
@@ -24,7 +27,7 @@ class Media(object):
             if not media.is_valid:
                 media.errors.append(result.error)
         else:
-            media = Media(result)
+            media = Media(result, mimetype=mimetype)
 
         return media
 
@@ -51,6 +54,8 @@ class Media(object):
 
     @property
     def mime(self):
+        if self._mimetype:
+            return self._mimetype
         mime = None
 
         # magic number detection
@@ -75,6 +80,8 @@ class Media(object):
                     header=self.buffer[0:10]
                 )
             )
+        else:
+            self._mimetype = mime
 
         return mime
 

--- a/thumbor/media.py
+++ b/thumbor/media.py
@@ -5,10 +5,10 @@ from thumbor.result_storages import ResultStorageResult
 from thumbor.utils import logger, EXTENSION
 
 class Media(object):
-    def __init__(self, buffer=None, metadata={}, errors=[]):
+    def __init__(self, buffer=None, metadata=None, errors=None):
         self.buffer = buffer
-        self.metadata = metadata
-        self.errors = errors
+        self.metadata = metadata or {}
+        self.errors = errors or []
 
     @classmethod
     def from_result(self, result):
@@ -22,7 +22,7 @@ class Media(object):
             media = Media(result.buffer)
 
             if not media.is_valid:
-                media.errors.push(result.error)
+                media.errors.append(result.error)
         else:
             media = Media(result)
 

--- a/thumbor/media.py
+++ b/thumbor/media.py
@@ -1,51 +1,85 @@
 # -*- coding: utf8 -*-
-
+from __future__ import unicode_literals, absolute_import
 from thumbor.loaders import LoaderResult
-from thumbor.result_storages import ResultStorageResult
 from thumbor.utils import logger, EXTENSION
+
 
 class Media(object):
     """
-    This object holds the image and its meta data.
+    This object holds the image and its metadata.
     """
     def __init__(self, buffer=None, metadata=None, mimetype=None, errors=None):
+        """
+        Constructor
+        :param buffer: The image buffer. (Also buffer for JSON result)
+        :type buffer: Binary String
+        :param metadata: All metadata for the media file. (Not just EXIF)
+        :type metadata: dict
+        :param mimetype: Mime-Type of the buffer content
+        :type mimetype: String
+        :param errors: List of errors that occured when loading or processing media
+        :type errors: Array of Strings
+        """
         self.buffer = buffer
         self.metadata = metadata or {}
         self.errors = errors or []
         self._mimetype = mimetype
+        # store debug and tracing information
+        self._info = {
+            'creator': 'unknown',
+            'changed_by': []
+        }
+        self.engine = None  # is this really necessary?
+        self.normalized = False
+        self.successful = False
 
     @classmethod
-    def from_result(self, result, mimetype=None):
-        media = None
+    def from_result(self, result):
+        """
+        Compatibility Factory. Creates a Media instance from a Result.
+        This should only be necessary for 3rd party storages.
+        :param result: The Result instance
+        :type result: Result
+        :return: Media instance
+        :rtype: Media
+        """
 
+        # If this is already a Media instance, pass it on.
         if isinstance(result, Media):
-            media = result
+            return result
 
-        elif isinstance(result, LoaderResult) or isinstance(result, ResultStorageResult):
-            media = Media(result.buffer)
+        elif isinstance(result, LoaderResult):
+            # try to get the mimetype from the Result
+            mime = result.get('mime')
+            media = Media(result.buffer, mimetype=mime)
+            media._info['creator'] = '{}.{}'.format(
+                result.__module__, result.__class__.__name__)
 
             if not media.is_valid:
                 media.errors.append(result.error)
-        else:
-            media = Media(result, mimetype=mimetype)
+            return media
 
-        return media
+        else:
+            raise AttributeError('Media.from_result should be called with a '
+                                 'Result instance as first argument.')
 
     @property
     def is_valid(self):
-        if not self.buffer:
+        if self.buffer is None:
+            logger.debug('Media objects contains no buffer.')
             return False
 
         if self.errors:
+            logger.debug('Media objects contains errors.')
             return False
 
         return True
 
     @property
     def last_modified(self):
-        '''
+        """
         Retrieves last_updated metadata if available
-        '''
+        """
         return self.metadata.get('LastModified', None)
 
     @property
@@ -56,27 +90,30 @@ class Media(object):
     def mime(self):
         if self._mimetype:
             return self._mimetype
-        mime = None
 
+        mime = ''
+
+        if not self.buffer:
+            return mime
         # magic number detection
-        if self.buffer.startswith('GIF8'):
+        if self.buffer.startswith(b'GIF8'):
             mime = 'image/gif'
-        elif self.buffer.startswith('\x89PNG\r\n\x1a\n'):
+        elif self.buffer.startswith(b'\x89PNG\r\n\x1a\n'):
             mime = 'image/png'
-        elif self.buffer.startswith('\xff\xd8'):
+        elif self.buffer.startswith(b'\xff\xd8'):
             mime = 'image/jpeg'
-        elif self.buffer.startswith('WEBP', 8):
+        elif self.buffer.startswith(b'WEBP', 8):
             mime = 'image/webp'
-        elif self.buffer.startswith('\x00\x00\x00\x0c'):
+        elif self.buffer.startswith(b'\x00\x00\x00\x0c'):
             mime = 'image/jp2'
-        elif self.buffer.startswith('\x00\x00\x00 ftyp'):
+        elif self.buffer.startswith(b'\x00\x00\x00 ftyp'):
             mime = 'video/mp4'
-        elif self.buffer.startswith('\x1aE\xdf\xa3'):
+        elif self.buffer.startswith(b'\x1aE\xdf\xa3'):
             mime = 'video/webm'
 
         if not mime:
             logger.debug(
-                '[Media] Unknown mime type for header: {header}'.format(
+                b'[Media] Unknown mime type for header: {header}'.format(
                     header=self.buffer[0:10]
                 )
             )
@@ -85,8 +122,19 @@ class Media(object):
 
         return mime
 
+    @mime.setter
+    def mime(self, value):
+        if self._mimetype is not None and value != self._mimetype:
+            logger.debug('Changed mimetype from {} to {}'
+                         .format(self._mimetype, value))
+        self._mimetype = value
+
     def __len__(self):
         if self.is_valid:
             return len(self.buffer)
         else:
             return 0
+
+    @property
+    def is_image(self):
+        return self.buffer and self.mime and self.mime.startswith('image/')

--- a/thumbor/result_storages/__init__.py
+++ b/thumbor/result_storages/__init__.py
@@ -10,13 +10,16 @@
 
 import os
 from os.path import exists
-from tornado.concurrent import return_future
 
 from thumbor.loaders import LoaderResult
 from thumbor.engines import BaseEngine
 
 
 class ResultStorageResult(LoaderResult):
+
+    def __init__(self, *args, **kwargs):
+        super(LoaderResult, self).__init__(*args, **kwargs)
+
     @property
     def last_modified(self):
         '''

--- a/thumbor/result_storages/__init__.py
+++ b/thumbor/result_storages/__init__.py
@@ -18,7 +18,7 @@ from thumbor.engines import BaseEngine
 class ResultStorageResult(LoaderResult):
 
     def __init__(self, *args, **kwargs):
-        super(LoaderResult, self).__init__(*args, **kwargs)
+        super(ResultStorageResult, self).__init__(*args, **kwargs)
 
     @property
     def last_modified(self):

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -74,7 +74,6 @@ class Storage(BaseStorage):
                 buffer=buffer,
                 metadata={
                     'LastModified': datetime.utcfromtimestamp(stats.st_mtime),
-                    'ContentLength': stats.st_size,  # TODO: Remove, redundant
                 }
             )
             result._info['creator'] = '{}.{}'.format(

--- a/thumbor/storages/file_storage.py
+++ b/thumbor/storages/file_storage.py
@@ -87,12 +87,21 @@ class Storage(storages.BaseStorage):
 
         def file_exists(resource_available):
             if not resource_available:
+                logger.debug('Resource {} not available.'.format(abs_path))
                 callback(None)
             else:
                 media = Media()
 
                 with open(self.path_on_filesystem(path), 'r') as _file:
+                    stats = os.fstat(_file.fileno())
                     media.buffer = _file.read()
+
+                    media.metadata.update({
+                        'LastModified': datetime.utcfromtimestamp(stats.st_mtime),
+                        'ContentLength': stats.st_size,  # TODO: Remove, calculate
+                    })
+                media._info['creator'] = '{}.{}'.format(
+                        __name__, self.__class__.__name__)
 
                 callback(media)
 
@@ -133,7 +142,9 @@ class Storage(storages.BaseStorage):
     def exists(self, path, callback, path_on_filesystem=None):
         if path_on_filesystem is None:
             path_on_filesystem = self.path_on_filesystem(path)
-        callback(os.path.exists(path_on_filesystem) and not self.__is_expired(path_on_filesystem))
+
+        callback(os.path.exists(path_on_filesystem) and
+                 not self.__is_expired(path_on_filesystem))
 
     def remove(self, path):
         n_path = self.path_on_filesystem(path)

--- a/thumbor/storages/file_storage.py
+++ b/thumbor/storages/file_storage.py
@@ -98,7 +98,6 @@ class Storage(storages.BaseStorage):
 
                     media.metadata.update({
                         'LastModified': datetime.utcfromtimestamp(stats.st_mtime),
-                        'ContentLength': stats.st_size,  # TODO: Remove, calculate
                     })
                 media._info['creator'] = '{}.{}'.format(
                         __name__, self.__class__.__name__)

--- a/thumbor/utils.py
+++ b/thumbor/utils.py
@@ -30,6 +30,8 @@ EXTENSION = {
     'image/webp': '.webp',
     'video/mp4': '.mp4',
     'video/webm': '.webm',
+    'application/json': '.json',
+    'text/javascript': '.js',
 }
 
 

--- a/vows/result_storages_file_storage_vows.py
+++ b/vows/result_storages_file_storage_vows.py
@@ -72,8 +72,6 @@ class ResultStoragesFileStorageVows(Vows.Context):
             expect(result).to_be_instance_of(Media)
             expect(result.is_valid).to_equal(True)
             expect(isinstance(result.metadata, dict)).to_be_true()
-            expect(result.metadata.get('ContentLength')).not_to_be_null()
             expect(result.metadata.get('LastModified')).not_to_be_null()
             expect(len(result)).to_equal(IMAGE_LEN)
-            expect(len(result)).to_equal(result.metadata['ContentLength'])
             expect(result.last_modified).to_be_instance_of(datetime)

--- a/vows/result_storages_file_storage_vows.py
+++ b/vows/result_storages_file_storage_vows.py
@@ -60,7 +60,8 @@ class ResultStoragesFileStorageVows(Vows.Context):
     class GetResultStorageResult(Vows.Context):
         @Vows.async_topic
         def topic(self, callback):
-            config = Config(RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=STORAGE_PATH)
+            config = Config(RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=STORAGE_PATH,
+                            STORAGE_EXPIRATION_SECONDS=100)
             context = Context(config=config)
             context.request = RequestParameters(url='image.jpg')
             fs = FileStorage(context)
@@ -70,6 +71,9 @@ class ResultStoragesFileStorageVows(Vows.Context):
             result = topic.args[0]
             expect(result).to_be_instance_of(Media)
             expect(result.is_valid).to_equal(True)
+            expect(isinstance(result.metadata, dict)).to_be_true()
+            expect(result.metadata.get('ContentLength')).not_to_be_null()
+            expect(result.metadata.get('LastModified')).not_to_be_null()
             expect(len(result)).to_equal(IMAGE_LEN)
             expect(len(result)).to_equal(result.metadata['ContentLength'])
             expect(result.last_modified).to_be_instance_of(datetime)


### PR DESCRIPTION
I have continued working on the media-object branch.

I replaced all Result classes with the Media class. A DeprecationWarning is thrown if someone uses a Result class but you can still use them.

I removed the possibility to call Media.from_result() wit a buffer as argument. There were just to many possibilities to call this function and it wasn't clear what was going on. 

I also moved the code that adds the `application/json` mimetype to the object to the `_write_media_to_client` method. It did throw off the filters if it was set to early.

There are still a few unit tests that don't pass but all the BDD tests are passing.

I also added a few debugging statements. We can remove them once we get close to finishing this refactor.