### PR TITLE
refactor BaseEngine.get_orientation() so it's free from side effects

### DIFF
--- a/tests/engines/test_base_engine.py
+++ b/tests/engines/test_base_engine.py
@@ -1,0 +1,212 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+from __future__ import unicode_literals, absolute_import
+from struct import pack
+
+from unittest import TestCase
+
+try:
+    from unittest import mock  # Python 3.3 +
+except ImportError:
+    import mock  # Python 2.7
+
+from preggy import expect
+
+from thumbor.context import Context
+from thumbor.config import Config
+from thumbor.engines import BaseEngine
+
+
+exif_str = lambda x: b'Exif\x00\x00II*\x00\x08\x00\x00\x00\x05\x00\x12\x01\x03\x00\x01\x00\x00\x00%s\x00\x00\x1a\x01\x05\x00\x01\x00\x00\x00J\x00\x00\x00\x1b\x01\x05\x00\x01\x00\x00\x00R\x00\x00\x00(\x01\x03\x00\x01\x00\x00\x00\x02\x00\x00\x00\x13\x02\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00H\x00\x00\x00\x01\x00\x00\x00H\x00\x00\x00\x01\x00\x00\x00' % pack('h', x)  # noqa
+
+
+
+class BaseEngineTestCase(TestCase):
+
+    def get_context(self):
+        cfg = Config(
+                SECURITY_KEY='ACME-SEC',
+                ENGINE = 'thumbor.engines',
+        )
+        cfg.STORAGE = 'thumbor.storages.no_storage'
+
+        return Context(config=cfg)
+
+    def flip_horizontally(self):
+        ((a, b), (c, d)) = self.image
+        self.image = (
+            (b, a),
+            (d, c)
+        )
+
+    def flip_vertically(self):
+        ((a, b), (c, d)) = self.image
+        self.image = (
+            (c, d),
+            (a, b)
+        )
+
+    def rotate(self, value):
+        ((a, b), (c, d)) = self.image
+        if value == 270:
+            self.image = (
+                (c, a),
+                (d, b)
+            )
+        elif value == 180:
+            self.image = (
+                (d, c),
+                (b, a)
+            )
+        elif value == 90:
+            self.image = (
+                (b, d),
+                (a, c)
+            )
+
+    def setUp(self):
+        self.image = (
+            (1, 2),
+            (3, 4)
+        )
+        self.context = self.get_context()
+        self.engine = BaseEngine(self.context)
+        self.engine.flip_horizontally = mock.MagicMock()
+        self.engine.flip_horizontally.side_effect = self.flip_horizontally
+        self.engine.flip_vertically = mock.MagicMock()
+        self.engine.flip_vertically.side_effect = self.flip_vertically
+        self.engine.rotate = mock.MagicMock()
+        self.engine.rotate.side_effect = self.rotate
+
+    def test_create_engine(self):
+        expect(self.engine).to_be_instance_of(BaseEngine)
+
+    def test_get_orientation(self):
+        self.engine.exif = exif_str(1)
+        expect(self.engine.get_orientation()).to_equal(1)
+        expect(self.engine.get_orientation()).to_equal(1)
+        self.engine.exif = exif_str(6)
+        expect(self.engine.get_orientation()).to_equal(6)
+        expect(self.engine.get_orientation()).to_equal(6)
+        self.engine.exif = exif_str(8)
+        expect(self.engine.get_orientation()).to_equal(8)
+        expect(self.engine.get_orientation()).to_equal(8)
+
+    def test_reorientate1(self):
+        # No rotation
+        self.engine.exif = exif_str(1)
+        self.engine.reorientate()
+        expect(self.engine.rotate.called).to_be_false()
+        expect(self.engine.flip_horizontally.called).to_be_false()
+        expect(self.engine.flip_vertically.called).to_be_false()
+        expect(self.image).to_equal(((1, 2), (3, 4)))
+
+        expect(self.engine.get_orientation()).to_equal(1)
+
+    def test_reorientate2(self):
+        self.image = (
+            (2, 1),
+            (4, 3)
+        )
+        # Flipped horizontally
+        self.engine.exif = exif_str(2)
+        self.engine.reorientate()
+        expect(self.engine.rotate.called).to_be_false()
+        expect(self.engine.flip_horizontally.called).to_be_true()
+        expect(self.engine.flip_vertically.called).to_be_false()
+        expect(self.image).to_equal(((1, 2), (3, 4)))
+
+        expect(self.engine.get_orientation()).to_equal(1)
+
+    def test_reorientate3(self):
+        # Rotated 180°  Ⅎ
+        self.image = (
+            (4, 3),
+            (2, 1)
+        )
+        self.engine.exif = exif_str(3)
+        self.engine.reorientate()
+        expect(self.engine.rotate.call_args[0]).to_equal((180,))
+        expect(self.engine.flip_horizontally.called).to_be_false()
+        expect(self.engine.flip_vertically.called).to_be_false()
+        expect(self.image).to_equal(((1, 2), (3, 4)))
+
+        expect(self.engine.get_orientation()).to_equal(1)
+
+    def test_reorientate4(self):
+        # Flipped vertically
+        self.image = (
+            (3, 4),
+            (1, 2)
+        )
+        self.engine.exif = exif_str(4)
+        self.engine.reorientate()
+        expect(self.engine.rotate.called).to_be_false()
+        expect(self.engine.flip_horizontally.called).to_be_false()
+        expect(self.engine.flip_vertically.called).to_be_true()
+        expect(self.image).to_equal(((1, 2), (3, 4)))
+
+        expect(self.engine.get_orientation()).to_equal(1)
+
+    def test_reorientate5(self):
+        # Horizontal Mirror + Rotation 270
+        # or Vertical Mirror + Rotation 90
+        self.image = (
+            (1, 3),
+            (2, 4)
+        )
+        self.engine.exif = exif_str(5)
+        self.engine.reorientate()
+        expect(self.image).to_equal(((1, 2), (3, 4)))
+
+        expect(self.engine.get_orientation()).to_equal(1)
+
+    def test_reorientate6(self):
+        # Rotate 270°
+        self.image = (
+            (2, 4),
+            (1, 3)
+        )
+        self.engine.exif = exif_str(6)
+        self.engine.reorientate()
+        expect(self.engine.rotate.call_args[0]).to_equal((270,))
+        expect(self.engine.flip_horizontally.called).to_be_false()
+        expect(self.engine.flip_vertically.called).to_be_false()
+        expect(self.image).to_equal(((1, 2), (3, 4)))
+
+        expect(self.engine.get_orientation()).to_equal(1)
+
+    def test_reorientate7(self):
+        # Flipped horizontally and rotate 90°
+        self.image = (
+            (4, 2),
+            (3, 1)
+        )
+        self.engine.exif = exif_str(7)
+        self.engine.reorientate()
+        expect(self.image).to_equal(((1, 2), (3, 4)))
+
+        expect(self.engine.get_orientation()).to_equal(1)
+
+    def test_reorientate8(self):
+        # Rotate 90°
+        self.image = (
+            (3, 1),
+            (4, 2)
+        )
+        self.engine.exif = exif_str(8)
+        self.engine.reorientate()
+        expect(self.engine.rotate.call_args[0]).to_equal((90,))
+        expect(self.engine.flip_horizontally.called).to_be_false()
+        expect(self.engine.flip_vertically.called).to_be_false()
+        expect(self.image).to_equal(((1, 2), (3, 4)))
+
+        expect(self.engine.get_orientation()).to_equal(1)

--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -31,7 +31,9 @@ class MultipleEngine:
         self.frame_engines.append(frame_engine)
 
     def read(self, extension=None, quality=None):
-        return self.source_engine.read_multiple([frame_engine.image for frame_engine in self.frame_engines], extension)
+        return self.source_engine.read_multiple(
+                [frame_engine.image for frame_engine in self.frame_engines],
+                extension)
 
     def size(self):
         return self.frame_engines[0].size
@@ -79,12 +81,14 @@ class BaseEngine(object):
         return mime
 
     def wrap(self, multiple_engine):
-        for method_name in ['resize', 'crop', 'flip_vertically', 'flip_horizontally']:
+        for method_name in ['resize', 'crop', 'flip_vertically',
+                            'flip_horizontally']:
             setattr(self, method_name, multiple_engine.do_many(method_name))
         setattr(self, 'read', multiple_engine.read)
 
     def is_multiple(self):
-        return hasattr(self, 'multiple_engine') and self.multiple_engine is not None
+        return hasattr(self, 'multiple_engine') \
+               and self.multiple_engine is not None
 
     def frame_engines(self):
         return self.multiple_engine.frame_engines
@@ -97,7 +101,8 @@ class BaseEngine(object):
 
         image_or_frames = self.create_image(buffer)
 
-        if self.context.config.ALLOW_ANIMATED_GIFS and isinstance(image_or_frames, (list, tuple)):
+        if self.context.config.ALLOW_ANIMATED_GIFS and isinstance(
+                image_or_frames, (list, tuple)):
             self.image = image_or_frames[0]
             if len(image_or_frames) > 1:
                 self.multiple_engine = MultipleEngine(self)
@@ -119,22 +124,26 @@ class BaseEngine(object):
         return self.image.size
 
     def can_convert_to_webp(self):
-        return self.size[0] <= WEBP_SIDE_LIMIT and self.size[1] <= WEBP_SIDE_LIMIT
+        return self.size[0] <= WEBP_SIDE_LIMIT \
+               and self.size[1] <= WEBP_SIDE_LIMIT
 
     def normalize(self):
         width, height = self.size
         self.source_width = width
         self.source_height = height
 
-        if width > self.context.config.MAX_WIDTH or height > self.context.config.MAX_HEIGHT:
+        if width > self.context.config.MAX_WIDTH \
+                or height > self.context.config.MAX_HEIGHT:
             width_diff = width - self.context.config.MAX_WIDTH
             height_diff = height - self.context.config.MAX_HEIGHT
             if self.context.config.MAX_WIDTH and width_diff > height_diff:
-                height = self.get_proportional_height(self.context.config.MAX_WIDTH)
+                height = self.get_proportional_height(
+                        self.context.config.MAX_WIDTH)
                 self.resize(self.context.config.MAX_WIDTH, height)
                 return True
             elif self.context.config.MAX_HEIGHT and height_diff > width_diff:
-                width = self.get_proportional_width(self.context.config.MAX_HEIGHT)
+                width = self.get_proportional_width(
+                        self.context.config.MAX_HEIGHT)
                 self.resize(width, self.context.config.MAX_HEIGHT)
                 return True
 
@@ -148,27 +157,41 @@ class BaseEngine(object):
         width, height = self.size
         return round(float(new_width) * height / width, 0)
 
-    def get_orientation(self, override_exif=True):
-        if (not hasattr(self, 'exif')) or self.exif is None:
-            return
-
-        orientation = None
-
+    def _get_exif_segment(self):
         try:
             segment = ExifSegment(None, None, self.exif, 'ro')
-            primary = segment.primary
-            orientation = primary['Orientation']
-            if orientation:
-                orientation = orientation[0]
-                if orientation != 1 and override_exif:
-                    primary['Orientation'] = [1]
-                    self.exif = segment.get_data()
         except Exception:
             logger.exception('Ignored error handling exif for reorientation')
-        finally:
-            return orientation
+        else:
+            return segment
+        return None
 
-    def reorientate(self):
+    def get_orientation(self):
+        """
+        Returns the image orientation of the buffer image or None
+        if it is undefined. Gets the original value from the Exif tag.
+        If the buffer has been rotated, then the value is adjusted to 1.
+        :return: Orientation value (1 - 8)
+        :rtype: int or None
+        """
+        if (not hasattr(self, 'exif')) or self.exif is None:
+            return None
+
+        segment = self._get_exif_segment()
+        if segment:
+            orientation = segment.primary['Orientation']
+            if orientation:
+                return orientation[0]
+        return None
+
+    def reorientate(self, override_exif=True):
+        """
+        Rotates the image in the buffer so that it is oriented correctly.
+        If override_exif is True (default) then the metadata
+        orientation is adjusted as well.
+        :param override_exif: If the metadata should be adjusted as well.
+        :type override_exif: Boolean
+        """
 
         orientation = self.get_orientation()
 
@@ -179,17 +202,23 @@ class BaseEngine(object):
         elif orientation == 4:
             self.flip_vertically()
         elif orientation == 5:
-            # Horizontal Mirror + Rotation 270
+            # Horizontal Mirror + Rotation 270 CCW
             self.flip_vertically()
             self.rotate(270)
         elif orientation == 6:
             self.rotate(270)
         elif orientation == 7:
-            # Vertical Mirror + Rotation 270
+            # Vertical Mirror + Rotation 270 CCW
             self.flip_horizontally()
             self.rotate(270)
         elif orientation == 8:
             self.rotate(90)
+
+        if orientation != 1 and override_exif:
+            segment = self._get_exif_segment()
+            if segment:
+                segment.primary['Orientation'] = [1]
+                self.exif = segment.get_data()
 
     def gen_image(self):
         raise NotImplementedError()
@@ -212,7 +241,12 @@ class BaseEngine(object):
     def flip_vertically(self):
         raise NotImplementedError()
 
-    def rotate(self):
+    def rotate(self, amount):
+        """
+        Rotates the image the given amount CCW.
+        :param amount: Amount to rotate in degrees.
+        :type amount: int
+        """
         pass
 
     def read(self, extension, quality):
@@ -225,7 +259,8 @@ class BaseEngine(object):
         raise NotImplementedError()
 
     def get_image_mode(self):
-        """ Possible return values should be: RGB, RBG, GRB, GBR, BRG, BGR, RGBA, AGBR, ...  """
+        """ Possible return values should be: RGB, RBG, GRB, GBR,
+            BRG, BGR, RGBA, AGBR, ...  """
         raise NotImplementedError()
 
     def paste(self):

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -105,6 +105,7 @@ class Engine(BaseEngine):
         ))
 
     def rotate(self, degrees):
+        # PIL rotates counter clockwise
         self.image = self.image.rotate(degrees)
 
     def flip_vertically(self):

--- a/thumbor/filters/no_upscale.py
+++ b/thumbor/filters/no_upscale.py
@@ -19,7 +19,7 @@ class Filter(BaseFilter):
     @filter_method()
     def no_upscale(self):
         image_size = self.context.request.engine.size
-        orientation = self.context.request.engine.get_orientation(False)
+        orientation = self.context.request.engine.get_orientation()
         if self.context.config.RESPECT_ORIENTATION and orientation in [5, 6, 7, 8]:
             image_size = (image_size[1], image_size[0])
         if self.context.request.width > image_size[0]:

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -97,10 +97,15 @@ class BaseHandler(tornado.web.RequestHandler):
         req.meta_callback = conf.META_CALLBACK_NAME or self.request.arguments.get('callback', [None])[0]
 
         self.filters_runner = self.context.filters_factory.create_instances(self.context, self.context.request.filters)
+        # Apply all the filters from the PRE_LOAD phase and call get_image() afterwards.
         self.filters_runner.apply_filters(thumbor.filters.PHASE_PRE_LOAD, self.get_image)
 
     @gen.coroutine  # NOQA
     def get_image(self):
+        """
+        This function is called after the PRE_LOAD filters have been applied.
+        It applies the AFTER_LOAD filters on the result, then crops the image.
+        """
         try:
             result = yield self._fetch(
                 self.context.request.image_url
@@ -437,6 +442,13 @@ class BaseHandler(tornado.web.RequestHandler):
 
     @gen.coroutine
     def _fetch(self, url):
+        """
+
+        :param url:
+        :type url:
+        :return:
+        :rtype:
+        """
         fetch_result = FetchResult()
 
         storage = self.context.modules.storage


### PR DESCRIPTION
The method `BaseEngine.get_orienation()` would reset the Exif orientation to 1 when called.
This should only be done in the method `BaseEngine.reorientate()`.

Added unit tests for `reorientate()` as well.