### PR TITLE
Add responsive capabilities

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -18,6 +18,7 @@ Filters
    noise
    quality
    red_eye
+   responsive
    rgb
    rotate
    round_corners

--- a/docs/responsive.rst
+++ b/docs/responsive.rst
@@ -1,0 +1,33 @@
+Responsive
+==========
+
+Description
+-----------
+
+This filter adds the possibility to create responsive images.
+If this filter is active and a user requests a 320x240 image with a dpr of 2,
+then a 640x480 image could be delivered.
+
+The output size depends on other
+things as well such as the source image resolution and the network quality.
+
+
+Arguments
+---------
+
+display resolution value (dpr) (optional, number)
+This value is the relationship between a CSS pixel and a physical pixel.
+For desktop browsers this value is 1. For retina displays it is 2.
+
+Valid values are from 0.5 to 4.
+
+
+Example
+-------
+
+    ``/filters:dpr(2)/`` or ``/filters:dpr()/``
+
+
+If no argument is given, then a dpr of 1 is assumed.
+HTTP Client Hints can override the default value. If a value is passed in
+as an argument, that value is used.

--- a/tests/base.py
+++ b/tests/base.py
@@ -23,6 +23,7 @@ from PIL import Image
 from skimage.measure import structural_similarity
 from preggy import create_assertions
 
+from thumbor.filters import PHASE_PRE_LOAD, PHASE_AFTER_LOAD, PHASE_POST_TRANSFORM
 from thumbor.app import ThumborServiceApp
 from thumbor.context import Context, RequestParameters
 from thumbor.config import Config
@@ -244,10 +245,18 @@ class FilterTestCase(PythonTestCase):
         img_buffer = BytesIO()
         im.save(img_buffer, 'JPEG', quality=100)
 
+        if getattr(fltr, 'phase', None) == PHASE_PRE_LOAD:
+            fltr.run()
+
         fltr.engine.load(img_buffer.getvalue(), '.jpg')
+
+        if getattr(fltr, 'phase', None) == PHASE_AFTER_LOAD:
+            fltr.run()
+
         fltr.context.transformer.img_operation_worker()
 
-        fltr.run()
+        if getattr(fltr, 'phase', PHASE_POST_TRANSFORM) == PHASE_POST_TRANSFORM:
+            fltr.run()
 
         fltr.engine.image = fltr.engine.image.convert('RGBA')
 

--- a/tests/filters/test_hi_dpr.py
+++ b/tests/filters/test_hi_dpr.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+from unittest import skip
+
+from preggy import expect
+
+from tests.base import FilterTestCase
+
+
+class ResponsiveTestCase(FilterTestCase):
+    def test_no_op(self):
+        # source size: 400x600
+
+        image = self.get_filtered('source.jpg', 'thumbor.filters.responsive',
+                                  'responsive()')
+        expected = self.get_fixture('source.jpg')
+        expect(len(image[0])).to_equal(400)
+        expect(len(image)).to_equal(600)
+
+        ssim = self.get_ssim(image, expected)
+        expect(ssim).to_be_greater_than(0.99)
+
+        image = self.get_filtered('source.jpg', 'thumbor.filters.responsive',
+                                  'responsive(1)')
+        expected = self.get_fixture('source.jpg')
+
+        ssim = self.get_ssim(image, expected)
+        expect(ssim).to_be_greater_than(0.99)
+
+        image = self.get_filtered('source.jpg', 'thumbor.filters.responsive',
+                                  'responsive(2)')
+        expected = self.get_fixture('source.jpg')
+
+        ssim = self.get_ssim(image, expected)
+        expect(ssim).to_be_greater_than(0.99)
+
+    def test_no_op_with_fit_in(self):
+        # fit_in = True
+        def config_context(context):
+            context.request.fit_in = True
+            context.request.width = 400
+            context.request.height = 600
+
+        image = self.get_filtered('source.jpg', 'thumbor.filters.responsive',
+                                  'responsive()', config_context=config_context)
+        expect(len(image[0])).to_equal(400)
+        expect(len(image)).to_equal(600)
+
+        image = self.get_filtered('source.jpg', 'thumbor.filters.responsive',
+                                  'responsive(1)', config_context=config_context)
+        expect(len(image[0])).to_equal(400)
+        expect(len(image)).to_equal(600)
+
+        image = self.get_filtered('source.jpg', 'thumbor.filters.responsive',
+                                  'responsive(2)', config_context=config_context)
+        expect(len(image[0])).to_equal(400)
+        expect(len(image)).to_equal(600)
+
+        image = self.get_filtered('source.jpg', 'thumbor.filters.responsive',
+                                  'responsive(0.5)', config_context=config_context)
+        expect(len(image[0])).to_equal(400)
+        expect(len(image)).to_equal(600)
+
+
+    def test_smaller_dpr(self):
+        image = self.get_filtered('source.jpg', 'thumbor.filters.responsive',
+                                  'responsive(0.5)')
+
+        expect(len(image[0])).to_equal(200)
+        expect(len(image)).to_equal(300)
+
+    def test_higher_dpr(self):
+        def config_context(context):
+            context.request.fit_in = False
+            context.request.width = 200
+            context.request.height = 300
+
+        image = self.get_filtered(
+                'source.jpg',
+                'thumbor.filters.responsive',
+                'responsive(2)',
+                config_context=config_context)
+
+        expect(len(image[0])).to_equal(400)
+        expect(len(image)).to_equal(600)
+
+
+        expected = self.get_fixture('source.jpg')
+        ssim = self.get_ssim(image, expected)
+        expect(ssim).to_be_greater_than(0.99)
+
+        def config_context(context):
+            context.request.fit_in = False
+            context.request.width = 100
+            context.request.height = 150
+
+        image = self.get_filtered(
+                'source.jpg',
+                'thumbor.filters.responsive',
+                'responsive(2)',
+                config_context=config_context)
+
+        expect(len(image[0])).to_equal(200)
+        expect(len(image)).to_equal(300)
+
+    def test_higher_dpr_with_fit_in(self):
+        # fit_in = True
+        def config_context(context):
+            context.request.fit_in = True
+            context.request.width = 200
+            context.request.height = 300
+
+        image = self.get_filtered(
+                'source.jpg',
+                'thumbor.filters.responsive',
+                'responsive(2)',
+                config_context=config_context)
+
+        expect(len(image[0])).to_equal(400)
+        expect(len(image)).to_equal(600)
+
+        expected = self.get_fixture('source.jpg')
+        ssim = self.get_ssim(image, expected)
+        expect(ssim).to_be_greater_than(0.99)
+
+        def config_context(context):
+            context.request.fit_in = True
+            context.request.width = 100
+            context.request.height = 150
+
+        image = self.get_filtered(
+                'source.jpg',
+                'thumbor.filters.responsive',
+                'responsive(2)',
+                config_context=config_context)
+
+        expect(len(image[0])).to_equal(200)
+        expect(len(image)).to_equal(300)

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -287,6 +287,7 @@ Config.define(
         'thumbor.filters.frame',
         'thumbor.filters.grayscale',
         'thumbor.filters.rotate',
+        'thumbor.filters.responsive',
         'thumbor.filters.format',
         'thumbor.filters.max_bytes',
         'thumbor.filters.convolution',

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -165,6 +165,7 @@ class RequestParameters:
         self.detection_error = None
         self.quality = quality
         self.buffer = None
+        self.headers = {}
 
         if focal_points is None:
             focal_points = []
@@ -182,6 +183,7 @@ class RequestParameters:
             self.url = request.path
             self.accepts_webp = 'image/webp' in request.headers.get('Accept', '')
             self.image_url = Url.encode_url(self.image_url.encode('utf-8'))
+            self.headers = request.headers
 
     def int_or_0(self, value):
         return 0 if value is None else int(value)

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -47,6 +47,7 @@ class Context:
         self.statsd_client = self.metrics  # TODO statsd_client is deprecated, remove me on next minor version bump
         self.thread_pool = ThreadPool.instance(getattr(config, 'ENGINE_THREADPOOL_SIZE', 0))
         self.headers = {}  # Response Headers
+        self.vary_headers = set()
 
 
 class ServerParameters(object):

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -46,7 +46,7 @@ class Context:
         self.request_handler = request_handler
         self.statsd_client = self.metrics  # TODO statsd_client is deprecated, remove me on next minor version bump
         self.thread_pool = ThreadPool.instance(getattr(config, 'ENGINE_THREADPOOL_SIZE', 0))
-        self.headers = {}
+        self.headers = {}  # Response Headers
 
 
 class ServerParameters(object):
@@ -102,6 +102,7 @@ class RequestParameters:
                  fit_in=False,
                  width=0,
                  height=0,
+                 dpr=1,
                  horizontal_flip=False,
                  vertical_flip=False,
                  halign='center',
@@ -150,6 +151,7 @@ class RequestParameters:
 
         self.width = width == "orig" and "orig" or self.int_or_0(width)
         self.height = height == "orig" and "orig" or self.int_or_0(height)
+        self.dpr = dpr
         self.horizontal_flip = bool(horizontal_flip)
         self.vertical_flip = bool(vertical_flip)
         self.halign = halign or 'center'

--- a/thumbor/filters/responsive.py
+++ b/thumbor/filters/responsive.py
@@ -30,9 +30,10 @@ class Filter(BaseFilter):
     MAX_DPR = 4.0
     MIN_DOWNLINK = 1.0  # mbit/s
 
-    @filter_method(BaseFilter.DecimalNumber)
+    @filter_method(r'(0\.[5-9]([0-9]*)?|[1-4](\.[0-9]+)?)?')  #
     def responsive(self, initial_dpr=None):
         logger.debug('DPR filter activated. Initial value: %s ' % initial_dpr)
+
         dpr = self._get_dpr(initial_dpr, self.context.request.headers)
 
         if self.context and self.context.request:
@@ -57,9 +58,11 @@ class Filter(BaseFilter):
             logger.debug('Dpr in header found. Using this value: %s'
                          % header_dpr)
             dpr = float(header_dpr)
+            self.context.vary_headers.add('Dpr')
 
         # args can override Headers
         if initial_dpr:
+            initial_dpr = float(initial_dpr)
             if self.MIN_DPR <= initial_dpr <= self.MAX_DPR:
                 dpr = initial_dpr
             else:
@@ -69,5 +72,6 @@ class Filter(BaseFilter):
         header_downlink = request_headers.get('Downlink')
         if header_downlink and float(header_downlink) < self.MIN_DOWNLINK:
             dpr = min(dpr, 1.0)
+            self.context.vary_headers.add('Downlink')
 
         return dpr

--- a/thumbor/filters/responsive.py
+++ b/thumbor/filters/responsive.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+from thumbor.filters import BaseFilter, filter_method, PHASE_PRE_LOAD
+from thumbor.utils import logger
+
+class Filter(BaseFilter):
+    """
+    This filter adds display resolution information to the context. It
+    allows to create retina images.
+    If this filter is active and a user requests a 320x240 image with a dpr of 2,
+    then a 640x480 image could be delivered. The output size depends on other
+    things as well such as the source image resolution and the network quality.
+
+    usage: /filters:dpr(2)/ or /filters:dpr()/
+
+    If no argument is given, then a dpr of 1 is assumed. Except if Client hints
+    are available. Then that dpr value is considered.
+    """
+    phase = PHASE_PRE_LOAD
+
+    MIN_DPR = 0.5
+    MAX_DPR = 4.0
+    MIN_DOWNLINK = 1.0  # mbit/s
+
+    @filter_method(BaseFilter.DecimalNumber)
+    def responsive(self, initial_dpr=None):
+        logger.debug('DPR filter activated. Initial value: %s ' % initial_dpr)
+        dpr = self._get_dpr(initial_dpr, self.context.request.headers)
+
+        if self.context and self.context.request:
+            self.context.request.dpr = dpr
+
+    def _get_dpr(self, initial_dpr, request_headers):
+        """
+        Returns the display resolution factor. The passed in values override
+        the client hint values. A slow connection reduces the dpr to a minimum.
+        :param initial_dpr: values from the URL
+        :type initial_dpr: float
+        :param request_headers: HTTP Request Headers
+        :type request_headers: dict
+        :return: Calculated values
+        :rtype: float
+        """
+        dpr = 1.0
+
+        # Check if the dpr was sent with HTTP Client Hints
+        header_dpr = request_headers.get('Dpr')
+        if header_dpr is not None:
+            logger.debug('Dpr in header found. Using this value: %s'
+                         % header_dpr)
+            dpr = float(header_dpr)
+
+        # args can override Headers
+        if initial_dpr:
+            if self.MIN_DPR <= initial_dpr <= self.MAX_DPR:
+                dpr = initial_dpr
+            else:
+                logger.debug('Illegal dpr value: %s' % initial_dpr)
+
+        # Check if the downlink speed is fast enough for retina images
+        header_downlink = request_headers.get('Downlink')
+        if header_downlink and float(header_downlink) < self.MIN_DOWNLINK:
+            dpr = min(dpr, 1.0)
+
+        return dpr

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -344,8 +344,16 @@ class BaseHandler(tornado.web.RequestHandler):
                 not context.request.engine.is_multiple() and \
                 context.request.engine.can_convert_to_webp() and \
                 context.request.engine.extension != '.webp':
-            self.set_header('Vary', 'Accept')
+            context.vary_headers.add('Accept')
 
+        # context.vary_headers is a set and has to be converted
+        # to a comma separated list first.
+        if len(context.vary_headers) > 0:
+            if self._headers.get('Vary'):
+                current = self._headers.get('Vary').split(',')
+                for value in current:
+                    context.vary_headers.add(value)
+            self.set_header('Vary', ','.join(context.vary_headers))
         context.headers = self._headers.copy()
 
         if isinstance(results, ResultStorageResult):

--- a/thumbor/transformer.py
+++ b/thumbor/transformer.py
@@ -64,7 +64,7 @@ class Transformer(object):
         """
         if self.target_height is None:
             self._calculate_target_dimensions()
-        return int(self.target_height), int(self.target_width)
+        return int(self.target_width), int(self.target_height)
 
     def adjust_focal_points(self):
         source_width, source_height = self.engine.size

--- a/vows/config_vows.py
+++ b/vows/config_vows.py
@@ -49,6 +49,7 @@ TEST_DATA = (
         'thumbor.filters.frame',
         'thumbor.filters.grayscale',
         'thumbor.filters.rotate',
+        'thumbor.filters.responsive',
         'thumbor.filters.format',
         'thumbor.filters.max_bytes',
         'thumbor.filters.convolution',


### PR DESCRIPTION
This code would add two features discussed in issue https://github.com/thumbor/thumbor/issues/549

Maybe master is not the best base branch. Do you guys have a development branch?

This code would allow Thumbor to output responsive images. Now you can request:

    http://localhost:8888/unsafe/200x200/filters:responsive(2)/Test-1.jpg 

and you get a 400x400 pixel image back.

The capability is added as a filter which just sets a global `dpr` value. That value is 1 by default so it doesn't change current behavior.
If there are no arguments, then the filter checks the request headers for the `Dpr` value (from HTTP client hints) and uses this value instead. If the value is used, then the `Vary` header in the response is updated accordingly.

The dpr value is stored in context.request.dpr as request parameter. If someone has a better idea then please tell me. It needs to be somewhere that is available during the full lifecycle of the request.

There is also a new property in the context called `vary_headers` which is a Python set. Any filter or plugin that updates something so it requires its own cache key can add it to the set. In the end it gets serialized into the HTTP response header.

I added about 10 test cases, but this feature would need a lot more testing. I had to make some adjustments to the Transformer class.

I had to adjust the FilterTestCase base class as well so the filter are executed at the right time. There is still an issue with the test class because the filter has access to the Transformer class while it shouldn't have.
