### PR TITLE
Add focal filter

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -293,6 +293,7 @@ Config.define(
         'thumbor.filters.convolution',
         'thumbor.filters.blur',
         'thumbor.filters.extract_focal',
+        'thumbor.filters.focal',
         'thumbor.filters.no_upscale',
         'thumbor.filters.saturation',
         'thumbor.filters.max_age',

--- a/thumbor/filters/focal.py
+++ b/thumbor/filters/focal.py
@@ -12,6 +12,7 @@ import re
 from thumbor.filters import BaseFilter, filter_method, PHASE_PRE_LOAD
 from thumbor.point import FocalPoint
 
+
 class Filter(BaseFilter):
     phase = PHASE_PRE_LOAD
 

--- a/thumbor/filters/focal.py
+++ b/thumbor/filters/focal.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+import re
+
+from thumbor.filters import BaseFilter, filter_method, PHASE_PRE_LOAD
+from thumbor.point import FocalPoint
+
+class Filter(BaseFilter):
+    phase = PHASE_PRE_LOAD
+
+    focal_regex = re.compile("(\d+)x(\d+):(\d+)x(\d+)")
+
+    @filter_method(BaseFilter.String)
+    def focal(self, focal_string):
+        left, top, right, bottom = self.focal_regex.match(focal_string).groups()
+        left, top, right, bottom = int(left), int(top), int(right), int(bottom)
+        width = right - left
+        height = bottom - top
+
+        if width and height:
+            self.context.request.focal_points.append(
+                FocalPoint.from_square(left, top, width, height, origin="Explicit")
+            )

--- a/thumbor/integration_tests/urls_helpers.py
+++ b/thumbor/integration_tests/urls_helpers.py
@@ -85,6 +85,8 @@ filters = [
     'filters:fill(transparent,true)',
     'filters:blur(2)',
     'filters:extract_focal()',
+    'filters:focal()',
+    'filters:focal(0x0:1x1)',
     'filters:no_upscale()',
     'filters:gifv()',
     'filters:gifv(webm)',

--- a/vows/config_vows.py
+++ b/vows/config_vows.py
@@ -62,6 +62,7 @@ TEST_DATA = (
         'thumbor.filters.convolution',
         'thumbor.filters.blur',
         'thumbor.filters.extract_focal',
+        'thumbor.filters.focal',
         'thumbor.filters.no_upscale',
         'thumbor.filters.saturation',
         'thumbor.filters.max_age',


### PR DESCRIPTION
This PR adds a new `focal()` filter. Usage is simple and consistent with previous crop/focal point syntax.

--------

**OBSERVE**. The real ultimate power of `focal` and tremble in the shadow of it's stoic awesomeness.

See America's greatest hero, in all his poise and grace - with this focused 4:3 crop
![gettyimages-480656886 0-2](https://cloud.githubusercontent.com/assets/142910/12839907/bf7978a4-cbab-11e5-8f00-33c019bedddf.jpg)
`http://localhost:8888/unsafe/664x498/filters:focal(1000x850:1675x1150)/cdn0.vox-cdn.com/uploads/chorus_image/image/46741032/GettyImages-480656886.0.jpg`

Or gaze into the steely eyes of his most trusted colleague and apprentice of the dark political arts - in this weird but focused 83:25 ratio crop
![gettyimages-480656886 0-4](https://cloud.githubusercontent.com/assets/142910/12839964/574764f2-cbac-11e5-8970-6137d5e58150.jpg)
`http://localhost:8888/unsafe/664x200/filters:focal(1000x850:1675x1150)/cdn0.vox-cdn.com/uploads/chorus_image/image/46741032/GettyImages-480656886.0.jpg`

No longer will your CDN's routing logic, results storage or image syntax become confused and frightened by the tyranny of the "double url" "double origin" "double trouble" required by the verbose `extract_focal` filter url syntax. This new filter is awesome and perfect in every possible way.

_____
  - I think this should be merged into the 5.2-stable branch AND master (but I couldn't get master working).
  - Check it. Let me know.
  - Please tag a 5.2.2 release if you merge. Better for Chef / automation in general.
  - Thanks to the previous creator of `extract_focal`, it's great.
  - Related issue: https://github.com/thumbor/thumbor/issues/525