### PR TITLE
Issues template

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,14 @@
+### Thumbor request URL
+The request url for the issue you are having, you can swap the host name with a fake
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead
+
+### Operating system
+OSx, Ubuntu, etc
+
+### Your thumbor.conf
+Your config file (WARNING: replace your SECURITY_KEY key with a dummy key or your key will become public)


### PR DESCRIPTION
Upon creating a new issue, use a template to scaffold out the issue. Example: https://github.com/okor/thumbor/issues/new

See related discussion: https://github.com/dear-github/dear-github/issues/125

We can change what the templates contents are, this is just a first pass to get the ball rolling. But I think it would be really helpful.