### PR TITLE
Fixed bug on loading images which contain wierd characters like space

### DIFF
--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -11,7 +11,7 @@
 import re
 from functools import partial
 from urlparse import urlparse
-from urllib import unquote
+from urllib import unquote, quote
 
 import tornado.httpclient
 
@@ -118,4 +118,10 @@ def load_sync(context, url, callback, normalize_url_func):
 
 
 def encode(string):
-    return None if string is None else string.encode('ascii')
+    if string is None:
+        return None
+
+    parsed_url = urlparse(string)
+    string = parsed_url.scheme + '://' +  parsed_url.netloc + quote(parsed_url.path)
+
+    return string.encode('ascii')


### PR DESCRIPTION
If you have /unsafe/1000x1000/http://x.y.z/Test Test/test.jpg thumbor does not encode that properly (i.e. whitespace replaced with %20). This pull request fixes that bug.