### PR TITLE
Let engines do their own cleanup on application shutdown

### DIFF
--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -52,6 +52,9 @@ class Context:
         return self
 
     def __exit__(self, type, value, traceback):
+        if self.modules:
+            self.modules.cleanup()
+
         self.thread_pool.cleanup()
 
 
@@ -223,6 +226,10 @@ class ContextImporter:
         self.filters = importer.filters
         self.optimizers = importer.optimizers
         self.url_signer = importer.url_signer
+
+    def cleanup(self):
+        if self.engine:
+            self.engine.cleanup()
 
 
 class ThreadPool(object):

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -48,6 +48,12 @@ class Context:
         self.thread_pool = ThreadPool.instance(getattr(config, 'ENGINE_THREADPOOL_SIZE', 0))
         self.headers = {}
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.thread_pool.cleanup()
+
 
 class ServerParameters(object):
     def __init__(self, port, ip, config_path, keyfile, log_level, app_class, fd=None, gifsicle_path=None):

--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -242,3 +242,6 @@ class BaseEngine(object):
 
     def extract_cover(self):
         raise NotImplementedError()
+
+    def cleanup(self):
+        pass

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -125,19 +125,17 @@ def main(arguments=None):
 
     validate_config(config, server_parameters)
 
-    context = get_context(server_parameters, config, importer)
+    with get_context(server_parameters, config, importer) as context:
+        application = get_application(context)
+        run_server(application, context)
 
-    application = get_application(context)
-    run_server(application, context)
+        try:
+            logging.debug('thumbor running at %s:%d' % (context.server.ip, context.server.port))
+            tornado.ioloop.IOLoop.instance().start()
+        except KeyboardInterrupt:
+            sys.stdout.write('\n')
+            sys.stdout.write("-- thumbor closed by user interruption --\n")
 
-    try:
-        logging.debug('thumbor running at %s:%d' % (context.server.ip, context.server.port))
-        tornado.ioloop.IOLoop.instance().start()
-    except KeyboardInterrupt:
-        sys.stdout.write('\n')
-        sys.stdout.write("-- thumbor closed by user interruption --\n")
-    finally:
-        context.thread_pool.cleanup()
 
 if __name__ == "__main__":
     main(sys.argv)


### PR DESCRIPTION
I have a custom engine that relies on exiftool running as a daemon, getting commands from a named pipe. When Thumbor shuts down, I need to have this engine unlink the named pipe gracefully.

Suggestions on how to do that differently are welcome, I couldn't find any other way for my engine to be made aware of application shutdown.