### PR TITLE
Fix for #721

### DIFF
--- a/thumbor/transformer.py
+++ b/thumbor/transformer.py
@@ -131,6 +131,7 @@ class Transformer(object):
     def smart_storage_key(self):
         return self.context.request.image_url
 
+    @gen.coroutine
     def smart_detect(self):
         is_gifsicle = (self.context.request.engine.extension == '.gif' and self.context.config.USE_GIFSICLE_ENGINE)
         if (not (self.context.modules.detectors and self.context.request.smart)) or is_gifsicle:
@@ -148,7 +149,7 @@ class Transformer(object):
             # image operation inside the try block.
             self.should_run_image_operations = False
             self.running_smart_detection = True
-            self.do_smart_detection().result()
+            yield self.do_smart_detection()
             self.running_smart_detection = False
         except Exception:
             if not self.context.config.IGNORE_SMART_ERRORS:


### PR DESCRIPTION
This is the fix I came up with for https://github.com/thumbor/thumbor/issues/721

It seems that self.do_smart_detection().result() fails if the detector takes more than an instant on asynchronous activities (such as fetching a detection file from s3 it seems?).

Please review this, I am not familiar at all with tornado so this might be a naive fix for a complex problem or might be hiding the issue.
