### PR TITLE
Use pyssim instead of scikit-image for SSIM calculation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ install:
   - tar -C /tmp/ffmpeg-release --strip 1 -xvf /tmp/ffmpeg-release.tar.xz
   - export PATH=/tmp/ffmpeg-release:$PATH
   - ffmpeg -version
-  - "pip install scikit-image --no-binary :all:"
   - pip install --upgrade pip
   - make setup
   - pip install coveralls

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ tests_require = [
     "yanc",
     "remotecv",
     "hiredis",
-    "scikit-image>=0.12.3",
+    "pyssim",
     "celery",
     "cairosvg",
 ]

--- a/tests/base.py
+++ b/tests/base.py
@@ -20,7 +20,7 @@ import mock
 
 import numpy as np
 from PIL import Image
-from skimage.measure import compare_ssim
+from ssim import compute_ssim
 from preggy import create_assertions
 
 from thumbor.app import ThumborServiceApp
@@ -116,7 +116,8 @@ def get_ssim(actual, expected):
                 im2.size[0], im2.size[1],
             )
         )
-    return compare_ssim(np.array(im), np.array(im2), multichannel=True)
+
+    return compute_ssim(im, im2)
 
 
 @create_assertions


### PR DESCRIPTION
scikit-image is a huge library, with some equally massive dependencies like pandas. It's overkill to use that just to calculate SSIM values, when pyssim can do the same.

This change would simplify debian packaging greatly.