### PR TITLE
Remove unused python-magic dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
             "pycurl>=7.19.0,<7.20.0",
             "Pillow>=3.0.0,<4.0.0",
             "derpconf>=0.2.0",
-            "python-magic>=0.4.3",
             "pexif>=0.15,<1.0",
             "statsd>=3.0.1",
             "libthumbor",


### PR DESCRIPTION
No usage of that library found anywhere in the code