### PR TITLE
Make dependency on preggy explicit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ tests_require = [
     "remotecv",
     "pyssim",
     "cairosvg",
+    "preggy>=1.3.0",
 ]
 
 


### PR DESCRIPTION
Preggy is used a bunch in the Thumbor tests. It probably works right now because some sub-dependencies of Thumbor depend on it too.
However, minimum version is important, since the test_load_with_utf8_url test in tests.loaders.test_http_loader.HttpLoaderTestCase relies on error_not_to_happen, which was introduced in Preggy 1.3.0.