### PR TITLE
Make app_class definable in config

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -61,6 +61,42 @@ class ContextTestCase(TestCase):
         expect(ctx.modules).not_to_be_null()
         expect(ctx.modules.importer).to_equal(importer)
 
+    def test_can_config_define_app_class(self):
+        server = ServerParameters(
+            port=8888,
+            ip='0.0.0.0',
+            config_path='/tmp/config_path.conf',
+            keyfile='./tests/fixtures/thumbor.key',
+            log_level='debug',
+            app_class='thumbor.app.ThumborServiceApp',
+        )
+
+        cfg = Config(
+            APP_CLASS='config.app',
+        )
+        importer = Importer(cfg)
+        ctx = Context(config=cfg, importer=importer, server=server)
+
+        expect(ctx.app_class).to_equal('config.app')
+
+    def test_can_server_app_class_override_config(self):
+        server = ServerParameters(
+            port=8888,
+            ip='0.0.0.0',
+            config_path='/tmp/config_path.conf',
+            keyfile='./tests/fixtures/thumbor.key',
+            log_level='debug',
+            app_class='server.app',
+        )
+
+        cfg = Config(
+            APP_CLASS='config.app',
+        )
+        importer = Importer(cfg)
+        ctx = Context(config=cfg, importer=importer, server=server)
+
+        expect(ctx.app_class).to_equal('server.app')
+
 
 class ServerParametersTestCase(TestCase):
     def test_can_create_server_parameters(self):

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -355,6 +355,11 @@ Config.define(
     '(python must be able to import it)', 'Extensibility'
 )
 
+Config.define(
+    'APP_CLASS', 'thumbor.app.ThumborServiceApp',
+    'Custom app class to override ThumborServiceApp. This config value is overridden by the -a command-line parameter.'
+)
+
 
 def generate_config():
     config.generate_config()

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -41,6 +41,14 @@ class Context:
             self.modules = None
             self.metrics = Metrics(config)
 
+        self.app_class = 'thumbor.app.ThumborServiceApp'
+
+        if hasattr(self.config, 'APP_CLASS'):
+            self.app_class = self.config.APP_CLASS
+
+        if hasattr(self.server, 'app_class') and self.server.app_class != 'thumbor.app.ThumborServiceApp':
+            self.app_class = self.server.app_class
+
         self.filters_factory = FiltersFactory(self.modules.filters if self.modules else [])
         self.request_handler = request_handler
         self.statsd_client = self.metrics  # TODO statsd_client is deprecated, remove me on next minor version bump

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -90,7 +90,7 @@ def get_context(server_parameters, config, importer):
 
 
 def get_application(context):
-    return context.modules.importer.import_class(context.server.app_class)(context)
+    return context.modules.importer.import_class(context.app_class)(context)
 
 
 def run_server(application, context):


### PR DESCRIPTION
Fixes #747

The command line -a argument overrides the config
value if both are present.