### PR TITLE
Add config var to specify desired png compression

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -49,6 +49,8 @@ Config.define('PILLOW_JPEG_QTABLES', None,
 
 Config.define('WEBP_QUALITY', None, 'Quality index used for generated WebP images. If not set (None) the same level of '
               'JPEG quality will be used.', 'Imaging')
+
+Config.define('PNG_COMPRESSION_LEVEL', 6, 'Compression level for generated PNG images.', 'Imaging')
 Config.define('AUTO_WEBP', False, 'Specifies whether WebP format should be used automatically if the request accepts it '
               '(via Accept header)', 'Imaging')
 Config.define('SVG_DPI', 150,

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -169,6 +169,9 @@ class Engine(BaseEngine):
                     else:
                         options['qtables'] = qtables_config
 
+        if ext == '.png':
+            options['optimize'] = True
+
         if options['quality'] is None:
             options['quality'] = self.context.config.QUALITY
 
@@ -185,7 +188,6 @@ class Engine(BaseEngine):
         try:
             if ext == '.webp':
                 if self.image.mode not in ['RGB', 'RGBA']:
-                    mode = None
                     if self.image.mode == 'P':
                         mode = 'RGBA'
                     else:

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -169,8 +169,8 @@ class Engine(BaseEngine):
                     else:
                         options['qtables'] = qtables_config
 
-        if ext == '.png':
-            options['optimize'] = True
+        if ext == '.png' and self.context.config.PNG_COMPRESSION_LEVEL is not None:
+            options['compress_level'] = self.context.config.PNG_COMPRESSION_LEVEL
 
         if options['quality'] is None:
             options['quality'] = self.context.config.QUALITY


### PR DESCRIPTION
I noticed this option is set for jpegs, so why not for png? 
Or the idea here to let people use optimizers after main transformations?
