### PR TITLE
Use draft to speed up resize operations. Add config var for Pillow resampling filters

### DIFF
--- a/tests/engines/test_pil.py
+++ b/tests/engines/test_pil.py
@@ -14,9 +14,12 @@ from os.path import abspath, join, dirname
 from unittest import TestCase, skipUnless
 from preggy import expect
 
+from PIL import Image
+
 from thumbor.context import Context
 from thumbor.config import Config
 from thumbor.engines.pil import Engine
+from thumbor.engines.pil import get_resize_filter
 
 try:
     from pyexiv2 import ImageMetadata  # noqa
@@ -78,6 +81,25 @@ class PilEngineTestCase(TestCase):
             buffer = im.read()
         engine.convert_tif_to_png(buffer)
         expect(engine.extension).to_equal('.png')
+
+    def test_can_set_resampling_filter(self):
+        to_test = {
+            'LANCZOS': Image.LANCZOS,
+            'NEAREST': Image.NEAREST,
+            'BiLinear': Image.BILINEAR,
+            'bicubic': Image.BICUBIC,
+            'garbage': Image.LANCZOS,
+        }
+
+        if hasattr(Image, 'HAMMING'):
+            to_test['HAMMING'] = Image.HAMMING
+
+        for setting, expected in to_test.items():
+            cfg = Config(PILLOW_RESAMPLING_FILTER=setting)
+            expect(get_resize_filter(cfg)).to_equal(expected)
+
+        cfg = Config()
+        expect(get_resize_filter(cfg)).to_equal(Image.LANCZOS)
 
     @mock.patch('thumbor.engines.pil.cv', new=None)
     @mock.patch('thumbor.engines.logger.error')

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -47,6 +47,10 @@ Config.define('PILLOW_JPEG_QTABLES', None,
               in http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#jpeg). '
               'Will ignore `quality`. Using `keep` will copy the original file\'s qtables.', 'Imaging')
 
+Config.define('PILLOW_RESAMPLING_FILTER', 'LANCZOS',
+              'Specify resampling filter for Pillow resize method.'
+              'One of LANCZOS, NEAREST, BILINEAR, BICUBIC, HAMMING (Pillow>=3.4.0).', 'Imaging')
+
 Config.define('WEBP_QUALITY', None, 'Quality index used for generated WebP images. If not set (None) the same level of '
               'JPEG quality will be used.', 'Imaging')
 Config.define('AUTO_WEBP', False, 'Specifies whether WebP format should be used automatically if the request accepts it '

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -99,10 +99,13 @@ class Engine(BaseEngine):
         del d
 
     def resize(self, width, height):
+        mode = self.image.mode
         if self.image.mode == 'P':
             logger.debug('converting image from 8-bit palette to 32-bit RGBA for resize')
-            self.image = self.image.convert('RGBA')
-        self.image = self.image.resize((int(width), int(height)), Image.ANTIALIAS)
+            mode = 'RGBA'
+
+        self.image.draft(mode, (int(width), int(height)))
+        self.image = self.image.resize((int(width), int(height)), Image.BICUBIC)
 
     def crop(self, left, top, right, bottom):
         self.image = self.image.crop((


### PR DESCRIPTION
ANTIALIAS seems to be deprecated and they use BICUBIC now in their thumbnail method. not sure if it sould be LANCZOS? http://pillow.readthedocs.io/en/stable/releasenotes/2.7.0.html#antialias-renamed-to-lanczos

I tested draft locally and there is 30% less time required to do just resize operation and save an image.