### PR TITLE
Fix for #739

### DIFF
--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -186,8 +186,8 @@ class ImagingOperationsWithHttpLoaderTestCase(BaseImagingTestCase):
                 f.read()
             )
 
-        url = quote(u"/unsafe/http://test.com/maracujá.jpg".encode('utf-8'));
-        response = self.fetch(image_url)
+        url = quote(u"/unsafe/http://test.com/maracujá.jpg".encode('utf-8'))
+        response = self.fetch(url)
         expect(response.code).to_equal(200)
 
 

--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -179,6 +179,17 @@ class ImagingOperationsWithHttpLoaderTestCase(BaseImagingTestCase):
         response = self.fetch(url)
         expect(response.code).to_equal(200)
 
+    def test_image_with_http_utf8_url(self):
+        with open('./tests/fixtures/images/maracujá.jpg', 'r') as f:
+            self.context.modules.storage.put(
+                quote(u"http://test.com/maracujá.jpg".encode('utf-8')),
+                f.read()
+            )
+
+        url = quote(u"/unsafe/http://test.com/maracujá.jpg".encode('utf-8'));
+        response = self.fetch(image_url)
+        expect(response.code).to_equal(200)
+
 
 class ImagingOperationsTestCase(BaseImagingTestCase):
     def get_context(self):

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -11,7 +11,7 @@
 import re
 from functools import partial
 from urlparse import urlparse
-from urllib2 import unquote
+from urllib2 import unquote,quote
 
 import tornado.httpclient
 
@@ -20,8 +20,11 @@ from thumbor.utils import logger
 from tornado.concurrent import return_future
 
 
+def encode_url(url):
+    return quote(url.encode('utf-8'),safe='~@#$&()*!+=:;,.?/\'')
+
 def quote_url(url):
-    return unquote(url).decode('utf-8')
+    return encode_url(unquote(url).decode('utf-8'))
 
 
 def _normalize_url(url):

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -19,9 +19,11 @@ from . import LoaderResult
 from thumbor.utils import logger
 from tornado.concurrent import return_future
 
-
 def encode_url(url):
-    return quote(url.encode('utf-8'),safe='~@#$&()*!+=:;,.?/\'')
+    if url == unquote(url):
+        return quote(url.encode('utf-8'),safe='~@#$&()*!+=:;,.?/\'')
+    else:
+        return url;
 
 def quote_url(url):
     return encode_url(unquote(url).decode('utf-8'))

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -11,7 +11,7 @@
 import re
 from functools import partial
 from urlparse import urlparse
-from urllib2 import unquote,quote
+from urllib2 import unquote, quote
 
 import tornado.httpclient
 
@@ -19,11 +19,13 @@ from . import LoaderResult
 from thumbor.utils import logger
 from tornado.concurrent import return_future
 
+
 def encode_url(url):
     if url == unquote(url):
-        return quote(url.encode('utf-8'),safe='~@#$&()*!+=:;,.?/\'')
+        return quote(url.encode('utf-8'), safe='~@#$&()*!+=:;,.?/\'')
     else:
-        return url;
+        return url
+
 
 def quote_url(url):
     return encode_url(unquote(url).decode('utf-8'))

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -19,7 +19,7 @@ from thumbor.engines import BaseEngine
 from thumbor.result_storages import BaseStorage
 from thumbor.utils import logger, deprecated
 from tornado.concurrent import return_future
-
+from urllib2 import unquote
 from . import ResultStorageResult
 
 
@@ -77,6 +77,7 @@ class Storage(BaseStorage):
         return abspath(path).startswith(self.context.config.RESULT_STORAGE_FILE_STORAGE_ROOT_PATH)
 
     def normalize_path(self, path):
+        path = unquote(path).decode('utf-8') 
         path_segments = [self.context.config.RESULT_STORAGE_FILE_STORAGE_ROOT_PATH.rstrip('/'), Storage.PATH_FORMAT_VERSION, ]
         if self.is_auto_webp:
             path_segments.append("webp")

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -77,7 +77,7 @@ class Storage(BaseStorage):
         return abspath(path).startswith(self.context.config.RESULT_STORAGE_FILE_STORAGE_ROOT_PATH)
 
     def normalize_path(self, path):
-        path = unquote(path).decode('utf-8') 
+        path = unquote(path).decode('utf-8')
         path_segments = [self.context.config.RESULT_STORAGE_FILE_STORAGE_ROOT_PATH.rstrip('/'), Storage.PATH_FORMAT_VERSION, ]
         if self.is_auto_webp:
             path_segments.append("webp")


### PR DESCRIPTION
encodes special characters, except: , / ? : @ & = + $ like javascript function encodeURI() in http loader
