### PR TITLE
Remove useless shebang in thumbor.conf

### DIFF
--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 from os.path import expanduser, join


### PR DESCRIPTION
The file's permissions don't show it as executable anyway