### PR TITLE
measure the size of the images loaded via http

### DIFF
--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -77,6 +77,7 @@ def return_contents(response, url, callback, context):
                 context.metrics.timing('original_image.time_info.' + x, response.time_info[x] * 1000)
             context.metrics.timing('original_image.time_info.bytes_per_second', len(response.body) / response.time_info['total'])
         result.buffer = response.body
+        context.metrics.incr('original_image.response_bytes', len(response.body))
 
     callback(result)
 


### PR DESCRIPTION
we recently had an incident where the resource-consumption of our thumbor cluster skyrocketed and we assume that it was because of increased sizes of images that are fetched from S3. having the size of the response body would have been a great help to triage the issue.