### PR TITLE
why is this calculated twice?

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -545,9 +545,6 @@ class BaseHandler(tornado.web.RequestHandler):
         self.context.config.PRESERVE_EXIF_INFO = True
 
         try:
-            mime = BaseEngine.get_mimetype(fetch_result.buffer)
-            self.context.request.extension = extension = EXTENSION.get(mime, None)
-
             if mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
                 self.context.request.engine = self.context.modules.gif_engine
             else:

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -539,7 +539,7 @@ class BaseHandler(tornado.web.RequestHandler):
         if mime is None:
             mime = BaseEngine.get_mimetype(fetch_result.buffer)
 
-        self.context.request.extension = EXTENSION.get(mime, '.jpg')
+        self.context.request.extension = extension = EXTENSION.get(mime, '.jpg')
 
         original_preserve = self.context.config.PRESERVE_EXIF_INFO
         self.context.config.PRESERVE_EXIF_INFO = True


### PR DESCRIPTION
is there any reason why `mime` and `context.request.extension` are calculated twice within 10 lines of code with slight variations?

```python
         if mime is None:
             mime = BaseEngine.get_mimetype(fetch_result.buffer)
 
         self.context.request.extension = EXTENSION.get(mime, '.jpg')
 
         original_preserve = self.context.config.PRESERVE_EXIF_INFO
          self.context.config.PRESERVE_EXIF_INFO = True
  
          try:
            mime = BaseEngine.get_mimetype(fetch_result.buffer)
            self.context.request.extension = extension = EXTENSION.get(mime, None)
```