### PR TITLE
fix unquote path on file loader

### DIFF
--- a/thumbor/loaders/file_loader.py
+++ b/thumbor/loaders/file_loader.py
@@ -13,11 +13,15 @@ from datetime import datetime
 from os import fstat
 from os.path import join, exists, abspath
 from tornado.concurrent import return_future
+from urllib2 import unquote
+
 
 
 @return_future
 def load(context, path, callback):
-    file_path = join(context.config.FILE_LOADER_ROOT_PATH.rstrip('/'), path.lstrip('/'))
+
+    file_path = unquote(path).decode('utf-8')
+    file_path = join(context.config.FILE_LOADER_ROOT_PATH.rstrip('/'), file_path.lstrip('/'))
     file_path = abspath(file_path)
     inside_root_path = file_path.startswith(context.config.FILE_LOADER_ROOT_PATH)
 


### PR DESCRIPTION
FIle loader don't unquote urls with special characters, `http://localhost:8888/unsafe/700xorig/viva%20espa%C3%B1a.jpg` try to get `/tmp/viva%20espa%C3%B1a.jpg` in the file system and not `/tmp/viva\ españa.jpg`
