### PR TITLE
Fixing bug when sending a quoted char on a hash

### DIFF
--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -224,6 +224,11 @@ class ImagingOperationsTestCase(BaseImagingTestCase):
         expect(response.code).to_equal(200)
         expect(response.body).to_be_similar_to(alabama1())
 
+    def test_url_with_encoded_hash(self):
+        url = '/%D1%80=/alabama1_ap620%C3%A9.jpg'
+        response = self.fetch(url)
+        expect(response.code).to_equal(400)
+
     def test_image_with_spaces_on_url(self):
         response = self.fetch(u'/unsafe/image%20space.jpg')
         expect(response.code).to_equal(200)

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -63,8 +63,14 @@ class ImagingHandler(ContextHandler):
         if url_signature:
             signer = self.context.modules.url_signer(self.context.server.security_key)
 
+            try:
+                quoted_hash = quote(self.context.request.hash)
+            except KeyError:
+                self._error(400, 'Invalid hash: %s' % self.context.request.hash)
+                return
+
             url_to_validate = url.replace('/%s/' % self.context.request.hash, '') \
-                .replace('/%s/' % quote(self.context.request.hash), '')
+                .replace('/%s/' % quote(quoted_hash), '')
 
             valid = signer.validate(unquote(url_signature), url_to_validate)
 


### PR DESCRIPTION
So, I've got a problem. When someone sent a hash with a quoted char like %D1%80 the request would not finish and no log output would be printed.

The fix tries to call the quote function on a try except block and treats the error, if it happens, the thumbor way.