### PR TITLE
Allow loader failures to 500

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -154,7 +154,7 @@ class BaseHandler(tornado.web.RequestHandler):
                     # Return a Gateway Timeout status if upstream timed out (i.e. 599)
                     self._error(504)
                     return
-                elif result.engine_error == EngineResult.COULD_NOT_LOAD_IMAGE:
+                elif hasattr(result, 'engine_error') and result.engine_error == EngineResult.COULD_NOT_LOAD_IMAGE:
                     self._error(400)
                     return
                 else:


### PR DESCRIPTION
If a loader error happens and it's not a 404, a 502 nor a 504, currently an AttributeError will happen on that condition, because engine_error doesn't exist for a FetchResult in the loader case.
