### PR TITLE
Fix invalid response bytes metric reporting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ tests_require = [
     "yanc",
     "remotecv",
     "pyssim",
-    "cairosvg!=1.0.21",
+    "cairosvg>=1.0.0,<2.0.0,!=1.0.21",
     "preggy>=1.3.0",
 ]
 


### PR DESCRIPTION
`PIL.Image.tobytes` returns [raw (uncompressed) bytes](https://pillow.readthedocs.io/en/3.4.x/reference/Image.html#PIL.Image.Image.tobytes). It's not the same as actual compressed (jpg/webp...) image would be.

Problem in logs: 
> thumbor:DEBUG METRICS: inc: result_storage.bytes_read:33574
thumbor:DEBUG METRICS: inc: response.bytes.webp:907500


test failures probably not related to this PR