### PR TITLE
Fix gif output and optimize Vary header logic

### DIFF
--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -424,32 +424,54 @@ class ImageOperationsWithAutoWebPTestCase(BaseImagingTestCase):
         response = self.get_as_webp('/unsafe/0x0:1681x596/1x/image.jpg')
 
         expect(response.code).to_equal(200)
+        expect(response.headers).to_include('Vary')
+        expect(response.headers['Vary']).to_include('Accept')
         expect(response.body).to_be_webp()
 
     def test_should_convert_monochromatic_jpeg(self):
         response = self.get_as_webp('/unsafe/grayscale.jpg')
         expect(response.code).to_equal(200)
+        expect(response.headers).to_include('Vary')
+        expect(response.headers['Vary']).to_include('Accept')
         expect(response.body).to_be_webp()
 
     def test_should_convert_cmyk_jpeg(self):
         response = self.get_as_webp('/unsafe/cmyk.jpg')
         expect(response.code).to_equal(200)
+        expect(response.headers).to_include('Vary')
+        expect(response.headers['Vary']).to_include('Accept')
         expect(response.body).to_be_webp()
 
     def test_shouldnt_convert_cmyk_jpeg_if_format_specified(self):
         response = self.get_as_webp('/unsafe/filters:format(png)/cmyk.jpg')
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include('Vary')
         expect(response.body).to_be_png()
 
     def test_shouldnt_convert_cmyk_jpeg_if_gif(self):
         response = self.get_as_webp('/unsafe/filters:format(gif)/cmyk.jpg')
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include('Vary')
         expect(response.body).to_be_gif()
 
-    def test_shouldnt_convert_cmyk_if_format_specified(self):
+    def test_shouldnt_convert_if_format_specified(self):
         response = self.get_as_webp('/unsafe/filters:format(gif)/image.jpg')
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include('Vary')
         expect(response.body).to_be_gif()
+
+    def test_shouldnt_add_vary_if_format_specified(self):
+        response = self.get_as_webp('/unsafe/filters:format(webp)/image.jpg')
+        expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include('Vary')
+        expect(response.body).to_be_webp()
+
+    def test_should_add_vary_if_format_invalid(self):
+        response = self.get_as_webp('/unsafe/filters:format(asdf)/image.jpg')
+        expect(response.code).to_equal(200)
+        expect(response.headers).to_include('Vary')
+        expect(response.headers['Vary']).to_include('Accept')
+        expect(response.body).to_be_webp()
 
     def test_converting_return_etags(self):
         response = self.get_as_webp('/unsafe/image.jpg')
@@ -501,7 +523,6 @@ class ImageOperationsWithAutoWebPWithResultStorageTestCase(BaseImagingTestCase):
         expect(response.headers).to_include('Vary')
         expect(response.headers['Vary']).to_include('Accept')
         expect(response.body).to_be_webp()
-        expect(self.context.request.engine.extension).to_equal('.webp')
 
     @patch('thumbor.handlers.Context')
     def test_can_auto_convert_unsafe_jpeg_from_result_storage(self, context_mock):

--- a/thumbor/engines/extensions/pil.py
+++ b/thumbor/engines/extensions/pil.py
@@ -429,7 +429,7 @@ class GifWriter:
                 # Gather info
                 data = getdata(im)
 
-                imdes, data = data[0], data[1:]
+                imdes, data = b''.join(data[:-2]), data[-2:]
                 graphext = self.getGraphicsControlExt(durations[frames], disposes[frames])
                 # Make image descriptor suitable for using 256 local color palette
                 lid = self.getImageDescriptor(im, xys[frames])

--- a/thumbor/engines/gif.py
+++ b/thumbor/engines/gif.py
@@ -118,8 +118,8 @@ class Engine(PILEngine):
 
         # Make sure gifsicle produced a valid gif.
         try:
-            with Image.open(BytesIO(self.buffer)) as image:
-                image.verify()
+            with BytesIO(self.buffer) as buff:
+                Image.open(buff).verify()
         except Exception:
             self.context.metrics.incr('gif_engine.no_output')
             logger.error("[GIF_ENGINE] invalid gif engine result for url `{url}`.".format(


### PR DESCRIPTION
[this](https://github.com/thumbor/thumbor/issues/779) bug was really bothering me. Why do we want to unpack an image from result storage just to see if we should set `Vary: Accept` header. That's potentially CPU intensive operation.
So it was used to cover cases where we can not convert an image to webp:
- AUTO_WEBP is set to true in config
- browser sends Accept webp (was removed in release 6.x, still in remains master branch)
- it's animated gif
- we can convert that image to webp (checking max dimensions of an image)

Last 2 steps is where we want to load image to get it's metadata.
So, instead, my suggestion is that we check gif-file data and count number of frames in there. If there are >2 frames, then it's animated. That's much cheaper then loading the image either into Pillow or Gifsicle.
For max webp dimensions, well, worst case we'll add Vary header to a jpeg which could not be converted, but that's rather a rare edge case and I don't think there is much value sacrificing CPU load for that case.
Additionally I added a check that file we're trying to serve is actually an image file. I am not 100% sure, but I guess if we use gifv optimizer, we'll put mp4 file into result storage and then next time when we load it and try to open with engine - it'll fail anyway.
Plus one more check to see if format was strictly specified in the request, then there is no need to add Vary header.

Running tests locally, the one where it supposed to output animated gif, with Pillow 3.4 it outputs broken gif file, which then partially fixed by gifsicle and otput as not-animated. So that fixed as well.

Also fixed annoying error in logs when use gifsicle engine where after Image.verify it tries to close a file.

@masom you might be interested in this.