### PR TITLE
Fixed unhandled "'NoneType' object has no attribute 'mode'" detector exceptions

### DIFF
--- a/thumbor/detectors/face_detector/__init__.py
+++ b/thumbor/detectors/face_detector/__init__.py
@@ -25,7 +25,10 @@ class Detector(CascadeLoaderDetector):
         return top
 
     def detect(self, callback):
-        features = self.get_features()
+        try:
+            features = self.get_features()
+        except Exception:
+            features = None
 
         if features:
             for (left, top, width, height), neighbors in features:

--- a/thumbor/detectors/face_detector/__init__.py
+++ b/thumbor/detectors/face_detector/__init__.py
@@ -10,6 +10,7 @@
 
 from thumbor.detectors.local_detector import CascadeLoaderDetector
 from thumbor.point import FocalPoint
+from thumbor.utils import logger
 
 HAIR_OFFSET = 0.12
 
@@ -28,7 +29,9 @@ class Detector(CascadeLoaderDetector):
         try:
             features = self.get_features()
         except Exception:
-            features = None
+            logger.warn('Error during face detection; skipping to next detector')
+            self.next(callback)
+            return
 
         if features:
             for (left, top, width, height), neighbors in features:

--- a/thumbor/detectors/feature_detector/__init__.py
+++ b/thumbor/detectors/feature_detector/__init__.py
@@ -19,12 +19,16 @@ class Detector(BaseDetector):
 
     def detect(self, callback):
         engine = self.context.modules.engine
-        img = np.array(
-            engine.convert_to_grayscale(
-                update_image=False,
-                with_alpha=False
+        try:
+            img = np.array(
+                engine.convert_to_grayscale(
+                    update_image=False,
+                    with_alpha=False
+                )
             )
-        )
+        except Exception:
+            self.next(callback)
+            return
 
         points = cv2.goodFeaturesToTrack(
             img,

--- a/thumbor/detectors/feature_detector/__init__.py
+++ b/thumbor/detectors/feature_detector/__init__.py
@@ -13,6 +13,7 @@ import numpy as np
 
 from thumbor.detectors import BaseDetector
 from thumbor.point import FocalPoint
+from thumbor.utils import logger
 
 
 class Detector(BaseDetector):
@@ -27,6 +28,7 @@ class Detector(BaseDetector):
                 )
             )
         except Exception:
+            logger.warn('Error during feature detection; skipping to next detector')
             self.next(callback)
             return
 


### PR DESCRIPTION
Unhandled exceptions inside the face and feature detectors cause HTTP connections to hang and 'Future exception was never retrieved' tornado error messages to be logged.

Example problem image:
http://s3-eu-west-1.amazonaws.com/nrcapp/cbf1017e5d2f798d48f5cf07bc428f0b12835e9e

This PR handles the exception by going to the next detector and replaces https://github.com/thumbor/thumbor/pull/812 because I messed that one up.

This problem only seems to occur when USE_GIFSICLE_ENGINE = True and when using the Metadata Endpoint.