### PR TITLE
Added Access-Control-Allow-Origin header to client response

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -375,6 +375,11 @@ class BaseHandler(tornado.web.RequestHandler):
             self.set_header('Cache-Control', 'max-age=' + str(max_age) + ',public')
             self.set_header('Expires', datetime.datetime.utcnow() + datetime.timedelta(seconds=max_age))
 
+        if self.context.config.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER:
+            ac_header = self.context.config.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER
+            self.set_header('Access-Control-Allow-Origin', ac_header)
+            logger.debug('CORS header found. Set to: %s' % ac_header)
+
         self.set_header('Server', 'Thumbor/%s' % __version__)
         self.set_header('Content-Type', content_type)
 

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -375,7 +375,7 @@ class BaseHandler(tornado.web.RequestHandler):
             self.set_header('Cache-Control', 'max-age=' + str(max_age) + ',public')
             self.set_header('Expires', datetime.datetime.utcnow() + datetime.timedelta(seconds=max_age))
 
-        if self.context.config.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER:
+        if hasattr(self.context.config, 'ACCESS_CONTROL_ALLOW_ORIGIN_HEADER'):
             ac_header = self.context.config.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER
             self.set_header('Access-Control-Allow-Origin', ac_header)
             logger.debug('CORS header found. Set to: %s' % ac_header)

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -51,6 +51,9 @@ MAX_AGE_TEMP_IMAGE = 0
 # Sends If-Modified-Since & Last-Modified headers; requires support from result storage
 SEND_IF_MODIFIED_LAST_MODIFIED_HEADERS = False
 
+# Sets the  Access-Control-Allow-Origin header
+# ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = '*'
+
 # the way images are to be loaded
 LOADER = 'thumbor.loaders.http_loader'
 #LOADER = 'thumbor.loaders.file_loader'


### PR DESCRIPTION
Added CORS header in order to allow various HTML5 canvas functionality.

https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image