### PR TITLE
fixing "'Engine' object has no attribute 'exif'" exception logging

### DIFF
--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -227,6 +227,9 @@ class BaseEngine(object):
         return round(float(new_width) * height / width, 0)
 
     def _get_exif_segment(self):
+        if (not hasattr(self, 'exif')) or self.exif is None:
+            return None
+
         try:
             segment = ExifSegment(None, None, self.exif, 'ro')
         except Exception:
@@ -243,9 +246,6 @@ class BaseEngine(object):
         :return: Orientation value (1 - 8)
         :rtype: int or None
         """
-        if (not hasattr(self, 'exif')) or self.exif is None:
-            return None
-
         segment = self._get_exif_segment()
         if segment:
             orientation = segment.primary['Orientation']
@@ -262,6 +262,9 @@ class BaseEngine(object):
         :type override_exif: Boolean
         """
         orientation = self.get_orientation()
+
+        if orientation is None:
+            return
 
         if orientation == 2:
             self.flip_horizontally()


### PR DESCRIPTION
the get_orientation() method is testing for the exif attribute/data
but the reorientation() method is later on doing a test which isn't
correct so it still tried to call the _get_exif_segment() method.

* fixes wrong 'if' statement `if orientation != 1 and override_exif:`
  which was also `true` in case there is no exif information at all
  by completly avoiding the reorientation logic if `orientation is None`
  (might improve performance a little bit)
* moved test for the `self.exif` attribute to the place it is actually
  used to avoid side effects