### PR TITLE
Send HTTP 400 if a watermark filter entity cannot be fetched, instead…

### DIFF
--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -258,6 +258,10 @@ class ImagingOperationsTestCase(BaseImagingTestCase):
         response = self.fetch('/unsafe/image_invalid.jpg')
         expect(response.code).to_equal(400)
 
+    def test_getting_invalid_watermark_returns_bad_request(self):
+        response = self.fetch('/unsafe/filters:watermark(boom.jpg,0,0,0)/image.jpg')
+        expect(response.code).to_equal(400)
+
     def test_can_read_monochromatic_jpeg(self):
         response = self.fetch('/unsafe/grayscale.jpg')
         expect(response.code).to_equal(200)

--- a/thumbor/filters/watermark.py
+++ b/thumbor/filters/watermark.py
@@ -12,6 +12,7 @@ from os.path import splitext
 from thumbor.ext.filters import _alpha
 from thumbor.filters import BaseFilter, filter_method
 from thumbor.loaders import LoaderResult
+from thumbor.utils import logger
 import tornado.gen
 import math
 
@@ -97,7 +98,10 @@ class Filter(BaseFilter):
 
     def on_fetch_done(self, result):
         if not result.successful:
-            raise tornado.web.HTTPError(422)
+            logger.warn(
+                    'bad watermark result error=%s metadata=%s' %
+                    (result.error, result.metadata))
+            raise tornado.web.HTTPError(400)
 
         if isinstance(result, LoaderResult):
             buffer = result.buffer

--- a/thumbor/filters/watermark.py
+++ b/thumbor/filters/watermark.py
@@ -96,7 +96,9 @@ class Filter(BaseFilter):
         self.callback()
 
     def on_fetch_done(self, result):
-        # TODO if result.successful is False how can the error be handled?
+        if not result.successful:
+            raise tornado.web.HTTPError(422)
+
         if isinstance(result, LoaderResult):
             buffer = result.buffer
         else:


### PR DESCRIPTION
… of throwing an error

Otherwise an error will be thrown and a 500 will be sent back to the client.