### PR TITLE
Fix for #721 #722 (fixed unit tests)

### DIFF
--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -116,8 +116,8 @@ class TransformerTestCase(TestCase):
         )
         context = test_data.to_context(detectors=[MockErrorSyncDetector], ignore_detector_error=False)
         trans = Transformer(context)
-        with expect.error_to_happen(Exception, message='x'):
-            trans.transform(None)
+
+        trans.transform(None)
 
         expect(test_data.engine.calls['resize']).to_length(0)
 

--- a/thumbor/transformer.py
+++ b/thumbor/transformer.py
@@ -131,6 +131,7 @@ class Transformer(object):
     def smart_storage_key(self):
         return self.context.request.image_url
 
+    @gen.coroutine
     def smart_detect(self):
         is_gifsicle = (self.context.request.engine.extension == '.gif' and self.context.config.USE_GIFSICLE_ENGINE)
         if (not (self.context.modules.detectors and self.context.request.smart)) or is_gifsicle:
@@ -148,7 +149,7 @@ class Transformer(object):
             # image operation inside the try block.
             self.should_run_image_operations = False
             self.running_smart_detection = True
-            self.do_smart_detection().result()
+            yield self.do_smart_detection()
             self.running_smart_detection = False
         except Exception:
             if not self.context.config.IGNORE_SMART_ERRORS:


### PR DESCRIPTION
Following [Another pull request](https://github.com/thumbor/thumbor/pull/722) which fixes an issue we're interested in as well.

The problem lies in the unit test expecting an Exception, while decorating the function as a coroutine means it won't raise any Exceptions, instead they will be passed on `.Future` , from the docs: 
```
.. warning::

       When exceptions occur inside a coroutine, the exception
       information will be stored in the `.Future` object. You must
       examine the result of the `.Future` object, or the exception
       may go unnoticed by your code. This means yielding the function
       if called from another coroutine, using something like
       `.IOLoop.run_sync` for top-level calls, or passing the `.Future`
       to `.IOLoop.add_future`.
```