### PR TITLE
adding another metrics class 'prometheus'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ install:
   - make setup
   - pip install coveralls
   - pip install cairosvg
+  - pip install prometheus_client
 before_script:
   - make redis
 script:

--- a/tests/metrics/test_prometheus_metrics.py
+++ b/tests/metrics/test_prometheus_metrics.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from preggy import expect
+
+from thumbor.context import Context
+from thumbor.importer import Importer
+from thumbor.config import Config
+import thumbor.metrics
+
+from tests.base import TestCase
+
+
+class PrometheusMetricsTestCase(TestCase):
+    def get_context(self):
+        conf = Config()
+        conf.METRICS = 'thumbor.metrics.prometheus_metrics'
+        imp = Importer(conf)
+        imp.import_modules()
+        return Context(None, conf, imp)
+
+    def test_should_initialize_metrics(self):
+        expect(self.context.metrics).to_be_instance_of(thumbor.metrics.prometheus_metrics.Metrics)
+
+    def test_should_not_fail_on_use(self):
+        expect(self.context.metrics.incr('test.count')).not_to_be_an_error()
+        expect(self.context.metrics.incr('test.count', 2)).not_to_be_an_error()
+        expect(self.context.metrics.timing('test.time', 100)).not_to_be_an_error()
+
+    def test_should_present_metrics(self):
+        self.context.metrics.incr('test.counter')
+        self.context.metrics.incr('test.counter', 5)
+        self.context.metrics.timing('test.timer', 150)
+        self.context.metrics.timing('test.timer', 350)
+
+        self.http_client.fetch('http://localhost:8000', self.stop)
+        response = self.wait()
+        expect(response.body).to_include('thumbor_test_counter 6')
+        expect(response.body).to_include('thumbor_test_timer_count 2')
+        expect(response.body).to_include('thumbor_test_timer_sum 500')

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -136,6 +136,7 @@ Config.define('MAX_ID_LENGTH', 32, 'Set maximum id length for images when stored
 Config.define('STATSD_HOST', None, 'Host to send statsd instrumentation to', 'Metrics')
 Config.define('STATSD_PORT', 8125, 'Port to send statsd instrumentation to', 'Metrics')
 Config.define('STATSD_PREFIX', None, 'Prefix for statsd', 'Metrics')
+Config.define('PROMETHEUS_SCRAPE_PORT', 8000, 'Port the prometheus client should listen on', 'Metrics')
 
 # FILE LOADER OPTIONS
 Config.define('FILE_LOADER_ROOT_PATH', home, 'The root path where the File Loader will try to find images', 'File Loader')

--- a/thumbor/metrics/prometheus_metrics.py
+++ b/thumbor/metrics/prometheus_metrics.py
@@ -20,23 +20,23 @@ class Metrics(BaseMetrics):
         if not hasattr(Metrics, 'http_server_started'):
             start_http_server(config.PROMETHEUS_SCRAPE_PORT)
             Metrics.http_server_started = True
-            Metrics.counters  = {}
+            Metrics.counters = {}
             Metrics.summaries = {}
 
         # hard coded mapping right now
         self.mapping = {
-                'response.status'       : ['statuscode'],
-                'response.format'       : ['extension'],
-                'response.bytes'        : ['extension'],
-                'original_image.status' : ['statuscode'],
-                'original_image.fetch'  : ['statuscode','networklocation'],
-                'response.time'         : ['statuscode_extension'],
+                'response.status': ['statuscode'],
+                'response.format': ['extension'],
+                'response.bytes': ['extension'],
+                'original_image.status': ['statuscode'],
+                'original_image.fetch': ['statuscode', 'networklocation'],
+                'response.time': ['statuscode_extension'],
         }
 
     def incr(self, metricname, value=1):
         name, labels = self.__data(metricname)
 
-        if not name in Metrics.counters:
+        if name not in Metrics.counters:
             Metrics.counters[name] = Counter(name, name, labels.keys())
 
         counter = Metrics.counters[name]
@@ -49,7 +49,7 @@ class Metrics(BaseMetrics):
     def timing(self, metricname, value):
         name, labels = self.__data(metricname)
 
-        if not name in Metrics.summaries:
+        if name not in Metrics.summaries:
             Metrics.summaries[name] = Summary(name, name, labels.keys())
 
         summary = Metrics.summaries[name]
@@ -69,10 +69,10 @@ class Metrics(BaseMetrics):
         # _ -> __
         # - -> __
         # . -> _
-        return basename.replace('_','__').replace('-','__').replace('.','_')
+        return basename.replace('_', '__').replace('-', '__').replace('.', '_')
 
     def __labels(self, name, metricname):
-        if not name in self.mapping:
+        if name not in self.mapping:
             return {}
 
         # the split('.', MAXSPLIT) is mainly necessary to get the correct
@@ -91,4 +91,3 @@ class Metrics(BaseMetrics):
             if metricname.startswith(mapped + "."):
                 metricname = mapped
         return "thumbor.{0}".format(metricname)
-

--- a/thumbor/metrics/prometheus_metrics.py
+++ b/thumbor/metrics/prometheus_metrics.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from prometheus_client import Counter, start_http_server, Summary
+from thumbor.metrics import BaseMetrics
+
+
+class Metrics(BaseMetrics):
+
+    def __init__(self, config):
+        super(Metrics, self).__init__(config)
+
+        if not hasattr(Metrics, 'http_server_started'):
+            start_http_server(config.PROMETHEUS_SCRAPE_PORT)
+            Metrics.http_server_started = True
+            Metrics.counters  = {}
+            Metrics.summaries = {}
+
+        # hard coded mapping right now
+        self.mapping = {
+                'response.status'       : ['statuscode'],
+                'response.format'       : ['extension'],
+                'response.bytes'        : ['extension'],
+                'original_image.status' : ['statuscode'],
+                'original_image.fetch'  : ['statuscode','networklocation'],
+                'response.time'         : ['statuscode_extension'],
+        }
+
+    def incr(self, metricname, value=1):
+        name, labels = self.__data(metricname)
+
+        if not name in Metrics.counters:
+            Metrics.counters[name] = Counter(name, name, labels.keys())
+
+        counter = Metrics.counters[name]
+
+        if len(labels) != 0:
+            counter = counter.labels(**labels)
+
+        counter.inc(value)
+
+    def timing(self, metricname, value):
+        name, labels = self.__data(metricname)
+
+        if not name in Metrics.summaries:
+            Metrics.summaries[name] = Summary(name, name, labels.keys())
+
+        summary = Metrics.summaries[name]
+
+        if len(labels) != 0:
+            summary = summary.labels(**labels)
+
+        summary.observe(value)
+
+    def __data(self, metricname):
+        basename = self.__basename(metricname)
+
+        return (self.__format(basename), self.__labels(basename, metricname))
+
+    def __format(self, basename):
+        # stolen from https://github.com/prometheus/statsd_exporter
+        # _ -> __
+        # - -> __
+        # . -> _
+        return basename.replace('_','__').replace('-','__').replace('.','_')
+
+    def __labels(self, name, metricname):
+        if not name in self.mapping:
+            return {}
+
+        # the split('.', MAXSPLIT) is mainly necessary to get the correct
+        # stuff for original_image.fetch where the networklocation is
+        # something like 'domain' so like 'test.com' and would be splitted at
+        # least 1 time too often
+        values = metricname.replace(name + '.', '').split('.', len(self.mapping[name])-1)
+        labels = {}
+        for index, label in enumerate(self.mapping[name]):
+            labels[label] = values[index]
+
+        return labels
+
+    def __basename(self, metricname):
+        for mapped in self.mapping.keys():
+            if metricname.startswith(mapped + "."):
+                metricname = mapped
+        return "thumbor.{0}".format(metricname)
+


### PR DESCRIPTION
this is an initial implementation for the prometheus exporter and will
be accessible on the configurable port PROMETHEUS_SCRAPE_PORT (default
8000)

the class tries to determine the labels (see
https://prometheus.io/docs/practices/naming/) while using a hardcoded
mapping and will prefix everything with "thumbor." to fit more the
prometheus standard