### PR TITLE
changing description of fit-in

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -83,7 +83,7 @@ This is very useful when you need to fit an image somewhere, but you
 have no idea about the original image dimensions.
 
 Keep in mind that it won't enlarge your image in case it is smaller than
-the specified "E" withd and "F" height! One way of getting the image in the
+the specified "E" width and "F" height! One way of getting the image in the
 size requested is to use the :doc:`filling` filter.
 
 Image Size

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -64,8 +64,8 @@ Fit in
 ~~~~~~
 
 The fit-in argument specifies that the image should not be auto-cropped
-and auto-resized to be **EXACTLY** the specified size, and should be fit
-in an imaginary box of "E" width and "F" height, instead.
+but auto-resized (shrinked) to fit in an imaginary box of "E" width and
+"F" height, instead.
 
 Consider an image of 800px x 600px, and a fit of 300px x 200px. This is
 how thumbor would resize it:
@@ -81,6 +81,10 @@ how thumbor would resize it:
 
 This is very useful when you need to fit an image somewhere, but you
 have no idea about the original image dimensions.
+
+Keep in mind that it won't enlarge your image in case it is smaller than
+the specified "E" withd and "F" height! One way of getting the image in the
+size requested is to use the :doc:`filling` filter.
 
 Image Size
 ~~~~~~~~~~


### PR DESCRIPTION
@masom can you check if this is correct what I'm writing there? Also two things:

1) is adaptive-fit-in and full-fit-in deprecated or why isn't it in the docs anymore? (if it should be in again, then I can say that I don't get the explanation in the old wiki.. or at least the result is different than the explanation, like there is never a `cropping` but this is said in the wiki)
2) maybe I missed it, but is there any way to specify a box WxH where images are either shrinked (like fit-in is doing) or upscaled to this box so that it keeps the ratio but will always use the maximum space in the box available?