### PR TITLE
fixes #808 - requests hangs in engine.read exception

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -333,6 +333,22 @@ class ThreadPoolTestCase(TestCase):
         instance._execute_in_foreground(add, handle_operation)
         expect(self.handled).to_be_true()
 
+    def test_can_run_task_in_foreground_and_exception_happens(self):
+        instance = ThreadPool.instance(0)
+        expect(instance).not_to_be_null()
+        exception = Exception('Boom')
+
+        def add():
+            raise exception
+
+        def handle_operation(result):
+            self.handled = True
+            with expect.error_to_happen(Exception, message='Boom'):
+                result.result()
+
+        instance._execute_in_foreground(add, handle_operation)
+        expect(self.handled).to_be_true()
+
     def test_queueing_task_when_no_pool_runs_sync(self):
         instance = ThreadPool.instance(0)
         expect(instance).not_to_be_null()
@@ -357,7 +373,8 @@ class ThreadPoolTestCase(TestCase):
 
         def handle_operation(result):
             self.handled = True
-            expect(result.result()).to_equal(exception)
+            with expect.error_to_happen(Exception, message='Boom'):
+                result.result()
 
         instance.queue(add, handle_operation)
         expect(self.handled).to_be_true()

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -263,12 +263,13 @@ class ThreadPool(object):
     def _execute_in_foreground(self, operation, callback):
         result = Future()
         returned = None
+
         try:
             returned = operation()
         except Exception as e:
-            # just log exception and release ioloop
+            # just release ioloop
             returned = e
-            logger.exception(e)
+
         result.set_result(returned)
         callback(result)
 

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -13,7 +13,6 @@ import tornado
 from concurrent.futures import ThreadPoolExecutor, Future
 import functools
 
-from thumbor.utils import logger
 from thumbor.filters import FiltersFactory
 from thumbor.metrics.logger_metrics import Metrics
 

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -266,10 +266,10 @@ class ThreadPool(object):
         try:
             returned = operation()
         except Exception as e:
-            # just release ioloop
-            returned = e
+            result.set_exception(e)
+        else:
+            result.set_result(returned)
 
-        result.set_result(returned)
         callback(result)
 
     def _execute_in_pool(self, operation, callback):

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -380,7 +380,7 @@ class BaseHandler(tornado.web.RequestHandler):
             try:
                 future_result = future.result()
             except Exception as e:
-                logger.exception(future_result)
+                logger.exception(e)
                 self._error(500)
                 return
 

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -378,16 +378,8 @@ class BaseHandler(tornado.web.RequestHandler):
 
         def inner(future):
             try:
-                # depending of ENGINE_THREADPOOLSIZE >0 or ==0 the
-                # future.result() is calling the corresponding
-                # operation right here, so an exception can occur here
-                # or it was already been called and the result() is simply
-                # returning the already cached result
                 future_result = future.result()
             except Exception as e:
-                future_result = e
-
-            if isinstance(future_result, Exception):
                 logger.exception(future_result)
                 self._error(500)
                 return

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -380,8 +380,8 @@ class BaseHandler(tornado.web.RequestHandler):
             try:
                 # depending of ENGINE_THREADPOOLSIZE >0 or ==0 the
                 # future.result() is calling the corresponding
-                # operation right here, so exception can occur here or
-                # it was already called and the result() is simply
+                # operation right here, so an exception can occur here
+                # or it was already been called and the result() is simply
                 # returning the already cached result
                 future_result = future.result()
             except Exception as e:


### PR DESCRIPTION
in case an exception is thrown inside the engine.read() method the
exception was either not catched properly (in case the THREADPOOL size
is >0) or the result was not a tuple and the unpacking waits for more
data while calling .result() (in case the THREADPOOL size is 0)