### PR TITLE
fix exception with smart detection + gif + meta endpoint

### DIFF
--- a/thumbor/engines/json_engine.py
+++ b/thumbor/engines/json_engine.py
@@ -18,6 +18,7 @@ class JSONEngine(BaseEngine):
     def __init__(self, engine, path, callback_name=None):
         super(JSONEngine, self).__init__(engine.context)
         self.engine = engine
+        self.extension = engine.extension
         self.width, self.height = self.engine.size
         self.path = path
         self.callback_name = callback_name


### PR DESCRIPTION
the JSONEngine was not having the `extension` attribute stored from the
wrapped Engine which leads to the exception fixed (ignored) in #841

with the added extension part the transformer won't call smart detection
if gifsicle is enabled and it's a GIF image