### PR TITLE
never hide unexpected exceptions without logging it

### DIFF
--- a/thumbor/detectors/face_detector/__init__.py
+++ b/thumbor/detectors/face_detector/__init__.py
@@ -28,7 +28,8 @@ class Detector(CascadeLoaderDetector):
     def detect(self, callback):
         try:
             features = self.get_features()
-        except Exception:
+        except Exception as e:
+            logger.exception(e)
             logger.warn('Error during face detection; skipping to next detector')
             self.next(callback)
             return

--- a/thumbor/detectors/feature_detector/__init__.py
+++ b/thumbor/detectors/feature_detector/__init__.py
@@ -27,7 +27,8 @@ class Detector(BaseDetector):
                     with_alpha=False
                 )
             )
-        except Exception:
+        except Exception as e:
+            logger.exception(e)
             logger.warn('Error during feature detection; skipping to next detector')
             self.next(callback)
             return


### PR DESCRIPTION
in #841 the exception were caugth and ignored and only a small warning
was logged, this will not allow to debug the underlying issue (because
it was actually a fixable issue, see #883).. so now the exception is
logged as well