### PR TITLE
resync BaseEngine with existing implementations

### DIFF
--- a/tests/engines/test_gif.py
+++ b/tests/engines/test_gif.py
@@ -81,10 +81,32 @@ class GitEngineTestCase(TestCase):
         engine.load(buffer, '.gif')
         expect(engine.is_multiple()).to_be_true()
 
-    def test_is_multiple_should_returns_false_if_gif_has_many_frames(self):
+    def test_is_multiple_should_returns_false_if_gif_has_one_frame(self):
         engine = Engine(self.context)
         with open(join(STORAGE_PATH, 'animated-one-frame.gif'), 'r') as im:
             buffer = im.read()
 
         engine.load(buffer, '.gif')
         expect(engine.is_multiple()).to_be_false()
+
+    def test_convert_to_grayscale_should_update_image(self):
+        engine = Engine(self.context)
+        with open(join(STORAGE_PATH, 'animated.gif'), 'r') as im:
+            buffer = im.read()
+
+        engine.load(buffer, '.gif')
+        buffer = engine.read()
+        engine.convert_to_grayscale()
+
+        expect(buffer).not_to_equal(engine.read())
+
+    def test_convert_to_grayscale_should_not_update_image(self):
+        engine = Engine(self.context)
+        with open(join(STORAGE_PATH, 'animated.gif'), 'r') as im:
+            buffer = im.read()
+
+        engine.load(buffer, '.gif')
+        buffer = engine.read()
+        engine.convert_to_grayscale(False)
+
+        expect(buffer).to_equal(engine.read())

--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -296,16 +296,16 @@ class BaseEngine(object):
                 segment.primary['Orientation'] = [1]
                 self.exif = segment.get_data()
 
-    def gen_image(self):
+    def gen_image(self, size, color):
         raise NotImplementedError()
 
-    def create_image(self):
+    def create_image(self, buffer):
         raise NotImplementedError()
 
-    def crop(self):
+    def crop(self, left, top, right, bottom):
         raise NotImplementedError()
 
-    def resize(self):
+    def resize(self, width, height):
         raise NotImplementedError()
 
     def focus(self, points):
@@ -317,13 +317,16 @@ class BaseEngine(object):
     def flip_vertically(self):
         raise NotImplementedError()
 
-    def rotate(self, amount):
+    def rotate(self, degrees):
         """
         Rotates the image the given amount CCW.
-        :param amount: Amount to rotate in degrees.
+        :param degrees: Amount to rotate in degrees.
         :type amount: int
         """
         pass
+
+    def read_multiple(self, images, extension=None):
+        raise NotImplementedError()
 
     def read(self, extension, quality):
         raise NotImplementedError()
@@ -339,7 +342,7 @@ class BaseEngine(object):
             BRG, BGR, RGBA, AGBR, ...  """
         raise NotImplementedError()
 
-    def paste(self):
+    def paste(self, other_engine, pos, merge=True):
         raise NotImplementedError()
 
     def enable_alpha(self):
@@ -350,6 +353,12 @@ class BaseEngine(object):
 
     def strip_exif(self):
         pass
+
+    def convert_to_grayscale(self, update_image=True, alpha=True):
+        raise NotImplementedError()
+
+    def draw_rectangle(self, x, y, width, height):
+        raise NotImplementedError()
 
     def strip_icc(self):
         pass

--- a/thumbor/engines/json_engine.py
+++ b/thumbor/engines/json_engine.py
@@ -115,7 +115,7 @@ class JSONEngine(BaseEngine):
     def image_data_as_rgb(self, update_image=True):
         return self.engine.image_data_as_rgb(update_image)
 
-    def convert_to_grayscale(self):
+    def convert_to_grayscale(self, update_image=True, alpha=True):
         pass
 
     def get_frame_count(self):


### PR DESCRIPTION
BaseEngine was using methods of "engines" without even implementing them
by itself (with `raise NotImplementedException`) and others with a
complete different set of parameters than the real implementations were
using.

Also the `convert_to_grayscale` is different in the implementations so I
tried to sync them as well as good as I was able to do