### PR TITLE
ensuring no exception if filter is async

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -267,7 +267,10 @@ class FilterTestCase(PythonTestCase):
 
         fltr.context.transformer.img_operation_worker()
 
-        fltr.run()
+        def dummy_callback(*args):
+            pass
+
+        fltr.run(dummy_callback)
 
         fltr.engine.image = fltr.engine.image.convert('RGB')
 


### PR DESCRIPTION
while trying something out I realized that we get exceptions on the `watermark` filter in the background because this filter is an  `async_filter` and requires a callback. All others will ignore the callback so I think it is safe to always pass this dummy callback.

How to see the error, apply this patch:
```diff
simon@ironman:~/repos/thumbor$ git diff
diff --git a/tests/filters/test_watermark.py b/tests/filters/test_watermark.py
index 93b4022..decc1b2 100644
--- a/tests/filters/test_watermark.py
+++ b/tests/filters/test_watermark.py
@@ -54,4 +54,4 @@ class WatermarkFilterTestCase(FilterTestCase):
         image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,30,-50,60)')
         expected = self.get_fixture('watermarkSimple.jpg')
         ssim = self.get_ssim(image, expected)
-        expect(ssim).to_be_greater_than(0.98)
+        expect(ssim).to_be_greater_than(0.9999)
diff --git a/thumbor/filters/watermark.py b/thumbor/filters/watermark.py
index 5d7a73b..ab2d853 100644
--- a/thumbor/filters/watermark.py
+++ b/thumbor/filters/watermark.py
@@ -131,8 +131,12 @@ class Filter(BaseFilter):
         self.watermark_engine = self.context.modules.engine.__class__(self.context)
         self.storage = self.context.modules.storage

-        buffer = yield tornado.gen.maybe_future(self.storage.get(self.url))
-        if buffer is not None:
-            self.on_image_ready(buffer)
-        else:
-            self.context.modules.loader.load(self.context, self.url, self.on_fetch_done)
+        try:
+            buffer = yield tornado.gen.maybe_future(self.storage.get(self.url))
+            if buffer is not None:
+                self.on_image_ready(buffer)
+            else:
+                self.context.modules.loader.load(self.context, self.url, self.on_fetch_done)
+        except Exception as e:
+            logger.exception(e)
+            raise e
```

and run the tests and you will see:
```sh
test_watermark_filter_centered (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_centered_x (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_centered_y (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_repeated (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_repeated_x (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_repeated_y (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_simple (tests.filters.test_watermark.WatermarkFilterTestCase) ... FAIL

======================================================================
FAIL: test_watermark_filter_simple (tests.filters.test_watermark.WatermarkFilterTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/thumbor/tests/filters/test_watermark.py", line 57, in test_watermark_filter_simple
    expect(ssim).to_be_greater_than(0.9999)
  File "/usr/local/lib/python2.7/site-packages/preggy/core.py", line 285, in _assert_topic
    return _registered_assertions[method_name](self.topic, *args, **kw)
  File "/usr/local/lib/python2.7/site-packages/preggy/core.py", line 58, in wrapper
    func(*args, **kw)
  File "/usr/local/lib/python2.7/site-packages/preggy/core.py", line 126, in test_assertion
    raise AssertionError(err_msg)
AssertionError: Expected topic(0.98959051693426192) to be greater than 0.9999
-------------------- >> begin captured logging << --------------------
PIL.PngImagePlugin: DEBUG: STREAM IHDR 16 13
PIL.PngImagePlugin: DEBUG: STREAM iCCP 41 284
PIL.PngImagePlugin: DEBUG: iCCP profile name ICC Profile
PIL.PngImagePlugin: DEBUG: Compression method 0
PIL.PngImagePlugin: DEBUG: STREAM IDAT 337 549564
PIL.PngImagePlugin: DEBUG: STREAM IHDR 16 13
PIL.PngImagePlugin: DEBUG: STREAM IDAT 41 1921
thumbor: ERROR: 'NoneType' object is not callable
Traceback (most recent call last):
  File "/opt/thumbor/thumbor/filters/watermark.py", line 137, in watermark
    self.on_image_ready(buffer)
  File "/opt/thumbor/thumbor/filters/watermark.py", line 97, in on_image_ready
    self.callback()
  File "/opt/thumbor/thumbor/filters/__init__.py", line 175, in single_callback
    callback(*args)
TypeError: 'NoneType' object is not callable
preggy.utils: DEBUG: fetching assertion: 'to_be_greater_than'
--------------------- >> end captured logging << ---------------------
```

but with this pull request applied you will see:
```sh
test_watermark_filter_centered (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_centered_x (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_centered_y (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_repeated (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_repeated_x (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_repeated_y (tests.filters.test_watermark.WatermarkFilterTestCase) ... ok
test_watermark_filter_simple (tests.filters.test_watermark.WatermarkFilterTestCase) ... FAIL

======================================================================
FAIL: test_watermark_filter_simple (tests.filters.test_watermark.WatermarkFilterTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/thumbor/tests/filters/test_watermark.py", line 57, in test_watermark_filter_simple
    expect(ssim).to_be_greater_than(0.9999)
  File "/usr/local/lib/python2.7/site-packages/preggy/core.py", line 285, in _assert_topic
    return _registered_assertions[method_name](self.topic, *args, **kw)
  File "/usr/local/lib/python2.7/site-packages/preggy/core.py", line 58, in wrapper
    func(*args, **kw)
  File "/usr/local/lib/python2.7/site-packages/preggy/core.py", line 126, in test_assertion
    raise AssertionError(err_msg)
AssertionError: Expected topic(0.98959051693426192) to be greater than 0.9999
-------------------- >> begin captured logging << --------------------
PIL.PngImagePlugin: DEBUG: STREAM IHDR 16 13
PIL.PngImagePlugin: DEBUG: STREAM iCCP 41 284
PIL.PngImagePlugin: DEBUG: iCCP profile name ICC Profile
PIL.PngImagePlugin: DEBUG: Compression method 0
PIL.PngImagePlugin: DEBUG: STREAM IDAT 337 549564
PIL.PngImagePlugin: DEBUG: STREAM IHDR 16 13
PIL.PngImagePlugin: DEBUG: STREAM IDAT 41 1921
preggy.utils: DEBUG: fetching assertion: 'to_be_greater_than'
--------------------- >> end captured logging << ---------------------
```