### PR TITLE
using the content detection to determine  extension

### DIFF
--- a/tests/filters/test_distributed_collage.py
+++ b/tests/filters/test_distributed_collage.py
@@ -21,7 +21,7 @@ class DistributedCollageFilterTestCase(FilterTestCase):
         '800px-Christophe_Henner_-_June_2016.jpg',
         '800px-Coffee_berries_1.jpg',
         '800px-A_small_cup_of_coffee.JPG',
-        '513px-Coffee_beans_-_ziarna_kawy.jpg',
+        '513px-Coffee_beans_-_ziarna_kawy',
     )
 
     def test_fallback_when_have_not_enough_images(self):

--- a/tests/filters/test_watermark.py
+++ b/tests/filters/test_watermark.py
@@ -50,6 +50,12 @@ class WatermarkFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    def test_watermark_filter_detect_extension_simple(self):
+        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark,30,-50,60)')
+        expected = self.get_fixture('watermarkSimple.jpg')
+        ssim = self.get_ssim(image, expected)
+        expect(ssim).to_be_greater_than(0.98)
+
     def test_watermark_filter_simple(self):
         image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,30,-50,60)')
         expected = self.get_fixture('watermarkSimple.jpg')

--- a/tests/fixtures/filters/513px-Coffee_beans_-_ziarna_kawy
+++ b/tests/fixtures/filters/513px-Coffee_beans_-_ziarna_kawy
@@ -1,0 +1,1 @@
+513px-Coffee_beans_-_ziarna_kawy.jpg

--- a/tests/fixtures/filters/watermark
+++ b/tests/fixtures/filters/watermark
@@ -1,0 +1,1 @@
+watermark.png

--- a/thumbor/filters/distributed_collage.py
+++ b/thumbor/filters/distributed_collage.py
@@ -6,7 +6,7 @@
 # TODO: custom alignment
 
 import math
-from os.path import abspath, dirname, isabs, join, splitext
+from os.path import abspath, dirname, isabs, join
 
 import cv2
 import numpy as np
@@ -120,7 +120,6 @@ class Picture:
     def __init__(self, url, thumbor_filter):
         self.url = url
         self.thumbor_filter = thumbor_filter
-        self.extension = splitext(url)[-1].lower()
         self.engine = None
         self.fetched = False
         self.failed = False
@@ -142,7 +141,7 @@ class Picture:
     def save_on_disc(self):
         if self.fetched:
             try:
-                self.engine.load(self.buffer, self.extension)
+                self.engine.load(self.buffer, None)
             except Exception as err:
                 self.failed = True
                 logger.exception(err)
@@ -173,7 +172,7 @@ class Picture:
 
     def process(self, canvas_width, canvas_height, size):
         try:
-            self.engine.load(self.buffer, self.extension)
+            self.engine.load(self.buffer, None)
             width, height = self.engine.size
             new_width, new_height = calc_new_size_by_height(width, height, canvas_height)
             focal_points = StandaloneFaceDetector.features_to_focal_points(

--- a/thumbor/filters/frame.py
+++ b/thumbor/filters/frame.py
@@ -8,7 +8,6 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
-from os.path import splitext
 from thumbor.ext.filters import _nine_patch
 from thumbor.filters import BaseFilter, filter_method
 from thumbor.loaders import LoaderResult
@@ -19,7 +18,7 @@ class Filter(BaseFilter):
     regex = r'(?:frame\((?P<url>.*?))'
 
     def on_image_ready(self, buffer):
-        self.nine_patch_engine.load(buffer, self.extension)
+        self.nine_patch_engine.load(buffer, None)
         self.nine_patch_engine.enable_alpha()
         self.engine.enable_alpha()
 
@@ -83,7 +82,7 @@ class Filter(BaseFilter):
         else:
             buffer = result
 
-        self.nine_patch_engine.load(buffer, self.extension)
+        self.nine_patch_engine.load(buffer, None)
         self.storage.put(self.url, self.nine_patch_engine.read())
         self.storage.put_crypto(self.url)
         self.on_image_ready(buffer)
@@ -93,7 +92,6 @@ class Filter(BaseFilter):
     def frame(self, callback, url):
         self.url = url
         self.callback = callback
-        self.extension = splitext(self.url)[-1].lower()
         self.nine_patch_engine = self.context.modules.engine.__class__(self.context)
         self.storage = self.context.modules.storage
 

--- a/thumbor/filters/watermark.py
+++ b/thumbor/filters/watermark.py
@@ -8,7 +8,6 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
-from os.path import splitext
 from thumbor.ext.filters import _alpha
 from thumbor.filters import BaseFilter, filter_method
 from thumbor.loaders import LoaderResult
@@ -21,7 +20,7 @@ class Filter(BaseFilter):
     regex = r'(?:watermark\((?P<url>.*?),(?P<x>(?:-?\d+)|center|repeat),(?P<y>(?:-?\d+)|center|repeat),(?P<alpha>[\d]*?)\))'
 
     def on_image_ready(self, buffer):
-        self.watermark_engine.load(buffer, self.extension)
+        self.watermark_engine.load(buffer, None)
         self.watermark_engine.enable_alpha()
 
         mode, data = self.watermark_engine.image_data_as_rgb()
@@ -108,7 +107,7 @@ class Filter(BaseFilter):
         else:
             buffer = result
 
-        self.watermark_engine.load(buffer, self.extension)
+        self.watermark_engine.load(buffer, None)
         self.storage.put(self.url, self.watermark_engine.read())
         self.storage.put_crypto(self.url)
         self.on_image_ready(buffer)
@@ -127,7 +126,6 @@ class Filter(BaseFilter):
         self.y = y
         self.alpha = alpha
         self.callback = callback
-        self.extension = splitext(self.url)[-1].lower()
         self.watermark_engine = self.context.modules.engine.__class__(self.context)
         self.storage = self.context.modules.storage
 


### PR DESCRIPTION
The filters were relying on the image url to contain the extension.
If no extension is given they passed an empty string to the engine which
somehow worked fine within the PIL engine but using OpenCVs engine the
extension is being used and gives back an `KeyError`.

In general the extension should be determined on the content and not
by name to not handle accidentally PNGs as GIFs or the other way around.