### PR TITLE
Remove scale option from ffmpeg - bugfix

### DIFF
--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -665,6 +665,14 @@ class ImageOperationsWithGifVTestCase(BaseImagingTestCase):
         expect(response.code).to_equal(200)
         expect(response.headers['Content-Type']).to_equal('video/webm')
 
+    def test_should_convert_animated_gif_to_video_and_force_even_dimensions(self):
+        response = self.fetch('/unsafe/meta/51x51/filters:gifv()/animated.gif')
+
+        expect(response.code).to_equal(200)
+        obj = loads(response.body)
+        expect(obj['thumbor']['target']['width']).to_equal(50)
+        expect(obj['thumbor']['target']['height']).to_equal(50)
+
 
 class ImageOperationsImageCoverTestCase(BaseImagingTestCase):
     def get_context(self):

--- a/thumbor/__init__.py
+++ b/thumbor/__init__.py
@@ -10,5 +10,5 @@
 
 '''This is the main module in thumbor'''
 
-__version__ = "6.3.1"
-__release_date__ = "27-Mar-2017"
+__version__ = "6.3.2"
+__release_date__ = "10-Apr-2017"

--- a/thumbor/optimizers/gifv.py
+++ b/thumbor/optimizers/gifv.py
@@ -49,8 +49,6 @@ class Optimizer(BaseOptimizer):
             '23',
             '-maxrate',
             '500k',
-            '-vf',
-            'scale=trunc(iw/2)*2:trunc(ih/2)*2',
             output_file,
             '-loglevel',
             'error'

--- a/thumbor/transformer.py
+++ b/thumbor/transformer.py
@@ -55,6 +55,14 @@ class Transformer(object):
             else:
                 self.target_height = self.engine.get_proportional_height(self.context.request.width)
 
+        # For gifv requests, videos can only have even number dimensions so we enforce that here.
+        # When this ffmpeg bug is fixed: https://trac.ffmpeg.org/ticket/6294
+        # we can remove this work around and restore the scale filter
+        # to the original ffmpeg command options => '-vf', 'scale=trunc(iw/2)*2:trunc(ih/2)*2'
+        if 'gifv' in self.context.request.filters:
+            self.target_width = (self.target_width // 2) * 2
+            self.target_height = (self.target_height // 2) * 2
+
     def get_target_dimensions(self):
         """
         Returns the target dimensions and calculates them if necessary.


### PR DESCRIPTION
This fixes a bug for mp4 videos (see: https://github.com/thumbor/thumbor/issues/903 and https://trac.ffmpeg.org/ticket/6294).

This PR removed the scale option from ffmpeg when converting a gif to a video. Instead, the request dimensions are munged in the transformer.py before the image is processed. It works with Pillow or Gifsicle engines.

Unfortunately, it does not fix the same issue which is present for webm videos. Removing the scale option has not affect and the last frame is still cut off. Similarly if all options are removed, making the simplest possible case `ffmpeg -i input.gif output.webm` the output still messes up the last frame duration. I can't find a solution but have submitted a bug to ffmpeg for that issue as well: https://trac.ffmpeg.org/ticket/6302 My suggestion would be to avoid using webm for now, as I have done.

If and when both bugs are fixed on the ffmpeg side, we can and should revert this change and push the responsibility of enforcing even dimensions back to ffmpeg since this restraint only applies to videos.

