### PR TITLE
Add manual garbage collection to free memory

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -617,6 +617,13 @@ Default filename for image uploaded.
 
 i.e.: ``UPLOAD_DEFAULT_FILENAME = 'image'``
 
+GC\_INTERVAL
+~~~~~~~~~~~~
+
+Set manual garbage collection interval in seconds. Defaults to None (no manual garbage collection). Try this if your Thumbor is running out of memory. May cause an increase in CPU load.
+
+i.e.: ``GC_INTERVAL=60``
+
 Example of Configuration File
 -----------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
             "futures",
             "argparse",
             "pytz",
+            "schedule",
         ],
 
         extras_require={

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -131,6 +131,7 @@ Config.define('ALLOW_UNSAFE_URL', True, 'Indicates if the /unsafe URL should be 
 Config.define('ALLOW_OLD_URLS', True, 'Indicates if encrypted (old style) URLs should be allowed', 'Security')
 Config.define('ENABLE_ETAGS', True, 'Enables automatically generated etags', 'HTTP')
 Config.define('MAX_ID_LENGTH', 32, 'Set maximum id length for images when stored', 'Storage')
+Config.define('GC_INTERVAL', None, 'Set garbage collection interval in seconds', 'Performance')
 
 # METRICS OPTIONS
 Config.define('STATSD_HOST', None, 'Host to send statsd instrumentation to', 'Metrics')

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -14,6 +14,7 @@ import datetime
 import re
 import pytz
 import traceback
+import schedule
 
 import tornado.web
 import tornado.gen as gen
@@ -394,6 +395,8 @@ class BaseHandler(tornado.web.RequestHandler):
 
             if should_store:
                 self._store_results(context, results)
+
+            schedule.run_pending()
 
         self.context.thread_pool.queue(
             operation=functools.partial(self._load_results, context),


### PR DESCRIPTION
More recent versions of thumbor have had a pretty serious problem with memory leaks of some kind. See https://github.com/thumbor/thumbor/issues/753 for discussion. I spend a non-trivial amount of time troubleshooting/investigating and testing work arounds. 

My conclusion is that we are **not** being affect by any memory issues which might exist in Pillow - that issue only affects Python 3+. Thumbor is not compatible with Python 3. My tests confirmed that.

I also dug into our request and object allocation cycles, looking for leaked objects ... but I could not find any. I did quite a bit of looking! But each time I looked, performing many thousands of requests to a local thumbor, not a single request resulted in a true memory leak. If an object was created it was able to be GC'ed and thus freed memory. This analysis does not align completely with production as we still see a leak over time but this patch which we have been running in production for about a month **DOES** dramatically increase the amount of time it takes to run the server out of memory.

Without a better solution I strongly propose this patch. The patch was initially composed by @mvdklip and he should get all the credit if it goes well. I am more than happy to let someone smarter / has a better solve but until then I think this is the best solution and should be in core thumbor.

As for concerns about CPU usage we have only seen a very small increase. Mileage will vary I'm sure. Even with some non-trivial increase in CPU for some users I still think that's better than crashing servers and tons of failed requests.

