### PR TITLE
Add background_color option to gifv 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,20 +40,24 @@ addons:
     - libopenblas-dev
     - liblapack-dev
     - python-pyexiv2
+    - yasm
 install:
   - pip install -U pip
-  - wget http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz
-    -O /tmp/ffmpeg-release.tar.xz
-  - mkdir /tmp/ffmpeg-release
-  - tar -C /tmp/ffmpeg-release --strip 1 -xvf /tmp/ffmpeg-release.tar.xz
-  - export PATH=/tmp/ffmpeg-release:$PATH
-  - ffmpeg -version
   - pip install --upgrade pip
-  - make setup
+  - cd $TRAVIS_BUILD_DIR && make setup
   - pip install coveralls
   - pip install cairosvg
+  - wget https://ffmpeg.org/releases/ffmpeg-3.2.4.tar.xz
+    -O /tmp/ffmpeg-3.2.4.tar.xz
+  - mkdir /tmp/ffmpeg-source
+  - tar -C /tmp/ffmpeg-source --strip 1 -xvf /tmp/ffmpeg-3.2.4.tar.xz
+  - cd /tmp/ffmpeg-source && ./configure --prefix=/tmp --enable-gpl --enable-libx264 --enable-libvpx
+  - cd /tmp/ffmpeg-source && make
+  - cd /tmp/ffmpeg-source && make install
+  - export PATH=/tmp/bin:$PATH
+  - ffmpeg -version
 before_script:
-  - make redis
+  - cd $TRAVIS_BUILD_DIR && make redis
 script:
   make compile_ext ci_test
 notifications:

--- a/docs/gifv.rst
+++ b/docs/gifv.rst
@@ -1,0 +1,53 @@
+gifv
+==========
+
+The gifv optimizer is able to convert gifs to mp4 or webm videos, often resulting in dramatically smaller sized files.
+
+**Gifv is categorized as experimental and should be used with caution.** It uses ffmpeg to convert gifs to videos and so it's sensitive to changes with ffmpeg. It's recommended to lock your ffmpeg version with a fixed version (chef, docker, etc) and if updating make sure to check that the update doesn't break gifv. **FFmpeg version 3.2.4 is the current recommended version.** Later version, such as 3.3 will break the proper conversion of gif delays to frame durations in videos ... meaning videos will not be the same length as equivelant gifs.
+
+To enable gifv, ensure ffmpeg is in PATH and enable the optimizer in your config:
+
+.. code-block:: python
+
+  OPTIMIZERS = [
+    'thumbor.optimizers.gifv',
+  ]
+
+Once activated, you must add the ``gifv()`` option to your filters list. An example request might look like this:
+
+.. code-block:: text
+
+  http://localhost:8888/unsafe/filters:gifv()/http://localhost/livingroom.gif
+
+The above example will default to using the mp4 video container with h264 video. You can also be explicit:
+
+.. code-block:: text
+
+  http://localhost:8888/unsafe/filters:gifv(mp4)/http://localhost/livingroom.gif
+
+or use explicitly specify webm
+
+.. code-block:: text
+
+  http://localhost:8888/unsafe/filters:gifv(webm)/http://localhost/livingroom.gif
+
+
+Because videos (in mp4 or webm format) cannot contain alpha transparency a background color will be automatically added. The default color is white. You can also specify a background color:
+
+.. code-block:: text
+
+  http://localhost:8888/unsafe/filters:gifv():background_color(ff00ff)/http://localhost/livingroom.gif
+
+.. code-block:: text
+
+  http://localhost:8888/unsafe/filters:gifv():background_color(f0f)/http://localhost/livingroom.gif
+
+
+.. code-block:: text
+
+  http://localhost:8888/unsafe/filters:gifv():background_color(magenta)/http://localhost/livingroom.gif
+
+
+The color must be specified in 6 character hex, 3 character hex or color name. But 6 or 3 character hex are the preferred formats. Including a ``#`` symbol in your color will break the url if not url encoded and thumbor will error on the request. The recommendation is to not use them at all which also makes urls shorter. But if you must a leading `%23` will probably work.
+
+

--- a/docs/imaging.rst
+++ b/docs/imaging.rst
@@ -15,3 +15,4 @@ Imaging
    lazy_detection
    posting_putting_deleting
    result_storage
+   optimizers

--- a/docs/jpegtran.rst
+++ b/docs/jpegtran.rst
@@ -1,0 +1,25 @@
+jpegtran
+==========
+
+Jpegtran is a lossless jpeg optimizer which can make your jpegs smaller by optimizing DCT coefficients. Information on jpegtran can be a bit difficult to find but the linux man page is pretty good: https://linux.die.net/man/1/jpegtran
+
+Jpegtran can be used in conjunction with Thumbor. If the optimizer has been activated, Thumbor will first process your jpeg normally then it will hand the jpeg off to jpegtran for further optimizations before Thumbor returns the final image.
+
+To use jpegtran with Thumbor you must first install jpegtran, various linux distros often provide a package by the same name or it can be installed from source. You should make sure that jpegtran is in PATH, do a `which jpegtran` and you should see an absolute path where the jpegtran resides.
+
+You also need to enable the Thumbor jpegtran optimizer in your thumbor.conf, like so:
+
+.. code-block:: python
+
+  OPTIMIZERS = [
+    'thumbor.optimizers.jpegtran'
+  ]
+
+
+You can also manually specify the jpegtran path, like this:
+
+.. code-block:: python
+
+  JPEGTRAN_PATH=/usr/local/bin/jpegtran
+
+Once activated, no extra url parameters are needed - jpegtran will run on all jpegs automatically. If you have opted to use progressive jpegs via the ``PROGRESSIVE_JPEG`` option, jpegtran will also honor and product progressive jpegs.

--- a/docs/optimizers.rst
+++ b/docs/optimizers.rst
@@ -1,0 +1,8 @@
+Optimizers
+==========
+
+.. toctree::
+   :maxdepth: 1
+
+   jpegtran
+   gifv

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
             "argparse",
             "pytz",
             "schedule",
+            "webcolors",
         ],
 
         extras_require={

--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -665,13 +665,11 @@ class ImageOperationsWithGifVTestCase(BaseImagingTestCase):
         expect(response.code).to_equal(200)
         expect(response.headers['Content-Type']).to_equal('video/webm')
 
-    def test_should_convert_animated_gif_to_video_and_force_even_dimensions(self):
-        response = self.fetch('/unsafe/meta/51x51/filters:gifv()/animated.gif')
+    def test_should_convert_animated_gif_to_mp4_with_filter_without_params(self):
+        response = self.fetch('/unsafe/filters:gifv(mp4):background_color(ff00ff)/animated.gif')
 
         expect(response.code).to_equal(200)
-        obj = loads(response.body)
-        expect(obj['thumbor']['target']['width']).to_equal(50)
-        expect(obj['thumbor']['target']['height']).to_equal(50)
+        expect(response.headers['Content-Type']).to_equal('video/mp4')
 
 
 class ImageOperationsImageCoverTestCase(BaseImagingTestCase):

--- a/tests/optimizers/test_gifv.py
+++ b/tests/optimizers/test_gifv.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from thumbor.config import Config
+from thumbor.context import Context, RequestParameters
+from thumbor.optimizers.gifv import Optimizer
+from thumbor.utils import which, EXTENSION
+
+from unittest import TestCase
+
+
+class GifvOptimizerTest(TestCase):
+    def get_context(self):
+        conf = Config()
+        conf.STATSD_HOST = ''
+        conf.FFMPEG_PATH = which('ffmpeg')
+        ctx = Context(config=conf)
+        ctx.request = RequestParameters()
+        ctx.request.filters.append('gifv')
+
+        return ctx
+
+    def test_should_run_for_gif(self):
+        optimizer = Optimizer(self.get_context())
+        self.assertTrue(optimizer.should_run('.gif', ''))
+
+    def test_should_not_run_for_not_gif(self):
+        optimizer = Optimizer(self.get_context())
+        for ext in EXTENSION.itervalues():
+            if ext != '.gif':
+                self.assertFalse(optimizer.should_run(ext, ''))
+
+    def test_should_parse_background_color_with_valid_value(self):
+        optimizer = Optimizer(self.get_context())
+        magenta_unicode_hex = u'#ff00ff'
+        self.assertEqual(optimizer.normalize_color_to_hex('ff00ff'), magenta_unicode_hex)
+        self.assertEqual(optimizer.normalize_color_to_hex('#ff00ff'), magenta_unicode_hex)
+        self.assertEqual(optimizer.normalize_color_to_hex('f0f'), magenta_unicode_hex)
+        self.assertEqual(optimizer.normalize_color_to_hex('#f0f'), magenta_unicode_hex)
+        self.assertEqual(optimizer.normalize_color_to_hex('magenta'), magenta_unicode_hex)
+
+    def test_should_not_parse_background_color_with_invalid_value(self):
+        optimizer = Optimizer(self.get_context())
+        self.assertEqual(optimizer.normalize_color_to_hex('asdfasdfasfd'), None)

--- a/thumbor/optimizers/gifv.py
+++ b/thumbor/optimizers/gifv.py
@@ -10,8 +10,11 @@
 
 import os
 import subprocess
+import re
+import webcolors
 
 from thumbor.optimizers import BaseOptimizer
+from thumbor.utils import logger
 
 
 class Optimizer(BaseOptimizer):
@@ -22,13 +25,29 @@ class Optimizer(BaseOptimizer):
     def optimize(self, buffer, input_file, output_file):
         format, command_params = self.set_format()
 
+        bg_color_hex = None
+        if 'background_color' in self.context.request.filters:
+            filters = self.context.request.filters.split(':')
+            bg_filter = [filter for filter in filters if filter.startswith('background_color')][0]
+            bg_color = re.search(r'\((.*?)\)', bg_filter).group(1)
+            bg_color_hex = self.normalize_color_to_hex(bg_color)
+
         command = [
             self.context.config.FFMPEG_PATH,
             '-y',
             '-f',
+            'lavfi',
+            '-i',
+            'color=%s' % (bg_color_hex or 'ffffff'),
+            '-f',
             'gif',
             '-i',
             input_file,
+            '-filter_complex',
+            ('[1]reverse,trim=end_frame=1[t];'
+                '[1][t]concat[g];[0][g]scale2ref[bg][gif];'
+                '[bg]setsar=1[bg];[bg][gif]overlay=shortest=1,'
+                'scale=trunc(iw/2)*2:trunc(ih/2)*2'),
             '-an',
             '-movflags',
             'faststart',
@@ -76,3 +95,22 @@ class Optimizer(BaseOptimizer):
                 '4.0'
             ]
         return format, command_params
+
+    def normalize_color_to_hex(self, color_string):
+        try:
+            return webcolors.normalize_hex("#" + color_string)
+        except ValueError:
+            pass
+
+        try:
+            return webcolors.name_to_hex(color_string)
+        except ValueError:
+            pass
+
+        try:
+            return webcolors.normalize_hex(color_string)
+        except ValueError:
+            pass
+
+        if color_string:
+            logger.error('background_color value could not be parsed')

--- a/thumbor/transformer.py
+++ b/thumbor/transformer.py
@@ -55,14 +55,6 @@ class Transformer(object):
             else:
                 self.target_height = self.engine.get_proportional_height(self.context.request.width)
 
-        # For gifv requests, videos can only have even number dimensions so we enforce that here.
-        # When this ffmpeg bug is fixed: https://trac.ffmpeg.org/ticket/6294
-        # we can remove this work around and restore the scale filter
-        # to the original ffmpeg command options => '-vf', 'scale=trunc(iw/2)*2:trunc(ih/2)*2'
-        if 'gifv' in self.context.request.filters:
-            self.target_width = (self.target_width // 2) * 2
-            self.target_height = (self.target_height // 2) * 2
-
     def get_target_dimensions(self):
         """
         Returns the target dimensions and calculates them if necessary.


### PR DESCRIPTION
This PR:
- Adds a `background_color` option which only works with gifv
- Moves the "scale to even pixel dimensions" work back to ffmpeg
- Preserves proper gif delay durations

The reason we need the background color option is that some gifs contain transparency. These transparent regions will be converted to `white` by default. But white isn't always the correct color for a websites design. ffmpeg has no simple option to change the background as far as I could tell so we use this complex filter. Since ffmpeg will fill transparency with white every time and this new command is just as fast as the old one (benchmarked locally) we just use the same command every time even if no background option is specified - we just use white like default ffmpeg would. If a background_color is specified we use that color. Web applications will need to keep track and use the appropriate color for their design. ffmpeg is a bit pickier about colors - it doesn't allow hex short code for instance. So I added `webcolors` and a clumsy but robust logic for extracting colors while maintaining color format compatibility with the color options used in the `background_color` and `fill` filters that work with pngs. **There may be a better way to do this, let me know if that's the case.**

We also reintroduce the scale option to ffmpeg as well with the complex filter. Both the scale and canvas (background color) filters are performed at the same time to avoid extra passes / processing time. This simplifies maintenance of thumbor because we only have a single command.

* This also works with transparent gifs with frames with transparency that are smaller than the full size of the gif. Using tools like imagemagic/convert handle that scenario poorly.
* This works if a gif only has only two frames. The duration specified in the gif version will be preserved in the mp4/webm version correctly. Many many other methods of converting gifs to videos do not preserve the corrected durations - including fixed frame rate methods and/or other ffmpeg scaling methods all of which will break the duration of the last frame of the gif making it shorter than it should be (a single tick).
* This does **not** add a `background_color` option to normal gifs. If present the option will simply be ignored.
* I used `background_color` instead of `fill` because the latter implies that all transparency should be filled but as mentioned this will mess up a gif with overlaying frame where a later frame doesn't take up 100% of the size of the image canvas or should appear to float over previous frames. This is a true background color option.

This PR has been tested against ffmpeg version `3.2.4` **There are known issues with using these filters with later releases such as 3.3** but earlier version may work as well. See open ffmpeg issue: https://trac.ffmpeg.org/ticket/6294 Since the gifv filter is still categorized as experimental I think it's ok to exclude some versions of ffmpeg. Hopefully ffmpeg will fix their bugs in the next release.

**Example requests with identical output:**
`http://localhost:8888/unsafe/500x0/filters:gifv():background_color(ff00ff)/http://localhost/top_pin_wide.gif`
`http://localhost:8888/unsafe/500x0/filters:gifv():background_color(f0f)/http://localhost/top_pin_wide.gif`
`http://localhost:8888/unsafe/500x0/filters:gifv():background_color(magenta)/http://localhost/top_pin_wide.gif`
`http://localhost:8888/unsafe/500x0/filters:gifv():background_color(Magenta)/http://localhost/top_pin_wide.gif`
`http://localhost:8888/unsafe/500x0/filters:gifv():background_color(MaGeNTa)/http://localhost/top_pin_wide.gif`

**Example input with transparency:**
![top_pin_wide-1](https://cloud.githubusercontent.com/assets/142910/25075021/6b2718da-22d8-11e7-8f0b-28ea2097dbb8.gif)

**Example output (mp4 converted back to gif manually, no mp4s supported in GH markdown)**
![top_pin_wide_ff00ff](https://cloud.githubusercontent.com/assets/142910/25075821/370790e6-22e9-11e7-817f-a9efd20d08ea.gif)

