### PR TITLE
added new timeout setting if using curl http client

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -190,6 +190,16 @@ Config.define(
 Config.define(
     'HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT', False,
     'If the CurlAsyncHTTPClient should be used', 'HTTP Loader')
+Config.define(
+    'HTTP_LOADER_CURL_LOW_SPEED_TIME', 0,
+    'If HTTP_LOADER_CURL_LOW_SPEED_LIMIT and HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT ' +
+    'are set, then this is the time in seconds as integer after a download should ' +
+    'timeout if the speed is below HTTP_LOADER_CURL_LOW_SPEED_LIMIT for that long')
+Config.define(
+    'HTTP_LOADER_CURL_LOW_SPEED_LIMIT', 0,
+    'If HTTP_LOADER_CURL_LOW_SPEED_TIME and HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT ' +
+    'are set, then this is the limit in bytes per second as integer which should ' +
+    'timeout if the speed is below that limit for HTTP_LOADER_CURL_LOW_SPEED_TIME seconds')
 
 # FILE STORAGE GENERIC OPTIONS
 Config.define(

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -105,8 +105,12 @@ def load(context, url, callback, normalize_url_func=_normalize_url):
 def load_sync(context, url, callback, normalize_url_func):
     using_proxy = context.config.HTTP_LOADER_PROXY_HOST and context.config.HTTP_LOADER_PROXY_PORT
     if using_proxy or context.config.HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT:
-        tornado.httpclient.AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
-    client = tornado.httpclient.AsyncHTTPClient(max_clients=context.config.HTTP_LOADER_MAX_CLIENTS)
+        http_client_implementation = 'tornado.curl_httpclient.CurlAsyncHTTPClient'
+    else:
+        http_client_implementation = None  # default
+
+    tornado.httpclient.AsyncHTTPClient.configure(http_client_implementation, max_clients=context.config.HTTP_LOADER_MAX_CLIENTS)
+    client = tornado.httpclient.AsyncHTTPClient()
 
     user_agent = None
     if context.config.HTTP_LOADER_FORWARD_USER_AGENT:
@@ -130,7 +134,8 @@ def load_sync(context, url, callback, normalize_url_func):
         ca_certs=encode(context.config.HTTP_LOADER_CA_CERTS),
         client_key=encode(context.config.HTTP_LOADER_CLIENT_KEY),
         client_cert=encode(context.config.HTTP_LOADER_CLIENT_CERT),
-        validate_cert=context.config.HTTP_LOADER_VALIDATE_CERTS
+        validate_cert=context.config.HTTP_LOADER_VALIDATE_CERTS,
+        prepare_curl_callback=_get_prepare_curl_callback(context.config)
     )
 
     start = datetime.datetime.now()
@@ -139,3 +144,18 @@ def load_sync(context, url, callback, normalize_url_func):
 
 def encode(string):
     return None if string is None else string.encode('ascii')
+
+
+def _get_prepare_curl_callback(config):
+    if config.HTTP_LOADER_CURL_LOW_SPEED_TIME == 0 or config.HTTP_LOADER_CURL_LOW_SPEED_LIMIT == 0:
+        return None
+
+    class CurlOpts:
+        def __init__(self, config):
+            self.config = config
+
+        def prepare_curl_callback(self, curl):
+            curl.setopt(curl.LOW_SPEED_TIME, self.config.HTTP_LOADER_CURL_LOW_SPEED_TIME)
+            curl.setopt(curl.LOW_SPEED_LIMIT, self.config.HTTP_LOADER_CURL_LOW_SPEED_LIMIT)
+
+    return CurlOpts(config).prepare_curl_callback

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -106,8 +106,10 @@ def load_sync(context, url, callback, normalize_url_func):
     using_proxy = context.config.HTTP_LOADER_PROXY_HOST and context.config.HTTP_LOADER_PROXY_PORT
     if using_proxy or context.config.HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT:
         http_client_implementation = 'tornado.curl_httpclient.CurlAsyncHTTPClient'
+        prepare_curl_callback = _get_prepare_curl_callback(context.config)
     else:
         http_client_implementation = None  # default
+        prepare_curl_callback = None
 
     tornado.httpclient.AsyncHTTPClient.configure(http_client_implementation, max_clients=context.config.HTTP_LOADER_MAX_CLIENTS)
     client = tornado.httpclient.AsyncHTTPClient()
@@ -135,7 +137,7 @@ def load_sync(context, url, callback, normalize_url_func):
         client_key=encode(context.config.HTTP_LOADER_CLIENT_KEY),
         client_cert=encode(context.config.HTTP_LOADER_CLIENT_CERT),
         validate_cert=context.config.HTTP_LOADER_VALIDATE_CERTS,
-        prepare_curl_callback=_get_prepare_curl_callback(context.config)
+        prepare_curl_callback=prepare_curl_callback
     )
 
     start = datetime.datetime.now()

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -196,3 +196,14 @@ ALLOW_UNSAFE_URL = True
 #]
 
 #JPEGTRAN_PATH = '/usr/local/bin/jpegtran'
+
+# If the CurlAsyncHTTPClient should be used
+# Defaults to: False
+#HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT = False
+
+# If the CurlAsyncHTTPClient is being used and
+# should timeout on slow download speed.
+# SPEED in bytes/s and TIME in s
+# Dfaults to: 0 (no timeout)
+#HTTP_LOADER_CURL_LOW_SPEED_TIME = 0
+#HTTP_LOADER_CURL_LOW_SPEED_LIMIT = 0


### PR DESCRIPTION
instead of an absolute timeout the curl http client also supports a
download-speed timeout (if for X seconds the download speed is below Y
bytes/s then abort)
this is now being configurable but disabled by default (and ignored if
the curl client isn't used)