### PR TITLE
Allow custom LoaderResult errors

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -152,6 +152,9 @@ class BaseHandler(tornado.web.RequestHandler):
                     # Return a Gateway Timeout status if upstream timed out (i.e. 599)
                     self._error(504)
                     return
+                elif isinstance(result.loader_error, int):
+                    self._error(result.loader_error)
+                    return
                 elif hasattr(result, 'engine_error') and result.engine_error == EngineResult.COULD_NOT_LOAD_IMAGE:
                     self._error(400)
                     return


### PR DESCRIPTION
Being constrained to the hardcoded list is too limiting.
Using the actual codes is also less prone to confusion.