### PR TITLE
Do not re-read image data coming from loader to store in storage

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -10,7 +10,6 @@
 
 import sys
 import functools
-import copy
 import datetime
 import re
 import pytz
@@ -595,8 +594,6 @@ class BaseHandler(tornado.web.RequestHandler):
 
         self.context.request.extension = extension = EXTENSION.get(mime, '.jpg')
 
-        original_preserve = self.context.config.PRESERVE_EXIF_INFO
-
         try:
             if mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
                 self.context.request.engine = self.context.modules.gif_engine
@@ -623,28 +620,12 @@ class BaseHandler(tornado.web.RequestHandler):
             is_mixed_no_file_storage = is_mixed_storage and isinstance(storage.file_storage, NoStorage)
 
             if not (is_no_storage or is_mixed_no_file_storage):
-                # in the case that we have local storage, it's important that we don't try
-                # and strip the exif data - so that we can make the choice about stripping
-                # it on output, instead of input.
-                # unfortunately, the only interface to the engine is the global config
-                # referenced by our context, which has the current setting of preserving
-                # the exif info or not. this is also being read by concurrent
-                # coroutine-threads, so just setting this value outright causes a race.
-                # we solve this in order not to influence these other coroutine-threads
-                # by doing an effective copy-on-write for the config until the end of this
-                # context (ie. this request).
-                # at some point in the future - the API should change, and this horrid hack
-                # should go away.
-                self.context.config = copy.deepcopy(self.context.config)
-                self.context.config.PRESERVE_EXIF_INFO = True
-                fetch_result.buffer = self.context.request.engine.read(extension)
                 storage.put(url, fetch_result.buffer)
 
             storage.put_crypto(url)
         except Exception:
             fetch_result.successful = False
         finally:
-            self.context.config.PRESERVE_EXIF_INFO = original_preserve
             if not fetch_result.successful:
                 raise
             fetch_result.buffer = None


### PR DESCRIPTION
I'm not completely sure on this change, but tests pass and that would fix some weird hidden issues it could be causing.

What's the value of calling engine.read method on buffer, containing image, which we just retrieved from loader? `engine.read` re-saves image taking current quality settings and other configuration into account, so stored copy will be different from original.
This behavior forces CMYK image with embedded CMYK ICC profile to be saved as RGB image with CMYK ICC profile. https://github.com/thumbor/thumbor/pull/927 

Also, if we save whatever bytes we fetched from loader, then we could eliminate issues like this: https://github.com/thumbor/thumbor/pull/901

Originally introduced [here](https://github.com/kkopachev/thumbor/commit/492659c5e9913f19aa653a63ceca978b35bb4c3e#diff-bfc9541389c9ec7130c9a9b3a7219ed3R54)
