### PR TITLE
This test should fail, but it does not.

### DIFF
--- a/tests/filters/test_watermark.py
+++ b/tests/filters/test_watermark.py
@@ -55,3 +55,10 @@ class WatermarkFilterTestCase(FilterTestCase):
         expected = self.get_fixture('watermarkSimple.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
+
+    def test_watermark_filter_should_fail(self):
+        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark',
+                                  'watermark(not-existing-image.png,center,center,60)')
+        expected = self.get_fixture('watermarkCenter.jpg')
+        ssim = self.get_ssim(image, expected)
+        expect(ssim).to_be_greater_than(0.98)


### PR DESCRIPTION
I tried to dig around and fix that thing, but can't find out how to do so. 
Essentially I want to test tat exception is thrown inside async filter. 

Test tries to apply non existing watermark file to an image. Filter throws exception, but it never surfaced. 
Somewhat related to https://github.com/thumbor/thumbor/pull/889