### PR TITLE
Allow pillow 4 since there were no BC breaks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
             "tornado>=4.1.0,<5.0.0",
             "pyCrypto>=2.1.0",
             "pycurl>=7.19.0,<7.44.0",
-            "Pillow>=3.0.0,<4.0.0",
+            "Pillow>=3.0.0,<5.0.0",
             "derpconf>=0.2.0",
             "pexif>=0.15,<1.0",
             "statsd>=3.0.1",


### PR DESCRIPTION
They [drop python 2.6](https://pillow.readthedocs.io/en/4.1.x/releasenotes/4.0.0.html), which is already dropped by thumbor, other changes seem insignificant. 

Tests pass locally, let's see what Travis thinks