### PR TITLE
Add new strip_exif filter in order to remove exif on demand

### DIFF
--- a/debian/thumbor.conf
+++ b/debian/thumbor.conf
@@ -166,6 +166,7 @@ ALLOW_UNSAFE_URL = True
     #'thumbor.filters.equalize',
     #'thumbor.filters.fill',
     #'thumbor.filters.sharpen',
+    #'thumbor.filters.strip_exif',
     #'thumbor.filters.strip_icc',
     #'thumbor.filters.frame',
     #'thumbor.filters.grayscale',

--- a/docs/documentation_structure.txt
+++ b/docs/documentation_structure.txt
@@ -53,6 +53,7 @@ Index (* About)
         * Rotate
         * Round corners
         * Sharpen
+        * Strip exif
         * Strip icc
         * Watermark
     Releases

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -36,6 +36,7 @@ Filters
    rotate
    round_corners
    sharpen
+   strip_exif
    strip_icc
    upscale
    watermark

--- a/docs/strip_exif.rst
+++ b/docs/strip_exif.rst
@@ -1,0 +1,22 @@
+Strip EXIF
+=========
+
+Usage: strip\_exif()
+
+Description
+-----------
+
+This filter removes any Exif information in the resulting image.
+This is useful if you have set the configuration PRESERVE_EXIF_INFO = True but still wish to overwrite this behavior in some cases 
+(e.g. for image icons)
+
+
+Arguments
+---------
+
+No arguments
+
+Example
+-------
+
+`<http://localhost:8888/unsafe/filters:strip\_exif()/http://www.arte.tv/static-epgapi/057460-011-A.jpg>`_

--- a/integration_tests/urls_helpers.py
+++ b/integration_tests/urls_helpers.py
@@ -75,6 +75,7 @@ filters = [
     'filters:round_corner(20,255,255,100)',
     'filters:sharpen(6,2.5,false)',
     'filters:sharpen(6,2.5,true)',
+    'filters:strip_exif()',
     'filters:strip_icc()',
     'filters:watermark(rgba-interlaced.png,10,10,50)',
     'filters:watermark(rgba-interlaced.png,center,center,50)',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,6 +69,7 @@ class ConfigValuesTestCase(TestCase):
                 'thumbor.filters.equalize',
                 'thumbor.filters.fill',
                 'thumbor.filters.sharpen',
+                'thumbor.filters.strip_exif',
                 'thumbor.filters.strip_icc',
                 'thumbor.filters.frame',
                 'thumbor.filters.grayscale',

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -308,6 +308,7 @@ Config.define(
         'thumbor.filters.equalize',
         'thumbor.filters.fill',
         'thumbor.filters.sharpen',
+        'thumbor.filters.strip_exif',
         'thumbor.filters.strip_icc',
         'thumbor.filters.frame',
         'thumbor.filters.grayscale',

--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -348,6 +348,9 @@ class BaseEngine(object):
     def image_data_as_rgb(self, update_image=True):
         raise NotImplementedError()
 
+    def strip_exif(self):
+        pass
+
     def strip_icc(self):
         pass
 

--- a/thumbor/engines/json_engine.py
+++ b/thumbor/engines/json_engine.py
@@ -97,6 +97,9 @@ class JSONEngine(BaseEngine):
     def enable_alpha(self):
         return self.engine.enable_alpha()
 
+    def strip_exif(self):
+        return self.engine.strip_exif()
+
     def strip_icc(self):
         return self.engine.strip_icc()
 

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -378,3 +378,6 @@ class Engine(BaseEngine):
 
     def strip_icc(self):
         self.icc_profile = None
+
+    def strip_exif(self):
+        self.exif = None

--- a/thumbor/filters/strip_exif.py
+++ b/thumbor/filters/strip_exif.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from thumbor.filters import BaseFilter, filter_method
+
+
+class Filter(BaseFilter):
+
+    @filter_method()
+    def strip_exif(self):
+        self.engine.strip_exif()

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -176,6 +176,7 @@ ALLOW_UNSAFE_URL = True
     #'thumbor.filters.fill',
     #'thumbor.filters.saturation',
     #'thumbor.filters.sharpen',
+    #'thumbor.filters.strip_exif',
     #'thumbor.filters.strip_icc',
     #'thumbor.filters.frame',
     #'thumbor.filters.grayscale',


### PR DESCRIPTION
This filter removes any Exif information in the resulting image.
This is useful if you have set the configuration PRESERVE_EXIF_INFO = True but still wish to overwrite this behaviour in some cases (e.g. for image icons)