### PR TITLE
Add options to allow header forwarding for the HTTP_Loader

### DIFF
--- a/tests/loaders/test_http_loader.py
+++ b/tests/loaders/test_http_loader.py
@@ -38,6 +38,12 @@ class EchoUserAgentHandler(tornado.web.RequestHandler):
         self.write(self.request.headers['User-Agent'])
 
 
+class EchoAllHeadersHandler(tornado.web.RequestHandler):
+    def get(self):
+        for header, value in sorted(self.request.headers.iteritems()):
+            self.write("%s:%s\n" % (header, value))
+
+
 class HandlerMock(object):
     def __init__(self, headers):
         self.request = RequestMock(headers)
@@ -213,6 +219,65 @@ class HttpLoaderTestCase(TestCase):
 
         future = loader.load(ctx, url)
         expect(isinstance(future, Future)).to_be_true()
+
+
+class HttpLoaderWithHeadersForwardingTestCase(TestCase):
+
+    def get_app(self):
+        application = tornado.web.Application([
+            (r"/", EchoAllHeadersHandler),
+        ])
+
+        return application
+
+    def test_load_with_some_headers(self):
+        url = self.get_url('/')
+        config = Config()
+        config.HTTP_LOADER_FORWARD_HEADERS_WHITELIST = ["X-Server"]
+        handler_mock_options = {
+            "Accept-Encoding": "gzip",
+            "User-Agent": "Thumbor",
+            "Host": "localhost",
+            "Accept": "*/*",
+            "X-Server": "thumbor"
+        }
+        ctx = Context(None, config, None, HandlerMock(handler_mock_options))
+
+        loader.load(ctx, url, self.stop)
+        result = self.wait()
+        expect(result).to_be_instance_of(LoaderResult)
+        expect(result.buffer).to_include("X-Server:thumbor")
+
+    def test_load_with_some_excluded_headers(self):
+        url = self.get_url('/')
+        config = Config()
+        handler_mock_options = {
+            "Accept-Encoding": "gzip",
+            "User-Agent": "Thumbor",
+            "Host": "localhost",
+            "Accept": "*/*",
+            "X-Server": "thumbor"
+        }
+        ctx = Context(None, config, None, HandlerMock(handler_mock_options))
+
+        loader.load(ctx, url, self.stop)
+        result = self.wait()
+        expect(result).to_be_instance_of(LoaderResult)
+        expect(result.buffer).Not.to_include("X-Server:thumbor")
+
+    def test_load_with_all_headers(self):
+        url = self.get_url('/')
+        config = Config()
+        config.HTTP_LOADER_FORWARD_ALL_HEADERS = True
+        handler_mock_options = {"X-Test": "123", "DNT": "1", "X-Server": "thumbor"}
+        ctx = Context(None, config, None, HandlerMock(handler_mock_options))
+
+        loader.load(ctx, url, self.stop)
+        result = self.wait()
+        expect(result).to_be_instance_of(LoaderResult)
+        expect(result.buffer).to_include("Dnt:1\n")
+        expect(result.buffer).to_include("X-Server:thumbor\n")
+        expect(result.buffer).to_include("X-Test:123\n")
 
 
 class HttpLoaderWithUserAgentForwardingTestCase(TestCase):

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -160,6 +160,12 @@ Config.define(
     'HTTP_LOADER_FORWARD_USER_AGENT', False,
     'Indicates whether thumbor should forward the user agent of the requesting user', 'HTTP Loader')
 Config.define(
+    'HTTP_LOADER_FORWARD_ALL_HEADERS', False,
+    'Indicates whether thumbor should forward the headers of the request', 'HTTP Loader')
+Config.define(
+    'HTTP_LOADER_FORWARD_HEADERS_WHITELIST', [],
+    'Indicates which headers should be forwarded among all the headers of the request', 'HTTP Loader')
+Config.define(
     'HTTP_LOADER_DEFAULT_USER_AGENT', "Thumbor/%s" % __version__,
     'Default user agent for thumbor http loader requests', 'HTTP Loader')
 Config.define(

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -109,15 +109,23 @@ def load_sync(context, url, callback, normalize_url_func):
     client = tornado.httpclient.AsyncHTTPClient(max_clients=context.config.HTTP_LOADER_MAX_CLIENTS)
 
     user_agent = None
-    if context.config.HTTP_LOADER_FORWARD_USER_AGENT:
-        if 'User-Agent' in context.request_handler.request.headers:
-            user_agent = context.request_handler.request.headers['User-Agent']
-    if user_agent is None:
+    headers = {}
+    if context.config.HTTP_LOADER_FORWARD_ALL_HEADERS:
+        headers = context.request_handler.request.headers
+    else:
+        if context.config.HTTP_LOADER_FORWARD_USER_AGENT:
+            context.config.HTTP_LOADER_FORWARD_HEADERS_WHITELIST.append('User-Agent')
+        if context.config.HTTP_LOADER_FORWARD_HEADERS_WHITELIST:
+            for header_key in context.config.HTTP_LOADER_FORWARD_HEADERS_WHITELIST:
+                if header_key in context.request_handler.request.headers:
+                    headers[header_key] = context.request_handler.request.headers[header_key]
+    if user_agent is None and not 'User-Agent' in headers:
         user_agent = context.config.HTTP_LOADER_DEFAULT_USER_AGENT
 
     url = normalize_url_func(url)
     req = tornado.httpclient.HTTPRequest(
         url=url,
+        headers=headers,
         connect_timeout=context.config.HTTP_LOADER_CONNECT_TIMEOUT,
         request_timeout=context.config.HTTP_LOADER_REQUEST_TIMEOUT,
         follow_redirects=context.config.HTTP_LOADER_FOLLOW_REDIRECTS,

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -114,12 +114,14 @@ def load_sync(context, url, callback, normalize_url_func):
         headers = context.request_handler.request.headers
     else:
         if context.config.HTTP_LOADER_FORWARD_USER_AGENT:
-            context.config.HTTP_LOADER_FORWARD_HEADERS_WHITELIST.append('User-Agent')
+            if 'User-Agent' in context.request_handler.request.headers:
+                user_agent = context.request_handler.request.headers['User-Agent']
         if context.config.HTTP_LOADER_FORWARD_HEADERS_WHITELIST:
             for header_key in context.config.HTTP_LOADER_FORWARD_HEADERS_WHITELIST:
                 if header_key in context.request_handler.request.headers:
                     headers[header_key] = context.request_handler.request.headers[header_key]
-    if user_agent is None and not 'User-Agent' in headers:
+
+    if user_agent is None and 'User-Agent' not in headers:
         user_agent = context.config.HTTP_LOADER_DEFAULT_USER_AGENT
 
     url = normalize_url_func(url)


### PR DESCRIPTION
## Problem

We have a security layer around Thumbor in our production environment that uses headers to validate the requests to our storage origin cluster.
Thumbor can forward the User-Agent header but it is the only header that can get forwarded by the HTTP_Loader.

## Solution

I have added two new configuration options:
 - HTTP_LOADER_FORWARD_HEADERS_WHITELIST: empty by default
 - HTTP_LOADER_FORWARD_ALL_HEADERS: False by default

First option will allow us to specify which header should be forwarded and second one tell thumbor to forward all the incoming headers.