### PR TITLE
Remove IGNORE_DECODING_ERRORS constant

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -44,9 +44,6 @@ FORMATS = {
 ImageFile.MAXBLOCK = 2 ** 25
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
-if hasattr(ImageFile, 'IGNORE_DECODING_ERRORS'):
-    ImageFile.IGNORE_DECODING_ERRORS = True
-
 
 class Engine(BaseEngine):
     def __init__(self, context):


### PR DESCRIPTION
This constant was never introduced in any release and was removed from the Pillow's master on next day:
https://github.com/python-pillow/Pillow/commit/f6da8c24dc8a30e4563dedf45aedd09dcf6f0b9d#diff-6b6c4410a4159082c840f529897c991a