### PR TITLE
Replaced 'pexif' dependency with 'piexif'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
             "pycurl>=7.19.0,<7.44.0",
             "Pillow>=3.0.0,<5.0.0",
             "derpconf>=0.2.0",
-            "pexif>=0.15,<1.0",
+            "piexif>=1.0.13,<1.1.0",
             "statsd>=3.0.1",
             "libthumbor>=1.3.2",
             "futures",

--- a/tests/engines/test_base_engine.py
+++ b/tests/engines/test_base_engine.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals, absolute_import
 from struct import pack
 from os.path import abspath, join, dirname
 
+import piexif
 from unittest import TestCase
 from xml.etree.ElementTree import ParseError
 
@@ -194,6 +195,11 @@ class BaseEngineTestCase(TestCase):
 
     def test_get_orientation_null_exif(self):
         self.engine.exif = None
+        expect(self.engine.get_orientation()).to_be_null()
+
+    def test_get_orientation_without_orientation_in_exif(self):
+        self.engine.exif = piexif.load(exif_str(1))
+        self.engine.exif['0th'].pop(piexif.ImageIFD.Orientation, None)
         expect(self.engine.get_orientation()).to_be_null()
 
     def test_get_orientation(self):


### PR DESCRIPTION
Replacing because piexif supports Python 2.7, 3.3, 3.4, 3.5, pypy, and pypy3; pexif only supports Python 2.7.
