### PR TITLE
Yield coroutines

### DIFF
--- a/tests/filters/test_background_color.py
+++ b/tests/filters/test_background_color.py
@@ -7,21 +7,21 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class BackgroundColorFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_background_color_filter_with_fixed_color(self):
         def config_context(context):
             context.request.fit_in = True
             context.request.width = 300
             context.request.height = 300
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'PNG_transparency_demonstration_1.png',
             'thumbor.filters.background_color',
             'background_color(blue)',

--- a/tests/filters/test_blur.py
+++ b/tests/filters/test_blur.py
@@ -7,36 +7,40 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class BlurFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_blur_filter_with_sigma(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.blur', 'blur(4,2)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.blur', 'blur(4,2)')
         expected = self.get_fixture('blur.jpg')
 
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.99)
 
+    @tornado.testing.gen_test
     def test_blur_filter_with_zero_radius(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.blur', 'blur(0)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.blur', 'blur(0)')
         expected = self.get_fixture('source.jpg')
 
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_equal(1)
 
+    @tornado.testing.gen_test
     def test_blur_filter_without_sigma(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.blur', 'blur(8)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.blur', 'blur(8)')
         expected = self.get_fixture('blur2.jpg')
 
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.99)
 
+    @tornado.testing.gen_test
     def test_blur_filter_with_max_radius(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.blur', 'blur(500)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.blur', 'blur(500)')
         expected = self.get_fixture('blur3.jpg')
 
         ssim = self.get_ssim(image, expected)

--- a/tests/filters/test_brightness.py
+++ b/tests/filters/test_brightness.py
@@ -7,15 +7,16 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class BrightnessFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_brightness_filter(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.brightness', 'brightness(20)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.brightness', 'brightness(20)')
         expected = self.get_fixture('brightness.jpg')
 
         ssim = self.get_ssim(image, expected)

--- a/tests/filters/test_colorize.py
+++ b/tests/filters/test_colorize.py
@@ -7,15 +7,16 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class ColorizeFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_colorize_filter(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.colorize', 'colorize(40,80,20,ffffff)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.colorize', 'colorize(40,80,20,ffffff)')
         expected = self.get_fixture('colorize.jpg')
 
         ssim = self.get_ssim(image, expected)

--- a/tests/filters/test_contrast.py
+++ b/tests/filters/test_contrast.py
@@ -7,15 +7,16 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class ContrastFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_contrast_filter(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.contrast', 'contrast(20)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.contrast', 'contrast(20)')
         expected = self.get_fixture('contrast.jpg')
 
         ssim = self.get_ssim(image, expected)

--- a/tests/filters/test_fill.py
+++ b/tests/filters/test_fill.py
@@ -7,21 +7,21 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class FillFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_fill_filter_with_fixed_color(self):
         def config_context(context):
             context.request.fit_in = True
             context.request.width = 800
             context.request.height = 800
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.fill',
             'fill(0000ff)',
@@ -33,13 +33,14 @@ class FillFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.97)
 
+    @tornado.testing.gen_test
     def test_fill_filter_with_average(self):
         def config_context(context):
             context.request.fit_in = True
             context.request.width = 800
             context.request.height = 800
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.fill',
             'fill(auto)',
@@ -51,6 +52,7 @@ class FillFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.97)
 
+    @tornado.testing.gen_test
     def test_fill_filter_with_full_fit_in(self):
         def config_context(context):
             context.request.fit_in = True
@@ -58,7 +60,7 @@ class FillFilterTestCase(FilterTestCase):
             context.request.width = 800
             context.request.height = 800
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.fill',
             'fill(auto)',
@@ -70,6 +72,7 @@ class FillFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.97)
 
+    @tornado.testing.gen_test
     def test_fill_filter_with_full_fit_in_orig_width(self):
         def config_context(context):
             context.request.fit_in = True
@@ -77,7 +80,7 @@ class FillFilterTestCase(FilterTestCase):
             context.request.width = 'orig'
             context.request.height = 800
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.fill',
             'fill(auto)',

--- a/tests/filters/test_focal.py
+++ b/tests/filters/test_focal.py
@@ -7,16 +7,16 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class FocalFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_focal_filter_valid(self):
-        self.get_filtered(
+        yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.focal',
             'focal(146x156:279x208)'
@@ -28,12 +28,13 @@ class FocalFilterTestCase(FilterTestCase):
         expect(self.context.request.focal_points[0].y).to_equal(182)
         expect(self.context.request.focal_points[0].x).to_equal(212)
 
+    @tornado.testing.gen_test
     def test_focal_filter_no_change(self):
         def config_context(context):
             context.request.width = 400
             context.request.height = 600
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.focal',
             'focal(0x0:400x600)'
@@ -43,8 +44,9 @@ class FocalFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.99)
 
+    @tornado.testing.gen_test
     def test_focal_filter_pass_through_empty(self):
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.focal',
             'focal()'
@@ -54,8 +56,9 @@ class FocalFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.99)
 
+    @tornado.testing.gen_test
     def test_focal_filter_pass_through_invalid(self):
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.focal',
             'focal(0x0:0x0)'
@@ -65,8 +68,9 @@ class FocalFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.99)
 
+    @tornado.testing.gen_test
     def test_focal_filter_pass_through_dumb(self):
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.focal',
             'focal(lkasjdklfjlkajsfd)'

--- a/tests/filters/test_format.py
+++ b/tests/filters/test_format.py
@@ -7,17 +7,19 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class FormatFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_invalid_format_should_be_null(self):
-        self.get_filtered('source.jpg', 'thumbor.filters.format', 'format(invalid)')
+        yield self.get_filtered('source.jpg', 'thumbor.filters.format', 'format(invalid)')
         expect(self.context.request.format).to_be_null()
 
+    @tornado.testing.gen_test
     def test_can_set_proper_format(self):
-        self.get_filtered('source.jpg', 'thumbor.filters.format', 'format(webp)')
+        yield self.get_filtered('source.jpg', 'thumbor.filters.format', 'format(webp)')
         expect(self.context.request.format).to_equal('webp')

--- a/tests/filters/test_noise.py
+++ b/tests/filters/test_noise.py
@@ -7,16 +7,16 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class NoiseFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_noise_filter(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.noise', 'noise(200,123)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.noise', 'noise(200,123)')
         expected = self.get_fixture('noise.png')
 
         ssim = self.get_ssim(image, expected)

--- a/tests/filters/test_quality.py
+++ b/tests/filters/test_quality.py
@@ -7,15 +7,16 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class QualityFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_quality_filter(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.quality', 'quality(10)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.quality', 'quality(10)')
         expected = self.get_fixture('quality-10%.jpg')
 
         expect(self.context.request.quality).to_equal(10)

--- a/tests/filters/test_redeye.py
+++ b/tests/filters/test_redeye.py
@@ -7,16 +7,16 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
-
+import tornado
 from preggy import expect
 from tests.base import FilterTestCase
 from thumbor.point import FocalPoint
 
 
 class RedEyeFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_redeye_passthrough_when_no_face_points(self):
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'redeye.png',
             'thumbor.filters.redeye',
             'red_eye()'
@@ -27,6 +27,7 @@ class RedEyeFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.99)
 
+    @tornado.testing.gen_test
     def test_redeye_applied(self):
         expected = self.get_fixture('redeye_applied.png')
 
@@ -36,7 +37,7 @@ class RedEyeFilterTestCase(FilterTestCase):
 
             context.request.focal_points = [point]
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'redeye.png',
             'thumbor.filters.redeye',
             'red_eye()',

--- a/tests/filters/test_rgb.py
+++ b/tests/filters/test_rgb.py
@@ -7,15 +7,16 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class RGBFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_rgb_filter(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.rgb', 'rgb(10,2,4)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.rgb', 'rgb(10,2,4)')
         expected = self.get_fixture('rgb.jpg')
 
         ssim = self.get_ssim(image, expected)

--- a/tests/filters/test_rotate.py
+++ b/tests/filters/test_rotate.py
@@ -7,7 +7,7 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
+import tornado
 from preggy import expect
 
 from thumbor.context import Context, RequestParameters
@@ -20,15 +20,17 @@ from tests.base import FilterTestCase
 
 
 class RotateFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_rotate_filter(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.rotate', 'rotate(180)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.rotate', 'rotate(180)')
         expected = self.get_fixture('rotate.jpg')
 
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.97)
 
+    @tornado.testing.gen_test
     def test_rotate_filter_with_invalid_value(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.rotate', 'rotate(181)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.rotate', 'rotate(181)')
         expected = self.get_fixture('source.jpg')
 
         ssim = self.get_ssim(image, expected)

--- a/tests/filters/test_upscale.py
+++ b/tests/filters/test_upscale.py
@@ -7,21 +7,21 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
 
 
 class UpscaleFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_upscale_filter_with_fit_in_big(self):
         def config_context(context):
             context.request.fit_in = True
             context.request.width = 1000
             context.request.height = 1000
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.upscale',
             'upscale()',
@@ -33,13 +33,14 @@ class UpscaleFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.97)
 
+    @tornado.testing.gen_test
     def test_upscale_filter_with_fit_in_small(self):
         def config_context(context):
             context.request.fit_in = True
             context.request.width = 400
             context.request.height = 400
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.upscale',
             'upscale()',
@@ -51,6 +52,7 @@ class UpscaleFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.97)
 
+    @tornado.testing.gen_test
     def test_upscale_filter_with_full_fit_in(self):
         def config_context(context):
             context.request.fit_in = True
@@ -58,7 +60,7 @@ class UpscaleFilterTestCase(FilterTestCase):
             context.request.width = 800
             context.request.height = 800
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.upscale',
             'upscale()',
@@ -70,6 +72,7 @@ class UpscaleFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.97)
 
+    @tornado.testing.gen_test
     def test_upscale_filter_with_adaptive_fit_in_big(self):
         def config_context(context):
             context.request.fit_in = True
@@ -77,7 +80,7 @@ class UpscaleFilterTestCase(FilterTestCase):
             context.request.width = 1000
             context.request.height = 1200
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.upscale',
             'upscale()',
@@ -89,6 +92,7 @@ class UpscaleFilterTestCase(FilterTestCase):
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.97)
 
+    @tornado.testing.gen_test
     def test_upscale_filter_with_adaptive_full_fit_in_big(self):
         def config_context(context):
             context.request.fit_in = True
@@ -97,7 +101,7 @@ class UpscaleFilterTestCase(FilterTestCase):
             context.request.width = 800
             context.request.height = 800
 
-        image = self.get_filtered(
+        image = yield self.get_filtered(
             'source.jpg',
             'thumbor.filters.upscale',
             'upscale()',

--- a/tests/filters/test_watermark.py
+++ b/tests/filters/test_watermark.py
@@ -7,7 +7,7 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
+import tornado
 from preggy import expect
 
 from tests.base import FilterTestCase
@@ -16,69 +16,80 @@ from tests.fixtures.watermark_fixtures import SOURCE_IMAGE_SIZES, WATERMARK_IMAG
 
 
 class WatermarkFilterTestCase(FilterTestCase):
+    @tornado.testing.gen_test
     def test_watermark_filter_centered(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,center,center,60)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,center,center,60)')
         expected = self.get_fixture('watermarkCenter.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_centered_x(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,center,40,20)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,center,40,20)')
         expected = self.get_fixture('watermarkCenterX.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_centered_y(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,80,center,50)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,80,center,50)')
         expected = self.get_fixture('watermarkCenterY.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_repeated(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,repeat,repeat,70)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,repeat,repeat,70)')
         expected = self.get_fixture('watermarkRepeat.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_repeated_x(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,repeat,center,70)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,repeat,center,70)')
         expected = self.get_fixture('watermarkRepeatX.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_repeated_y(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,30,repeat,30)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,30,repeat,30)')
         expected = self.get_fixture('watermarkRepeatY.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_detect_extension_simple(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark,30,-50,60)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark,30,-50,60)')
         expected = self.get_fixture('watermarkSimple.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_simple(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,30,-50,60)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,30,-50,60)')
         expected = self.get_fixture('watermarkSimple.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_calculated(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,4p,-30p,60)')
-        expected = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,32,-160,60)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,4p,-30p,60)')
+        expected = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,32,-160,60)')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_calculated_center(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,4p,center,60)')
-        expected = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,32,center,60)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,4p,center,60)')
+        expected = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,32,center,60)')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_calculated_repeat(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,repeat,30p,60)')
-        expected = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,repeat,160,60)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,repeat,30p,60)')
+        expected = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,repeat,160,60)')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
@@ -94,26 +105,30 @@ class WatermarkFilterTestCase(FilterTestCase):
 
             expect(filter.detect_and_get_ratio_position(pos, length)).to_be_equal_with_additional_info(expected, **test)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_simple_big(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermarkBig.png,-10,-100,50)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermarkBig.png,-10,-100,50)')
         expected = self.get_fixture('watermarkSimpleBig.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_simple_50p_width(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,30,-50,20,50)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,30,-50,20,50)')
         expected = self.get_fixture('watermarkResize50pWidth.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_simple_70p_height(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,30,-50,20,none,70)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,30,-50,20,none,70)')
         expected = self.get_fixture('watermarkResize70pHeight.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
 
+    @tornado.testing.gen_test
     def test_watermark_filter_simple_60p_80p(self):
-        image = self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,-30,-200,20,60,80)')
+        image = yield self.get_filtered('source.jpg', 'thumbor.filters.watermark', 'watermark(watermark.png,-30,-200,20,60,80)')
         expected = self.get_fixture('watermarkResize60p80p.jpg')
         ssim = self.get_ssim(image, expected)
         expect(ssim).to_be_greater_than(0.98)
@@ -163,3 +178,9 @@ class WatermarkFilterTestCase(FilterTestCase):
 
                     test['topic_name'] = 'image ratio'
                     expect(watermark_image).to_almost_equal(ratio, 2, **test)
+
+    @tornado.testing.gen_test
+    def test_watermark_filter_should_throw_exception(self):
+        with expect.error_to_happen(Exception):
+            yield self.get_filtered('source.jpg', 'thumbor.filters.watermark',
+                                    'watermark(not-existing-image.png,center,center,60)')

--- a/thumbor/app.py
+++ b/thumbor/app.py
@@ -7,7 +7,6 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-import tornado.web
 import tornado.ioloop
 
 from thumbor.handlers.blacklist import BlacklistHandler

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -9,9 +9,7 @@
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
 from os.path import abspath, exists
-
 from concurrent.futures import ThreadPoolExecutor, Future
-from tornado.ioloop import IOLoop
 
 from thumbor.filters import FiltersFactory
 from thumbor.metrics.logger_metrics import Metrics
@@ -265,7 +263,7 @@ class ThreadPool(object):
         else:
             self.pool = None
 
-    def _execute_in_foreground(self, operation, callback):
+    def _execute_in_foreground(self, operation):
         result = Future()
 
         try:
@@ -276,18 +274,16 @@ class ThreadPool(object):
         else:
             result.set_result(returned)
 
-        callback(result)
+        return result
 
-    def _execute_in_pool(self, operation, callback):
-        future = self.pool.submit(operation)
+    def _execute_in_pool(self, operation):
+        return self.pool.submit(operation)
 
-        IOLoop.current().add_future(future, callback)
-
-    def queue(self, operation, callback):
+    def queue(self, operation):
         if not self.pool:
-            self._execute_in_foreground(operation, callback)
+            return self._execute_in_foreground(operation)
         else:
-            self._execute_in_pool(operation, callback)
+            return self._execute_in_pool(operation)
 
     def cleanup(self):
         if self.pool:

--- a/thumbor/engines/gif.py
+++ b/thumbor/engines/gif.py
@@ -52,8 +52,6 @@ class Engine(PILEngine):
         return self.frame_count > 1
 
     def update_image_info(self):
-        self._is_multiple = False
-
         result = self.run_gifsicle('--info')
         size = GIFSICLE_SIZE_REGEX.search(result)
         self.image_size = size.groups()[0].split('x')

--- a/thumbor/filters/frame.py
+++ b/thumbor/filters/frame.py
@@ -45,7 +45,6 @@ class Filter(BaseFilter):
                                     self.nine_patch_engine.size[0],
                                     self.nine_patch_engine.size[1])
         self.engine.set_image_data(imgdata)
-        self.callback()
 
     def handle_padding(self, padding):
         '''Pads the image with transparent pixels if necessary.'''
@@ -89,9 +88,8 @@ class Filter(BaseFilter):
 
     @filter_method(BaseFilter.String, async=True)
     @tornado.gen.coroutine
-    def frame(self, callback, url):
+    def frame(self, url):
         self.url = url
-        self.callback = callback
         self.nine_patch_engine = self.context.modules.engine.__class__(self.context)
         self.storage = self.context.modules.storage
 
@@ -99,4 +97,5 @@ class Filter(BaseFilter):
         if buffer is not None:
             self.on_image_ready(buffer)
         else:
-            self.context.modules.loader.load(self.context, self.url, self.on_fetch_done)
+            load_result = yield self.context.modules.loader.load(self.context, self.url)
+            self.on_fetch_done(load_result)

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -8,56 +8,30 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
-import sys
-import functools
+
 import datetime
-import re
-import pytz
 import traceback
 
-import tornado.web
 import tornado.gen as gen
-from tornado.locks import Condition
+import tornado.web
 
-from thumbor import __version__
 from thumbor.context import Context
-from thumbor.engines import BaseEngine, EngineResult
-from thumbor.engines.json_engine import JSONEngine
-from thumbor.loaders import LoaderResult
-from thumbor.result_storages import ResultStorageResult
-from thumbor.storages.no_storage import Storage as NoStorage
-from thumbor.storages.mixed_storage import Storage as MixedStorage
-from thumbor.transformer import Transformer
-from thumbor.utils import logger, CONTENT_TYPE, EXTENSION
-import thumbor.filters
-
-
-HTTP_DATE_FMT = "%a, %d %b %Y %H:%M:%S GMT"
+from thumbor.engines import BaseEngine
+from thumbor.utils import logger
 
 try:
-    basestring        # Python 2
+    basestring  # Python 2
 except NameError:
     basestring = str  # Python 3
 
 
-class FetchResult(object):
-
-    def __init__(self, normalized=False, buffer=None, engine=None, successful=False, loader_error=None):
-        self.normalized = normalized
-        self.engine = engine
-        self.buffer = buffer
-        self.successful = successful
-        self.loader_error = loader_error
-
-
 class BaseHandler(tornado.web.RequestHandler):
-    url_locks = {}
+    pass
 
+
+class ContextHandler(BaseHandler):
     def prepare(self, *args, **kwargs):
         super(BaseHandler, self).prepare(*args, **kwargs)
-
-        if not hasattr(self, 'context'):
-            return
 
         self._response_ext = None
         self._response_length = None
@@ -67,9 +41,6 @@ class BaseHandler(tornado.web.RequestHandler):
 
     def on_finish(self, *args, **kwargs):
         super(BaseHandler, self).on_finish(*args, **kwargs)
-
-        if not hasattr(self, 'context'):
-            return
 
         total_time = (datetime.datetime.now() - self._response_start).total_seconds() * 1000
         status = self.get_status()
@@ -85,7 +56,7 @@ class BaseHandler(tornado.web.RequestHandler):
                 self.context.metrics.incr('response.bytes{0}'.format(ext), self._response_length)
 
         self.context.request_handler = None
-        if hasattr(self.context, 'request'):
+        if hasattr(self.context, 'request') and hasattr(self.context.request, 'engine'):
             self.context.request.engine = None
         self.context.modules = None
         self.context.filters_factory = None
@@ -94,589 +65,6 @@ class BaseHandler(tornado.web.RequestHandler):
         self.context.transformer = None
         self.context = None
 
-    def _error(self, status, msg=None):
-        self.set_status(status)
-        if msg is not None:
-            logger.warn(msg)
-        self.finish()
-
-    @gen.coroutine
-    def execute_image_operations(self):
-        self.context.request.quality = None
-
-        req = self.context.request
-        conf = self.context.config
-
-        should_store = self.context.config.RESULT_STORAGE_STORES_UNSAFE or not self.context.request.unsafe
-        if self.context.modules.result_storage and should_store:
-            start = datetime.datetime.now()
-
-            try:
-                result = yield gen.maybe_future(self.context.modules.result_storage.get())
-            except Exception as e:
-                logger.exception('[BaseHander.execute_image_operations] %s', e)
-                self._error(500, 'Error while trying to get the image from the result storage: {}'.format(e))
-                return
-
-            finish = datetime.datetime.now()
-
-            self.context.metrics.timing('result_storage.incoming_time', (finish - start).total_seconds() * 1000)
-
-            if result is None:
-                self.context.metrics.incr('result_storage.miss')
-            else:
-                self.context.metrics.incr('result_storage.hit')
-                self.context.metrics.incr('result_storage.bytes_read', len(result))
-                logger.debug('[RESULT_STORAGE] IMAGE FOUND: %s' % req.url)
-                self.finish_request(result)
-                return
-
-        if conf.MAX_WIDTH and (not isinstance(req.width, basestring)) and req.width > conf.MAX_WIDTH:
-            req.width = conf.MAX_WIDTH
-        if conf.MAX_HEIGHT and (not isinstance(req.height, basestring)) and req.height > conf.MAX_HEIGHT:
-            req.height = conf.MAX_HEIGHT
-
-        req.meta_callback = conf.META_CALLBACK_NAME or self.request.arguments.get('callback', [None])[0]
-
-        self.filters_runner = self.context.filters_factory.create_instances(self.context, self.context.request.filters)
-        # Apply all the filters from the PRE_LOAD phase and call get_image() afterwards.
-        self.filters_runner.apply_filters(thumbor.filters.PHASE_PRE_LOAD, self.get_image)
-
-    @gen.coroutine  # NOQA
-    def get_image(self):
-        """
-        This function is called after the PRE_LOAD filters have been applied.
-        It applies the AFTER_LOAD filters on the result, then crops the image.
-        """
-        try:
-            result = yield self._fetch(
-                self.context.request.image_url
-            )
-
-            if not result.successful:
-                if result.loader_error == LoaderResult.ERROR_NOT_FOUND:
-                    self._error(404)
-                    return
-                elif result.loader_error == LoaderResult.ERROR_UPSTREAM:
-                    # Return a Bad Gateway status if the error came from upstream
-                    self._error(502)
-                    return
-                elif result.loader_error == LoaderResult.ERROR_TIMEOUT:
-                    # Return a Gateway Timeout status if upstream timed out (i.e. 599)
-                    self._error(504)
-                    return
-                elif isinstance(result.loader_error, int):
-                    self._error(result.loader_error)
-                    return
-                elif hasattr(result, 'engine_error') and result.engine_error == EngineResult.COULD_NOT_LOAD_IMAGE:
-                    self._error(400)
-                    return
-                else:
-                    self._error(500)
-                    return
-
-        except Exception as e:
-            msg = '[BaseHandler] get_image failed for url `{url}`. error: `{error}`'.format(
-                url=self.context.request.image_url,
-                error=e
-            )
-
-            self.log_exception(*sys.exc_info())
-
-            if 'cannot identify image file' in e.message:
-                logger.warning(msg)
-                self._error(400)
-            else:
-                logger.error(msg)
-                self._error(500)
-            return
-
-        normalized = result.normalized
-        buffer = result.buffer
-        engine = result.engine
-
-        req = self.context.request
-
-        if engine is None:
-            if buffer is None:
-                self._error(504)
-                return
-
-            engine = self.context.request.engine
-            try:
-                engine.load(buffer, self.context.request.extension)
-            except Exception:
-                self._error(504)
-                return
-
-        self.context.transformer = Transformer(self.context)
-
-        def transform():
-            self.normalize_crops(normalized, req, engine)
-
-            if req.meta:
-                self.context.transformer.engine = \
-                    self.context.request.engine = \
-                    JSONEngine(engine, req.image_url, req.meta_callback)
-
-            self.context.transformer.transform(self.after_transform)
-
-        self.filters_runner.apply_filters(thumbor.filters.PHASE_AFTER_LOAD, transform)
-
-    def normalize_crops(self, normalized, req, engine):
-        new_crops = None
-        if normalized and req.should_crop:
-            crop_left = req.crop['left']
-            crop_top = req.crop['top']
-            crop_right = req.crop['right']
-            crop_bottom = req.crop['bottom']
-
-            actual_width, actual_height = engine.size
-
-            if not req.width and not req.height:
-                actual_width = engine.size[0]
-                actual_height = engine.size[1]
-            elif req.width:
-                actual_height = engine.get_proportional_height(engine.size[0])
-            elif req.height:
-                actual_width = engine.get_proportional_width(engine.size[1])
-
-            new_crops = self.translate_crop_coordinates(
-                engine.source_width,
-                engine.source_height,
-                actual_width,
-                actual_height,
-                crop_left,
-                crop_top,
-                crop_right,
-                crop_bottom
-            )
-            req.crop['left'] = new_crops[0]
-            req.crop['top'] = new_crops[1]
-            req.crop['right'] = new_crops[2]
-            req.crop['bottom'] = new_crops[3]
-
-    def after_transform(self):
-        if self.context.request.extension == '.gif' and self.context.config.USE_GIFSICLE_ENGINE:
-            self.finish_request()
-        else:
-            self.filters_runner.apply_filters(thumbor.filters.PHASE_POST_TRANSFORM, self.finish_request)
-
-    def is_webp(self, context):
-        return (context.config.AUTO_WEBP and
-                context.request.accepts_webp and
-                not context.request.engine.is_multiple() and
-                context.request.engine.can_convert_to_webp())
-
-    def is_animated_gif(self, data):
-        if data[:6] not in [b"GIF87a", b"GIF89a"]:
-            return False
-        i = 10  # skip header
-        frames = 0
-
-        def skip_color_table(i, flags):
-            if flags & 0x80:
-                i += 3 << ((flags & 7) + 1)
-            return i
-
-        flags = ord(data[i])
-        i = skip_color_table(i + 3, flags)
-        while frames < 2:
-            block = data[i]
-            i += 1
-            if block == b'\x3B':
-                break
-            if block == b'\x21':
-                i += 1
-            elif block == b'\x2C':
-                frames += 1
-                i += 8
-                i = skip_color_table(i + 1, ord(data[i]))
-                i += 1
-            else:
-                return False
-            while True:
-                j = ord(data[i])
-                i += 1
-                if not j:
-                    break
-                i += j
-        return frames > 1
-
-    def can_auto_convert_png_to_jpg(self):
-        return self.context.request.engine.can_auto_convert_png_to_jpg()
-
-    def define_image_type(self, context, result):
-        if result is not None:
-            if isinstance(result, ResultStorageResult):
-                buffer = result.buffer
-            else:
-                buffer = result
-            image_extension = EXTENSION.get(BaseEngine.get_mimetype(buffer), '.jpg')
-        else:
-            image_extension = context.request.format
-            if image_extension is not None:
-                image_extension = '.%s' % image_extension
-                logger.debug('Image format specified as %s.' % image_extension)
-            elif self.is_webp(context):
-                image_extension = '.webp'
-                logger.debug('Image format set by AUTO_WEBP as %s.' % image_extension)
-            elif self.can_auto_convert_png_to_jpg():
-                image_extension = '.jpg'
-                logger.debug('Image format set by AUTO_PNG_TO_JPG as %s.' % image_extension)
-            else:
-                image_extension = context.request.engine.extension
-                logger.debug('No image format specified. Retrieving from the image extension: %s.' % image_extension)
-
-        content_type = CONTENT_TYPE.get(image_extension, CONTENT_TYPE['.jpg'])
-
-        if context.request.meta:
-            context.request.meta_callback = context.config.META_CALLBACK_NAME or self.request.arguments.get('callback', [None])[0]
-            content_type = 'text/javascript' if context.request.meta_callback else 'application/json'
-            logger.debug('Metadata requested. Serving content type of %s.' % content_type)
-
-        logger.debug('Content Type of %s detected.' % content_type)
-
-        return (image_extension, content_type)
-
-    def _load_results(self, context):
-        image_extension, content_type = self.define_image_type(context, None)
-
-        quality = self.context.request.quality
-        if quality is None:
-            if image_extension == '.webp' and self.context.config.WEBP_QUALITY is not None:
-                quality = self.context.config.get('WEBP_QUALITY')
-            else:
-                quality = self.context.config.QUALITY
-
-        results = context.request.engine.read(image_extension, quality)
-
-        if context.request.max_bytes is not None:
-            results = self.reload_to_fit_in_kb(
-                context.request.engine,
-                results,
-                image_extension,
-                quality,
-                context.request.max_bytes
-            )
-        if not context.request.meta:
-            results = self.optimize(context, image_extension, results)
-            # An optimizer might have modified the image format.
-            content_type = BaseEngine.get_mimetype(results)
-
-        return results, content_type
-
-    @gen.coroutine
-    def _process_result_from_storage(self, result):
-        if self.context.config.SEND_IF_MODIFIED_LAST_MODIFIED_HEADERS:
-            # Handle If-Modified-Since & Last-Modified header
-            try:
-                if isinstance(result, ResultStorageResult):
-                    result_last_modified = result.last_modified
-                else:
-                    result_last_modified = yield gen.maybe_future(self.context.modules.result_storage.last_updated())
-
-                if result_last_modified:
-                    if 'If-Modified-Since' in self.request.headers:
-                        date_modified_since = datetime.datetime.strptime(
-                            self.request.headers['If-Modified-Since'], HTTP_DATE_FMT
-                        ).replace(tzinfo=pytz.utc)
-
-                        if result_last_modified <= date_modified_since:
-                            self.set_status(304)
-                            self.finish()
-                            return
-
-                    self.set_header('Last-Modified', result_last_modified.strftime(HTTP_DATE_FMT))
-            except NotImplementedError:
-                logger.warn('last_updated method is not supported by your result storage service, hence If-Modified-Since & '
-                            'Last-Updated headers support is disabled.')
-
-    @gen.coroutine
-    def finish_request(self, result_from_storage=None):
-        if result_from_storage is not None:
-            self._process_result_from_storage(result_from_storage)
-
-            image_extension, content_type = self.define_image_type(self.context, result_from_storage)
-            self._write_results_to_client(result_from_storage, content_type)
-
-            return
-
-        context = self.context
-        result_storage = context.modules.result_storage
-        metrics = context.metrics
-
-        should_store = result_storage and not context.request.prevent_result_storage \
-            and (context.config.RESULT_STORAGE_STORES_UNSAFE or not context.request.unsafe)
-
-        def inner(future):
-            try:
-                future_result = future.result()
-            except Exception as e:
-                logger.exception('[BaseHander.finish_request] %s', e)
-                self._error(500, 'Error while trying to fetch the image: {}'.format(e))
-                return
-
-            results, content_type = future_result
-            self._write_results_to_client(results, content_type)
-
-            if should_store:
-                tornado.ioloop.IOLoop.instance().add_callback(self._store_results, result_storage, metrics, results)
-
-        self.context.thread_pool.queue(
-            operation=functools.partial(self._load_results, context),
-            callback=inner,
-        )
-
-    def _write_results_to_client(self, results, content_type):
-        max_age = self.context.config.MAX_AGE
-
-        if self.context.request.max_age is not None:
-            max_age = self.context.request.max_age
-
-        if self.context.request.prevent_result_storage or self.context.request.detection_error:
-            max_age = self.context.config.MAX_AGE_TEMP_IMAGE
-
-        if max_age:
-            self.set_header('Cache-Control', 'max-age=' + str(max_age) + ',public')
-            self.set_header('Expires', datetime.datetime.utcnow() + datetime.timedelta(seconds=max_age))
-
-        self.set_header('Server', 'Thumbor/%s' % __version__)
-        self.set_header('Content-Type', content_type)
-
-        if isinstance(results, ResultStorageResult):
-            buffer = results.buffer
-        else:
-            buffer = results
-
-        # auto-convert configured?
-        should_vary = self.context.config.AUTO_WEBP
-        # we have image (not video)
-        should_vary = should_vary and content_type.startswith("image/")
-        # output format is not requested via format filter
-        should_vary = should_vary and not (
-            self.context.request.format and  # format is supported by filter
-            bool(re.search(r"format\([^)]+\)", self.context.request.filters))  # filter is in request
-        )
-        # our image is not animated gif
-        should_vary = should_vary and not self.is_animated_gif(buffer)
-
-        if should_vary:
-            self.set_header('Vary', 'Accept')
-
-        self.context.headers = self._headers.copy()
-        self._response_ext = EXTENSION.get(content_type)
-        self._response_length = len(buffer)
-
-        self.write(buffer)
-        self.finish()
-
-    @gen.coroutine
-    def _store_results(self, result_storage, metrics, results):
-        start = datetime.datetime.now()
-
-        yield gen.maybe_future(result_storage.put(results))
-
-        finish = datetime.datetime.now()
-        metrics.incr('result_storage.bytes_written', len(results))
-        metrics.timing('result_storage.outgoing_time', (finish - start).total_seconds() * 1000)
-
-    def optimize(self, context, image_extension, results):
-        for optimizer in context.modules.optimizers:
-            new_results = optimizer(context).run_optimizer(image_extension, results)
-            if new_results is not None:
-                results = new_results
-
-        return results
-
-    def reload_to_fit_in_kb(self, engine, initial_results, extension, initial_quality, max_bytes):
-        if extension not in ['.webp', '.jpg', '.jpeg'] or len(initial_results) <= max_bytes:
-            return initial_results
-
-        results = initial_results
-        quality = initial_quality
-
-        while len(results) > max_bytes:
-            quality = int(quality * 0.75)
-
-            if quality < 10:
-                logger.debug('Could not find any reduction that matches required size of %d bytes.' % max_bytes)
-                return initial_results
-
-            logger.debug('Trying to downsize image with quality of %d...' % quality)
-            results = engine.read(extension, quality)
-
-        prev_result = results
-        while len(results) <= max_bytes:
-            quality = int(quality * 1.1)
-            logger.debug('Trying to upsize image with quality of %d...' % quality)
-            prev_result = results
-            results = engine.read(extension, quality)
-
-        return prev_result
-
-    @classmethod
-    def translate_crop_coordinates(
-            cls,
-            original_width,
-            original_height,
-            width,
-            height,
-            crop_left,
-            crop_top,
-            crop_right,
-            crop_bottom):
-
-        if original_width == width and original_height == height:
-            return
-
-        crop_left = crop_left * width / original_width
-        crop_top = crop_top * height / original_height
-
-        crop_right = crop_right * width / original_width
-        crop_bottom = crop_bottom * height / original_height
-
-        return (crop_left, crop_top, crop_right, crop_bottom)
-
-    def validate(self, path):
-        if not hasattr(self.context.modules.loader, 'validate'):
-            return True
-
-        is_valid = self.context.modules.loader.validate(self.context, path)
-
-        if not is_valid:
-            logger.warn('Request denied because the specified path "%s" was not identified by the loader as a valid path' % path)
-
-        return is_valid
-
-    @gen.coroutine
-    def _fetch(self, url):
-        """
-
-        :param url:
-        :type url:
-        :return:
-        :rtype:
-        """
-        fetch_result = FetchResult()
-
-        storage = self.context.modules.storage
-
-        yield self.acquire_url_lock(url)
-
-        try:
-            fetch_result.buffer = yield gen.maybe_future(storage.get(url))
-            mime = None
-
-            if fetch_result.buffer is not None:
-                self.release_url_lock(url)
-
-                fetch_result.successful = True
-
-                self.context.metrics.incr('storage.hit')
-                mime = BaseEngine.get_mimetype(fetch_result.buffer)
-                self.context.request.extension = EXTENSION.get(mime, '.jpg')
-                if mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
-                    self.context.request.engine = self.context.modules.gif_engine
-                else:
-                    self.context.request.engine = self.context.modules.engine
-
-                raise gen.Return(fetch_result)
-            else:
-                self.context.metrics.incr('storage.miss')
-
-            loader_result = yield self.context.modules.loader.load(self.context, url)
-        finally:
-            self.release_url_lock(url)
-
-        if isinstance(loader_result, LoaderResult):
-            # TODO _fetch should probably return a result object vs a list to
-            # to allow returning metadata
-            if not loader_result.successful:
-                fetch_result.buffer = None
-                fetch_result.loader_error = loader_result.error
-                raise gen.Return(fetch_result)
-
-            fetch_result.buffer = loader_result.buffer
-        else:
-            # Handle old loaders
-            fetch_result.buffer = loader_result
-
-        if fetch_result.buffer is None:
-            raise gen.Return(fetch_result)
-
-        fetch_result.successful = True
-
-        if mime is None:
-            mime = BaseEngine.get_mimetype(fetch_result.buffer)
-
-        self.context.request.extension = extension = EXTENSION.get(mime, '.jpg')
-
-        try:
-            if mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
-                self.context.request.engine = self.context.modules.gif_engine
-            else:
-                self.context.request.engine = self.context.modules.engine
-
-            self.context.request.engine.load(fetch_result.buffer, extension)
-
-            if self.context.request.engine.image is None:
-                fetch_result.successful = False
-                fetch_result.buffer = None
-                fetch_result.engine = self.context.request.engine
-                fetch_result.engine_error = EngineResult.COULD_NOT_LOAD_IMAGE
-                raise gen.Return(fetch_result)
-
-            fetch_result.normalized = self.context.request.engine.normalize()
-
-            # Allows engine or loader to override storage on the fly for the purpose of
-            # marking a specific file as unstoreable
-            storage = self.context.modules.storage
-
-            is_no_storage = isinstance(storage, NoStorage)
-            is_mixed_storage = isinstance(storage, MixedStorage)
-            is_mixed_no_file_storage = is_mixed_storage and isinstance(storage.file_storage, NoStorage)
-
-            if not (is_no_storage or is_mixed_no_file_storage):
-                storage.put(url, fetch_result.buffer)
-
-            storage.put_crypto(url)
-        except Exception:
-            fetch_result.successful = False
-        finally:
-            if not fetch_result.successful:
-                raise
-            fetch_result.buffer = None
-            fetch_result.engine = self.context.request.engine
-            raise gen.Return(fetch_result)
-
-    @gen.coroutine
-    def get_blacklist_contents(self):
-        filename = 'blacklist.txt'
-
-        exists = yield gen.maybe_future(self.context.modules.storage.exists(filename))
-        if exists:
-            blacklist = yield gen.maybe_future(self.context.modules.storage.get(filename))
-            raise tornado.gen.Return(blacklist)
-        else:
-            raise tornado.gen.Return("")
-
-    @gen.coroutine
-    def acquire_url_lock(self, url):
-        if url not in BaseHandler.url_locks:
-            BaseHandler.url_locks[url] = Condition()
-        else:
-            yield BaseHandler.url_locks[url].wait()
-
-    def release_url_lock(self, url):
-        try:
-            BaseHandler.url_locks[url].notify_all()
-            del BaseHandler.url_locks[url]
-        except KeyError:
-            pass
-
-
-class ContextHandler(BaseHandler):
     def initialize(self, context):
         self.context = Context(
             server=context.server,
@@ -696,17 +84,28 @@ class ContextHandler(BaseHandler):
 
         try:
             if self.context.config.USE_CUSTOM_ERROR_HANDLING:
-                self.context.modules.importer.error_handler.handle_error(context=self.context, handler=self, exception=exc_info)
+                self.context.modules.importer.error_handler.handle_error(context=self.context, handler=self,
+                                                                         exception=exc_info)
         finally:
             del exc_info
             logger.error('ERROR: %s' % "".join(msg))
+
+    @gen.coroutine
+    def get_blacklist_contents(self):
+        filename = 'blacklist.txt'
+
+        exists = yield gen.maybe_future(self.context.modules.storage.exists(filename))
+        if exists:
+            blacklist = yield gen.maybe_future(self.context.modules.storage.get(filename))
+            raise tornado.gen.Return(blacklist)
+        else:
+            raise tornado.gen.Return("")
 
 
 ##
 # Base handler for Image API operations
 ##
 class ImageApiHandler(ContextHandler):
-
     def validate(self, body):
         conf = self.context.config
         mime = BaseEngine.get_mimetype(body)
@@ -720,23 +119,20 @@ class ImageApiHandler(ContextHandler):
         try:
             engine.load(body, None)
         except IOError:
-            self._error(415, 'Unsupported Media Type')
-            return False
+            raise tornado.web.HTTPError(415, 'Unsupported Media Type')
 
         # Check weight constraints
-        if (conf.UPLOAD_MAX_SIZE != 0 and len(self.request.body) > conf.UPLOAD_MAX_SIZE):
-            self._error(
+        if conf.UPLOAD_MAX_SIZE != 0 and len(self.request.body) > conf.UPLOAD_MAX_SIZE:
+            raise tornado.web.HTTPError(
                 412,
                 'Image exceed max weight (Expected : %s, Actual : %s)' % (conf.UPLOAD_MAX_SIZE, len(self.request.body)))
-            return False
 
         # Check size constraints
         size = engine.size
-        if (conf.MIN_WIDTH > size[0] or conf.MIN_HEIGHT > size[1]):
-            self._error(
-                412,
-                'Image is too small (Expected: %s/%s , Actual : %s/%s) % (conf.MIN_WIDTH, conf.MIN_HEIGHT, size[0], size[1])')
-            return False
+        if conf.MIN_WIDTH > size[0] or conf.MIN_HEIGHT > size[1]:
+            raise tornado.web.HTTPError(412, 'Image is too small (Expected: %s/%s , Actual : %s/%s)' % (
+                conf.MIN_WIDTH, conf.MIN_HEIGHT, size[0], size[1]))
+
         return True
 
     def write_file(self, id, body):

--- a/thumbor/handlers/blacklist.py
+++ b/thumbor/handlers/blacklist.py
@@ -15,7 +15,6 @@ import tornado
 
 class BlacklistHandler(ContextHandler):
 
-    @tornado.web.asynchronous
     @tornado.gen.coroutine
     def get(self):
         blacklist = yield self.get_blacklist_contents()
@@ -24,7 +23,6 @@ class BlacklistHandler(ContextHandler):
         self.set_header('Content-Type', 'text/plain')
         self.set_status(200)
 
-    @tornado.web.asynchronous
     @tornado.gen.coroutine
     def put(self):
         blacklist = yield self.get_blacklist_contents()

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -7,16 +7,70 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
+import datetime
+import re
+import sys
 
-from six.moves.urllib.parse import quote, unquote
-
-from thumbor.handlers import ContextHandler
-from thumbor.context import RequestParameters
+import pytz
 import tornado.gen as gen
 import tornado.web
+from six.moves.urllib.parse import quote, unquote
+from tornado.locks import Condition
+
+import thumbor.filters
+from thumbor import __version__
+from thumbor.context import RequestParameters
+from thumbor.engines import BaseEngine, EngineResult
+from thumbor.engines.json_engine import JSONEngine
+from thumbor.handlers import ContextHandler
+from thumbor.loaders import LoaderResult
+from thumbor.result_storages import ResultStorageResult
+from thumbor.storages.mixed_storage import Storage as MixedStorage
+from thumbor.storages.no_storage import Storage as NoStorage
+from thumbor.transformer import Transformer
+from thumbor.utils import logger, CONTENT_TYPE, EXTENSION
+
+try:
+    basestring  # Python 2
+except NameError:
+    basestring = str  # Python 3
+
+HTTP_DATE_FMT = "%a, %d %b %Y %H:%M:%S GMT"
+
+
+class FetchResult(object):
+    def __init__(self, normalized=False, buffer=None, engine=None, successful=False, loader_error=None):
+        self.normalized = normalized
+        self.engine = engine
+        self.buffer = buffer
+        self.successful = successful
+        self.loader_error = loader_error
 
 
 class ImagingHandler(ContextHandler):
+    url_locks = {}
+
+    @classmethod
+    def translate_crop_coordinates(
+            cls,
+            original_width,
+            original_height,
+            width,
+            height,
+            crop_left,
+            crop_top,
+            crop_right,
+            crop_bottom):
+        if original_width == width and original_height == height:
+            return
+
+        crop_left = crop_left * width / original_width
+        crop_top = crop_top * height / original_height
+
+        crop_right = crop_right * width / original_width
+        crop_bottom = crop_bottom * height / original_height
+
+        return crop_left, crop_top, crop_right, crop_bottom
 
     def compute_etag(self):
         if self.context.config.ENABLE_ETAGS:
@@ -28,16 +82,16 @@ class ImagingHandler(ContextHandler):
     def check_image(self, kw):
         if self.context.config.MAX_ID_LENGTH > 0:
             # Check if an image with an uuid exists in storage
-            exists = yield gen.maybe_future(self.context.modules.storage.exists(kw['image'][:self.context.config.MAX_ID_LENGTH]))
+            image_key = kw['image'][:self.context.config.MAX_ID_LENGTH]
+            exists = yield gen.maybe_future(self.context.modules.storage.exists(image_key))
             if exists:
-                kw['image'] = kw['image'][:self.context.config.MAX_ID_LENGTH]
+                kw['image'] = image_key
 
         url = self.request.path
 
         kw['image'] = quote(kw['image'].encode('utf-8'))
         if not self.validate(kw['image']):
-            self._error(400, 'No original image was specified in the given URL')
-            return
+            raise tornado.web.HTTPError(400, 'No original image was specified in the given URL')
 
         kw['request'] = self.request
         self.context.request = RequestParameters(**kw)
@@ -46,18 +100,18 @@ class ImagingHandler(ContextHandler):
         has_both = self.context.request.unsafe and self.context.request.hash
 
         if has_none or has_both:
-            self._error(400, 'URL does not have hash or unsafe, or has both: %s' % url)
-            return
+            raise tornado.web.HTTPError(400, 'URL does not have hash or unsafe, or has both: %s' % url)
 
         if self.context.request.unsafe and not self.context.config.ALLOW_UNSAFE_URL:
-            self._error(400, 'URL has unsafe but unsafe is not allowed by the config: %s' % url)
-            return
+            raise tornado.web.HTTPError(400, 'URL has unsafe but unsafe is not allowed by the config: %s' % url)
 
         if self.context.config.USE_BLACKLIST:
             blacklist = yield self.get_blacklist_contents()
             if self.context.request.image_url in blacklist:
-                self._error(400, 'Source image url has been blacklisted: %s' % self.context.request.image_url)
-                return
+                raise tornado.web.HTTPError(
+                    400,
+                    'Source image url has been blacklisted: %s' % self.context.request.image_url
+                )
 
         url_signature = self.context.request.hash
         if url_signature:
@@ -66,8 +120,7 @@ class ImagingHandler(ContextHandler):
             try:
                 quoted_hash = quote(self.context.request.hash)
             except KeyError:
-                self._error(400, 'Invalid hash: %s' % self.context.request.hash)
-                return
+                raise tornado.web.HTTPError(400, 'Invalid hash: %s' % self.context.request.hash)
 
             url_to_validate = url.replace('/%s/' % self.context.request.hash, '') \
                 .replace('/%s/' % quoted_hash, '')
@@ -76,21 +129,541 @@ class ImagingHandler(ContextHandler):
 
             if not valid and self.context.config.STORES_CRYPTO_KEY_FOR_EACH_IMAGE:
                 # Retrieves security key for this image if it has been seen before
-                security_key = yield gen.maybe_future(self.context.modules.storage.get_crypto(self.context.request.image_url))
+                security_key = yield gen.maybe_future(
+                    self.context.modules.storage.get_crypto(self.context.request.image_url))
                 if security_key is not None:
                     signer = self.context.modules.url_signer(security_key)
                     valid = signer.validate(url_signature, url_to_validate)
 
             if not valid:
-                self._error(400, 'Malformed URL: %s' % url)
+                raise tornado.web.HTTPError(500, 'Malformed URL')
+
+        yield self.execute_image_operations()
+
+    def validate(self, path):
+        if not hasattr(self.context.modules.loader, 'validate'):
+            return True
+
+        is_valid = self.context.modules.loader.validate(self.context, path)
+
+        if not is_valid:
+            logger.warn('Request denied because the specified path "%s" was not identified by the loader as a valid '
+                        'path' % path)
+
+        return is_valid
+
+    @gen.coroutine
+    def execute_image_operations(self):
+        self.context.request.quality = None
+
+        req = self.context.request
+        conf = self.context.config
+
+        should_store = conf.RESULT_STORAGE_STORES_UNSAFE or not req.unsafe
+        if self.context.modules.result_storage and should_store:
+            start = datetime.datetime.now()
+
+            try:
+                result = yield gen.maybe_future(self.context.modules.result_storage.get())
+            except Exception as e:
+                logger.exception('[BaseHander.execute_image_operations] %s', e)
+                raise tornado.web.HTTPError(500,
+                                            'Error while trying to get the image from the result storage: {}'.format(e))
+
+            finish = datetime.datetime.now()
+
+            self.context.metrics.timing('result_storage.incoming_time', (finish - start).total_seconds() * 1000)
+
+            if result is None:
+                self.context.metrics.incr('result_storage.miss')
+            else:
+                self.context.metrics.incr('result_storage.hit')
+                self.context.metrics.incr('result_storage.bytes_read', len(result))
+                logger.debug('[RESULT_STORAGE] IMAGE FOUND: %s' % req.url)
+                yield self.finish_request_from_storage(result)
                 return
 
-        self.execute_image_operations()
+        if conf.MAX_WIDTH and (not isinstance(req.width, basestring)) and req.width > conf.MAX_WIDTH:
+            req.width = conf.MAX_WIDTH
+        if conf.MAX_HEIGHT and (not isinstance(req.height, basestring)) and req.height > conf.MAX_HEIGHT:
+            req.height = conf.MAX_HEIGHT
 
-    @tornado.web.asynchronous
+        req.meta_callback = conf.META_CALLBACK_NAME or self.request.arguments.get('callback', [None])[0]
+
+        self.filters_runner = self.context.filters_factory.create_instances(self.context, self.context.request.filters)
+        # Apply all the filters from the PRE_LOAD phase and call get_image() afterwards.
+        yield self.filters_runner.apply_filters(thumbor.filters.PHASE_PRE_LOAD)
+        yield self.get_image()
+
+    @gen.coroutine
+    def finish_request_from_storage(self, result_from_storage):
+        yield self._process_result_from_storage(result_from_storage)
+
+        image_extension, content_type = self.define_image_type(result_from_storage)
+        self._write_results_to_client(result_from_storage, content_type)
+
+    @gen.coroutine
+    def _process_result_from_storage(self, result):
+        if self.context.config.SEND_IF_MODIFIED_LAST_MODIFIED_HEADERS:
+            # Handle If-Modified-Since & Last-Modified header
+            try:
+                if isinstance(result, ResultStorageResult):
+                    result_last_modified = result.last_modified
+                else:
+                    result_last_modified = yield gen.maybe_future(self.context.modules.result_storage.last_updated())
+
+                if result_last_modified:
+                    if 'If-Modified-Since' in self.request.headers:
+                        date_modified_since = datetime.datetime.strptime(
+                            self.request.headers['If-Modified-Since'], HTTP_DATE_FMT
+                        ).replace(tzinfo=pytz.utc)
+
+                        if result_last_modified <= date_modified_since:
+                            self.set_status(304)
+                            self.finish()
+                            return
+
+                    self.set_header('Last-Modified', result_last_modified.strftime(HTTP_DATE_FMT))
+            except NotImplementedError:
+                logger.warn('last_updated method is not supported by your result storage service, '
+                            'hence If-Modified-Since & '
+                            'Last-Updated headers support is disabled.')
+
+    def _write_results_to_client(self, results, content_type):
+        max_age = self.context.config.MAX_AGE
+
+        if self.context.request.max_age is not None:
+            max_age = self.context.request.max_age
+
+        if self.context.request.prevent_result_storage or self.context.request.detection_error:
+            max_age = self.context.config.MAX_AGE_TEMP_IMAGE
+
+        if max_age:
+            self.set_header('Cache-Control', 'max-age=' + str(max_age) + ',public')
+            self.set_header('Expires', datetime.datetime.utcnow() + datetime.timedelta(seconds=max_age))
+
+        self.set_header('Server', 'Thumbor/%s' % __version__)
+        self.set_header('Content-Type', content_type)
+
+        if isinstance(results, ResultStorageResult):
+            buffer = results.buffer
+        else:
+            buffer = results
+
+        # auto-convert configured?
+        should_vary = self.context.config.AUTO_WEBP
+        # we have image (not video)
+        should_vary = should_vary and content_type.startswith("image/")
+        # output format is not requested via format filter
+        should_vary = should_vary and not (
+            self.context.request.format and  # format is supported by filter
+            bool(re.search(r"format\([^)]+\)", self.context.request.filters))  # filter is in request
+        )
+        # our image is not animated gif
+        should_vary = should_vary and not self.is_animated_gif(buffer)
+
+        if should_vary:
+            self.set_header('Vary', 'Accept')
+
+        self._response_ext = EXTENSION.get(content_type)
+        self._response_length = len(buffer)
+
+        self.write(buffer)
+        self.finish()
+
+    @staticmethod
+    def is_animated_gif(data):
+        if data[:6] not in [b"GIF87a", b"GIF89a"]:
+            return False
+        i = 10  # skip header
+        frames = 0
+
+        def skip_color_table(i, flags):
+            if flags & 0x80:
+                i += 3 << ((flags & 7) + 1)
+            return i
+
+        flags = ord(data[i])
+        i = skip_color_table(i + 3, flags)
+        while frames < 2:
+            block = data[i]
+            i += 1
+            if block == b'\x3B':
+                break
+            if block == b'\x21':
+                i += 1
+            elif block == b'\x2C':
+                frames += 1
+                i += 8
+                i = skip_color_table(i + 1, ord(data[i]))
+                i += 1
+            else:
+                return False
+            while True:
+                skip = ord(data[i])
+                i += 1
+                if not skip:
+                    break
+                i += skip
+        return frames > 1
+
+    def can_auto_convert_png_to_jpg(self):
+        return self.context.request.engine.can_auto_convert_png_to_jpg()
+
+    def define_image_type(self, result=None):
+        if result is not None:
+            if isinstance(result, ResultStorageResult):
+                buffer = result.buffer
+            else:
+                buffer = result
+            image_extension = EXTENSION.get(BaseEngine.get_mimetype(buffer), '.jpg')
+        else:
+            image_extension = self.context.request.format
+            if image_extension is not None:
+                image_extension = '.%s' % image_extension
+                logger.debug('Image format specified as %s.' % image_extension)
+            elif self.is_webp():
+                image_extension = '.webp'
+                logger.debug('Image format set by AUTO_WEBP as %s.' % image_extension)
+            elif self.can_auto_convert_png_to_jpg():
+                image_extension = '.jpg'
+                logger.debug('Image format set by AUTO_PNG_TO_JPG as %s.' % image_extension)
+            else:
+                image_extension = self.context.request.engine.extension
+                logger.debug('No image format specified. Retrieving from the image extension: %s.' % image_extension)
+
+        content_type = CONTENT_TYPE.get(image_extension, CONTENT_TYPE['.jpg'])
+
+        if self.context.request.meta:
+            self.context.request.meta_callback = self.context.config.META_CALLBACK_NAME or \
+                self.request.arguments.get('callback', [None])[0]
+            content_type = 'text/javascript' if self.context.request.meta_callback else 'application/json'
+            logger.debug('Metadata requested. Serving content type of %s.' % content_type)
+
+        logger.debug('Content Type of %s detected.' % content_type)
+
+        return image_extension, content_type
+
+    def is_webp(self):
+        return (self.context.config.AUTO_WEBP and
+                self.context.request.accepts_webp and
+                not self.context.request.engine.is_multiple() and
+                self.context.request.engine.can_convert_to_webp())
+
+    @gen.coroutine  # NOQA
+    def get_image(self):
+        """
+        This function is called after the PRE_LOAD filters have been applied.
+        It applies the AFTER_LOAD filters on the result, then crops the image.
+        """
+        try:
+            result = yield self._fetch(
+                self.context.request.image_url
+            )
+        except Exception as e:
+            msg = '[BaseHandler] get_image failed for url `{url}`. error: `{error}`'.format(
+                url=self.context.request.image_url,
+                error=e
+            )
+
+            self.log_exception(*sys.exc_info())
+
+            if 'cannot identify image file' in e.message:
+                logger.warning(msg)
+                raise tornado.web.HTTPError(400)
+            else:
+                logger.error(msg)
+                raise tornado.web.HTTPError(500)
+
+        if not result.successful:
+            if result.loader_error == LoaderResult.ERROR_NOT_FOUND:
+                raise tornado.web.HTTPError(404)
+            elif result.loader_error == LoaderResult.ERROR_UPSTREAM:
+                # Return a Bad Gateway status if the error came from upstream
+                raise tornado.web.HTTPError(502)
+            elif result.loader_error == LoaderResult.ERROR_TIMEOUT:
+                # Return a Gateway Timeout status if upstream timed out (i.e. 599)
+                raise tornado.web.HTTPError(504)
+            elif isinstance(result.loader_error, int):
+                raise tornado.web.HTTPError(result.loader_error)
+            elif hasattr(result, 'engine_error') and result.engine_error == EngineResult.COULD_NOT_LOAD_IMAGE:
+                raise tornado.web.HTTPError(400)
+            else:
+                raise tornado.web.HTTPError(500)
+
+        normalized = result.normalized
+        buffer = result.buffer
+        engine = result.engine
+
+        req = self.context.request
+
+        if engine is None:
+            if buffer is None:
+                raise tornado.web.HTTPError(504)
+
+            engine = self.context.request.engine
+            try:
+                engine.load(buffer, self.context.request.extension)
+            except Exception:
+                raise tornado.web.HTTPError(504)
+
+        self.context.transformer = Transformer(self.context)
+
+        yield self.filters_runner.apply_filters(thumbor.filters.PHASE_AFTER_LOAD)
+
+        self.normalize_crops(normalized, req, engine)
+
+        if req.meta:
+            self.context.transformer.engine = \
+                self.context.request.engine = \
+                JSONEngine(engine, req.image_url, req.meta_callback)
+
+        yield self.context.transformer.transform()
+        yield self.after_transform()
+
+    def normalize_crops(self, normalized, req, engine):
+        if normalized and req.should_crop:
+            crop_left = req.crop['left']
+            crop_top = req.crop['top']
+            crop_right = req.crop['right']
+            crop_bottom = req.crop['bottom']
+
+            actual_width, actual_height = engine.size
+
+            if req.width:
+                actual_height = engine.get_proportional_height(engine.size[0])
+            elif req.height:
+                actual_width = engine.get_proportional_width(engine.size[1])
+
+            new_crops = self.translate_crop_coordinates(
+                engine.source_width,
+                engine.source_height,
+                actual_width,
+                actual_height,
+                crop_left,
+                crop_top,
+                crop_right,
+                crop_bottom
+            )
+            req.crop['left'] = new_crops[0]
+            req.crop['top'] = new_crops[1]
+            req.crop['right'] = new_crops[2]
+            req.crop['bottom'] = new_crops[3]
+
+    @gen.coroutine
+    def after_transform(self):
+        if self.context.request.extension != '.gif' or not self.context.config.USE_GIFSICLE_ENGINE:
+            yield self.filters_runner.apply_filters(thumbor.filters.PHASE_POST_TRANSFORM)
+
+        yield self.finish_request()
+
+    @gen.coroutine
+    def finish_request(self):
+        should_store = self.context.modules.result_storage and not self.context.request.prevent_result_storage and (
+            self.context.config.RESULT_STORAGE_STORES_UNSAFE or not self.context.request.unsafe)
+
+        try:
+            results, content_type = yield self.context.thread_pool.queue(self._load_results)
+        except Exception as e:
+            logger.exception('[BaseHander.finish_request] %s', e)
+            raise tornado.web.HTTPError(504, 'Error while trying to fetch the image: {}'.format(e))
+
+        result_storage = self.context.modules.result_storage
+        metrics = self.context.metrics
+        self._write_results_to_client(results, content_type)
+
+        if should_store:
+            self._store_results(result_storage, metrics, results)
+
+    def _load_results(self):
+        image_extension, content_type = self.define_image_type()
+
+        quality = self.context.request.quality
+        if quality is None:
+            if image_extension == '.webp' and self.context.config.WEBP_QUALITY is not None:
+                quality = self.context.config.get('WEBP_QUALITY')
+            else:
+                quality = self.context.config.QUALITY
+        results = self.context.request.engine.read(image_extension, quality)
+        if self.context.request.max_bytes is not None:
+            results = self.reload_to_fit_in_kb(
+                self.context.request.engine,
+                results,
+                image_extension,
+                quality,
+                self.context.request.max_bytes
+            )
+        if not self.context.request.meta:
+            results = self.optimize(image_extension, results)
+            # An optimizer might have modified the image format.
+            content_type = BaseEngine.get_mimetype(results)
+
+        return results, content_type
+
+    def optimize(self, image_extension, results):
+        for optimizer in self.context.modules.optimizers:
+            new_results = optimizer(self.context).run_optimizer(image_extension, results)
+            if new_results is not None:
+                results = new_results
+
+        return results
+
+    def reload_to_fit_in_kb(self, engine, initial_results, extension, initial_quality, max_bytes):
+        if extension not in ['.webp', '.jpg', '.jpeg'] or len(initial_results) <= max_bytes:
+            return initial_results
+
+        results = initial_results
+        quality = initial_quality
+
+        while len(results) > max_bytes:
+            quality = int(quality * 0.75)
+
+            if quality < 10:
+                logger.debug('Could not find any reduction that matches required size of %d bytes.' % max_bytes)
+                return initial_results
+
+            logger.debug('Trying to downsize image with quality of %d...' % quality)
+            results = engine.read(extension, quality)
+
+        prev_result = results
+        while len(results) <= max_bytes:
+            quality = int(quality * 1.1)
+            logger.debug('Trying to upsize image with quality of %d...' % quality)
+            prev_result = results
+            results = engine.read(extension, quality)
+
+        return prev_result
+
+    @gen.coroutine
+    def _store_results(self, result_storage, metrics, results):
+        start = datetime.datetime.now()
+
+        yield gen.maybe_future(result_storage.put(results))
+
+        finish = datetime.datetime.now()
+        metrics.incr('result_storage.bytes_written', len(results))
+        metrics.timing('result_storage.outgoing_time', (finish - start).total_seconds() * 1000)
+
+    @gen.coroutine
+    def _fetch(self, url):
+        """
+
+        :param url:
+        :type url:
+        :return:
+        :rtype:
+        """
+        fetch_result = FetchResult()
+
+        storage = self.context.modules.storage
+
+        yield self.acquire_url_lock(url)
+
+        try:
+            fetch_result.buffer = yield gen.maybe_future(storage.get(url))
+            mime = None
+
+            if fetch_result.buffer is not None:
+                self.release_url_lock(url)
+
+                fetch_result.successful = True
+
+                self.context.metrics.incr('storage.hit')
+                mime = BaseEngine.get_mimetype(fetch_result.buffer)
+                self.context.request.extension = EXTENSION.get(mime, '.jpg')
+                if mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
+                    self.context.request.engine = self.context.modules.gif_engine
+                else:
+                    self.context.request.engine = self.context.modules.engine
+
+                raise gen.Return(fetch_result)
+            else:
+                self.context.metrics.incr('storage.miss')
+
+            loader_result = yield self.context.modules.loader.load(self.context, url)
+        finally:
+            self.release_url_lock(url)
+
+        if isinstance(loader_result, LoaderResult):
+            # TODO _fetch should probably return a result object vs a list to
+            # to allow returning metadata
+            if not loader_result.successful:
+                fetch_result.buffer = None
+                fetch_result.loader_error = loader_result.error
+                raise gen.Return(fetch_result)
+
+            fetch_result.buffer = loader_result.buffer
+        else:
+            # Handle old loaders
+            fetch_result.buffer = loader_result
+
+        if fetch_result.buffer is None:
+            raise gen.Return(fetch_result)
+
+        fetch_result.successful = True
+
+        if mime is None:
+            mime = BaseEngine.get_mimetype(fetch_result.buffer)
+
+        self.context.request.extension = extension = EXTENSION.get(mime, '.jpg')
+
+        try:
+            if mime == 'image/gif' and self.context.config.USE_GIFSICLE_ENGINE:
+                self.context.request.engine = self.context.modules.gif_engine
+            else:
+                self.context.request.engine = self.context.modules.engine
+
+            try:
+                self.context.request.engine.load(fetch_result.buffer, extension)
+            except Exception:
+                pass
+
+            if self.context.request.engine.image is None:
+                fetch_result.successful = False
+                fetch_result.buffer = None
+                fetch_result.engine = self.context.request.engine
+                fetch_result.engine_error = EngineResult.COULD_NOT_LOAD_IMAGE
+                raise gen.Return(fetch_result)
+
+            fetch_result.normalized = self.context.request.engine.normalize()
+
+            # Allows engine or loader to override storage on the fly for the purpose of
+            # marking a specific file as unstoreable
+            storage = self.context.modules.storage
+
+            is_no_storage = isinstance(storage, NoStorage)
+            is_mixed_storage = isinstance(storage, MixedStorage)
+            is_mixed_no_file_storage = is_mixed_storage and isinstance(storage.file_storage, NoStorage)
+
+            if not (is_no_storage or is_mixed_no_file_storage):
+                storage.put(url, fetch_result.buffer)
+
+            storage.put_crypto(url)
+        except Exception:
+            raise
+
+        fetch_result.buffer = None
+        fetch_result.engine = self.context.request.engine
+        raise gen.Return(fetch_result)
+
+    @gen.coroutine
+    def acquire_url_lock(self, url):
+        if url not in ImagingHandler.url_locks:
+            ImagingHandler.url_locks[url] = Condition()
+        else:
+            yield ImagingHandler.url_locks[url].wait()
+
+    def release_url_lock(self, url):
+        try:
+            ImagingHandler.url_locks[url].notify_all()
+            del ImagingHandler.url_locks[url]
+        except KeyError:
+            pass
+
+    @gen.coroutine
     def get(self, **kw):
-        self.check_image(kw)
+        yield self.check_image(kw)
 
-    @tornado.web.asynchronous
+    @gen.coroutine
     def head(self, **kw):
-        self.check_image(kw)
+        yield self.check_image(kw)


### PR DESCRIPTION
Reason for these changes is that sometimes, when exception happens inside coroutine which was not yielded, it got trapped inside Future object for timeout (of 60 seconds) and request hangs for that time (since handler methods are `@asynchronous`)

Unyielded coroutines create other issues as well, like [inability to write a test for fail case ](https://github.com/thumbor/thumbor/pull/932)

Also, crossing fingers, that such change could help with memory leaks.

Also would be nice to have #894 merged before this one.