### PR TITLE
I'm making this commit to replace the deprecated library dlitz/pycrypto

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ You'll need Python 2.7 and we seriously advise you to use virtualenv (http://pyp
 The following packages are required:
 
 * Tornado >= 2.3.0
-* pyCrypto >= 2.4.1
+* pycryptodome >= 3.4.5
 * pycurl >= 7.19.0
 * Pillow >= 2.3.0
 * redis >= 2.4.11

--- a/docs/hacking_on_thumbor.rst
+++ b/docs/hacking_on_thumbor.rst
@@ -22,7 +22,7 @@ You'll also need python >= 2.6 and < 3.0.
 The following packages are required:
 
 -  Tornado >= 2.1.1
--  pyCrypto >= 2.4.1
+-  pycryptodome >= 3.4.7
 -  pycurl >= 7.19.0
 -  Pillow >= 1.7.5
 -  redis >= 2.4.11

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import logging
 
 tests_require = [
     "redis>=2.4.9,<3.0.0",
-    "coverage",
+    "coverage>=4.4.1",
     "mock>=1.0.1,<3.0.0",
     "raven",
     "nose",
@@ -32,6 +32,7 @@ tests_require = [
     "cairosvg>=1.0.0,<2.0.0,!=1.0.21",
     "preggy>=1.3.0",
     "opencv-python",
+    "yanc>=0.3.3",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
 
         install_requires=[
             "tornado>=4.1.0,<5.0.0",
-            "pyCrypto>=2.1.0",
+            "pycryptodome >= 3.4.7",
             "pycurl>=7.19.0,<7.44.0",
             "Pillow>=3.0.0,<5.0.0",
             "derpconf>=0.2.0",

--- a/thumbor/crypto.py
+++ b/thumbor/crypto.py
@@ -23,7 +23,7 @@ try:
 except NameError:
     unicode = str  # Python 3
 
-
+MODE_ECB = 1       
 class Cryptor(object):
     def __init__(self, security_key):
         self.security_key = (security_key * 16)[:16]
@@ -72,7 +72,7 @@ class Cryptor(object):
         def pad(s):
             return s + (16 - len(s) % 16) * "{"
 
-        cipher = AES.new(self.security_key)
+        cipher = AES.new(self.security_key, MODE_ECB)
         encrypted = base64.urlsafe_b64encode(cipher.encrypt(pad(url.encode('utf-8'))))
 
         return encrypted
@@ -121,7 +121,7 @@ class Cryptor(object):
         return opt
 
     def decrypt(self, encrypted):
-        cipher = AES.new(self.security_key)
+        cipher = AES.new(self.security_key, MODE_ECB)
 
         try:
             debased = base64.urlsafe_b64decode(encrypted.encode("utf-8"))

--- a/thumbor/crypto.py
+++ b/thumbor/crypto.py
@@ -23,7 +23,7 @@ try:
 except NameError:
     unicode = str  # Python 3
 
-MODE_ECB = 1       
+MODE_ECB = 1
 class Cryptor(object):
     def __init__(self, security_key):
         self.security_key = (security_key * 16)[:16]


### PR DESCRIPTION
for legrandin/pycryptome mostly a drag and drop replacement

For deprecation notice see: https://github.com/dlitz/pycrypto/issues/173
For Legrandin/pycryptome see: https://github.com/Legrandin/pycryptodome

You should note that this does require the replacement library pycryptodome.  I will leave it to the owners of Thumbor to decide how that changes versioning.

```$ nosEtests -v -s tests/test_crypto.py
test_can_create_crypto_with_key (tests.test_crypto.CryptoTestCase) ... ok
test_can_decrypt (tests.test_crypto.CryptoTestCase) ... ok
test_can_encrypt (tests.test_crypto.CryptoTestCase) ... ok
test_decrypting_with_wrong_key (tests.test_crypto.CryptoTestCase) ... /Users/torrho/Projects/thumbor/thumbor-crypto-test/lib/python2.7/site-packages/preggy/assertions/equality.py:26: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  return expected == topic
ok
test_get_options (tests.test_crypto.CryptoTestCase) ... ok
test_get_options_from_storage (tests.test_crypto.CryptoTestCase) ... ok
test_get_options_from_storage_returns_null_if_key_not_found (tests.test_crypto.CryptoTestCase) ... ok
test_get_options_returns_null_if_different_path (tests.test_crypto.CryptoTestCase) ... ok
test_get_options_returns_null_if_invalid (tests.test_crypto.CryptoTestCase) ... ok
tests.test_crypto.test_decrypting_combinations({'trim': None, 'full': False, 'image_hash': 'f33af67e41168e80fcc5b00f8bd8061a', 'halign': 'center', 'fit_in': False, 'vertical_flip': False, 'crop': {'top': 0, 'right': 0, 'bottom': 0, 'left': 0}, 'height': 200, 'width': 300, 'meta': False, 'horizontal_flip': False, 'filters': '', 'valign': 'middle', 'debug': False, 'adaptive': False, 'smart': False}, {'trim': None, 'fit_in': False, 'image_hash': 'f33af67e41168e80fcc5b00f8bd8061a', 'full': False, 'width': 300, 'vertical_flip': False, 'crop': {'top': 0, 'right': 0, 'bottom': 0, 'left': 0}, 'height': 200, 'halign': 'center', 'meta': False, 'horizontal_flip': False, 'filters': '', 'valign': 'middle', 'debug': False, 'adaptive': False, 'smart': False}) ... ok
tests.test_crypto.test_decrypting_combinations({'trim': None, 'full': False, 'image_hash': 'f33af67e41168e80fcc5b00f8bd8061a', 'halign': 'center', 'fit_in': False, 'vertical_flip': False, 'crop': {'top': 0, 'right': 0, 'bottom': 0, 'left': 0}, 'height': 0, 'width': 0, 'meta': False, 'horizontal_flip': False, 'filters': 'quality(20):brightness(10)', 'valign': 'middle', 'debug': False, 'adaptive': False, 'smart': False}, {'trim': None, 'fit_in': False, 'image_hash': 'f33af67e41168e80fcc5b00f8bd8061a', 'full': False, 'width': 0, 'vertical_flip': False, 'crop': {'top': 0, 'right': 0, 'bottom': 0, 'left': 0}, 'height': 0, 'halign': 'center', 'meta': False, 'horizontal_flip': False, 'filters': 'quality(20):brightness(10)', 'valign': 'middle', 'debug': False, 'adaptive': False, 'smart': False}) ... ok

----------------------------------------------------------------------
Ran 11 tests in 0.021s

OK
```