### PR TITLE
follow scheme when thumbor is behind a proxy

### DIFF
--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -31,13 +31,26 @@ def quote_url(url):
     return encode_url(unquote(url).decode('utf-8'))
 
 
-def _normalize_url(url):
+def _normalize_url(url, forwarded_proto=None):
     url = quote_url(url)
-    return url if url.startswith('http') else 'http://%s' % url
+    if url.startswith('http') or url.startswith('https'):
+        pass
+    else:
+        if forwarded_proto:
+            scheme = forwarded_proto
+        else:
+            scheme = 'http'
+        url = '%s://%s' % (scheme, url)
+    return url
 
 
 def validate(context, url, normalize_url_func=_normalize_url):
-    url = normalize_url_func(url)
+    if "X-Forwarded-Proto" in context.request_handler.request.headers:
+        forwarded_proto = context.request_handler.request.headers['X-Forwarded-Proto']
+    else:
+        forwarded_proto = None
+    
+    url = normalize_url_func(url, forwarded_proto)
     res = urlparse(url)
 
     if not res.hostname:

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -49,7 +49,6 @@ def validate(context, url, normalize_url_func=_normalize_url):
         forwarded_proto = context.request_handler.request.headers['X-Forwarded-Proto']
     else:
         forwarded_proto = None
-    
     url = normalize_url_func(url, forwarded_proto)
     res = urlparse(url)
 

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -45,8 +45,9 @@ def _normalize_url(url, forwarded_proto=None):
 
 
 def validate(context, url, normalize_url_func=_normalize_url):
-    if "X-Forwarded-Proto" in context.request_handler.request.headers:
-        forwarded_proto = context.request_handler.request.headers['X-Forwarded-Proto']
+    if context.request_handler.request.headers is not None:
+        if "X-Forwarded-Proto" in context.request_handler.request.headers:
+            forwarded_proto = context.request_handler.request.headers['X-Forwarded-Proto']
     else:
         forwarded_proto = None
     url = normalize_url_func(url, forwarded_proto)


### PR DESCRIPTION
follow scheme: if thumbor is behind a proxy (as ssl terminator) and proxy pass the pretty standard header "X-Forwarded-Proto", thumbor choose this schema to request the original image.