### PR TITLE
Pass through querystring params via new `HTTP_LOADER_FORWARD_QUERYSTRING*` settings

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -172,6 +172,12 @@ Config.define(
     'HTTP_LOADER_FORWARD_HEADERS_WHITELIST', [],
     'Indicates which headers should be forwarded among all the headers of the request', 'HTTP Loader')
 Config.define(
+    'HTTP_LOADER_FORWARD_QUERYSTRING', False,
+    'Indicates whether thumbor should forward the querystring of the request', 'HTTP Loader')
+Config.define(
+    'HTTP_LOADER_FORWARD_QUERYSTRING_WHITELIST', [],
+    'Indicates which of the request querystring parameters should be forwarded', 'HTTP Loader')
+Config.define(
     'HTTP_LOADER_DEFAULT_USER_AGENT', "Thumbor/%s" % __version__,
     'Default user agent for thumbor http loader requests', 'HTTP Loader')
 Config.define(

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -134,6 +134,7 @@ class RequestParameters:
                  quality=80,
                  image=None,
                  url=None,
+                 query=None,
                  extension=None,
                  buffer=None,
                  focal_points=None,
@@ -185,6 +186,7 @@ class RequestParameters:
         self.filters = filters
         self.image_url = image
         self.url = url
+        self.query = query
         self.detection_error = None
         self.quality = quality
         self.buffer = None
@@ -203,6 +205,7 @@ class RequestParameters:
 
         if request:
             self.url = request.path
+            self.query = request.query
             self.accepts_webp = 'image/webp' in request.headers.get('Accept', '')
 
     def int_or_0(self, value):

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -13,7 +13,7 @@ import re
 from functools import partial
 
 import tornado.httpclient
-from six.moves.urllib.parse import quote, unquote, urlparse
+from six.moves.urllib.parse import quote, unquote, urlparse, urlunparse, parse_qs, urlencode
 
 from . import LoaderResult
 from thumbor.utils import logger
@@ -130,6 +130,26 @@ def load_sync(context, url, callback, normalize_url_func):
         user_agent = context.config.HTTP_LOADER_DEFAULT_USER_AGENT
 
     url = normalize_url_func(url)
+
+    # Pass through querystring parameters from Thumbor URL when fetching
+    # original image URL.
+    query = parse_qs(context.request.query)
+    if not context.config.HTTP_LOADER_FORWARD_QUERYSTRING:
+        # Ignore case when comparing parameter names against the whitelist.
+        allowed = [key.lower() for key in context.config.HTTP_LOADER_FORWARD_QUERYSTRING_WHITELIST]
+        for key in query.keys():
+            if key.lower() not in allowed:
+                # Remove any non-whitelisted parameters.
+                query.pop(key, None)
+    if query:
+        # The original image URL might also contain querystring parameters, so
+        # we need to merge them with any being passed through. Do not allow
+        # passthrough parameters to override original URL parameters.
+        url = urlparse(url)
+        query.update(parse_qs(url.query))
+        url = url._replace(query=urlencode(query, doseq=True))
+        url = urlunparse(url)
+
     req = tornado.httpclient.HTTPRequest(
         url=url,
         headers=headers,


### PR DESCRIPTION
This allows you to generate thumbnails for any number of private AWS S3 buckets with a single Thumbor server, as long as you pass absolute signed AWS S3 URLs to Thumbor.

This follows the pattern established with the `HTTP_LOADER_FORWARD_*HEADERS*` settings.

Case is ignored when comparing parameter names against the whitelist.

To prevent tampering, querystring parameters being passed through are not allowed to override or extend existing querystring parameters in the urlencoded original image URL.

NOTE:

Any querystring parameters that are not temporary/ephemeral, and which affect the original image to be downloaded, should be specified as part of the urlencoded original image URL, NOT as part of the Thumbor URL.

Querystring parameters in the Thumbor URL are (still) not considered to be part of the original image URL, which is used as a cache key, which would mean multiple requests for the same image with different signatures would be downloaded and processed multiple times.

A consequence of this is that you should NOT allow "unsafe" Thumbor URLs when passing through auth credentials as querystring parameters. Once Thumbor has successfully processed and cached the image for such a request, subsequent requests could access the cached image without providing any auth credentials.

Instead, you are expected to rely on the HMAC validation for "safe" Thumbor URLs, and ensure that clients are authorized before generating safe URLs for private images that require auth credentials.

The same is true for auth credentials passed through as request headers.

Likewise, a similar issue exists when allowing unsafe URLs with the AWS S3 loader, where Thumbor itself generates the AWS S3 signatures.