### PR TITLE
fix issues with the jpegtran optimizer and the epoll IOLoop

### DIFF
--- a/thumbor/optimizers/jpegtran.py
+++ b/thumbor/optimizers/jpegtran.py
@@ -41,7 +41,11 @@ class Optimizer(BaseOptimizer):
                 '-progressive'
             ]
 
-        jpg_process = Popen(command, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        # close_fds would have a sane default on Python 3 but with Python 2.7 it is False
+        # per default but setting it to True + setting any of stdin, stdout, stderr will
+        # make this crash on Windows
+        # TODO remove close_fds=True if code was upgraded to Python 3
+        jpg_process = Popen(command, stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True)
         output_stdout, output_stderr = jpg_process.communicate(buffer)
 
         if jpg_process.returncode != 0:


### PR DESCRIPTION
after enabling the jpegtran optimizer and having enough traffic the IOLoop from tornado
starts to through now and then the following exception.
```json
{
  "module": "ioloop",
  "funcName": "handle_callback_exception",
  "message": "Exception in callback None",
  "exception": [
    "Traceback (most recent call last):\n",
    "  File \"/usr/local/lib/python2.7/site-packages/tornado/ioloop.py\", line 887, in start\n    fd_obj, handler_func = self._handlers[fd]\n",
    "KeyError: 14\n"
  ],
  "name": "tornado.application",
  "threadName": "MainThread",
  "filename": "ioloop.py",
  "processName": "MainProcess",
  "pathname": "/usr/local/lib/python2.7/site-packages/tornado/ioloop.py",
  "lineno": 638,
  "levelname": "ERROR"
}
```

Reading through http://y.tsutsumi.io/keyerror-in-self_handlers-a-journey-deep-into-tornados-internals.html
and keeping in mind that Popen is also doing a fork the base idea was to ensure that all FDs are being closed
on the fork which worked for us and the error doesn't happen anymore.

The error was easily reproducable with a local running thumbor 6.2.1 with Pillow and also with the OpenCV engine
(tested both) by doing something like this:

ab -c 10 -n 1000 "http://localhost:8080/unsafe/filters:format(jpeg)/http://172.17.0.1:8081/pic.png"

(be aware the error happens not immediately so wait until you have 300-400 requests)