### PR TITLE
Add Bumbo to Libraries

### DIFF
--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -73,6 +73,12 @@ PHP
 -  `Phumbor for Symfony2 <https://github.com/jbouzekri/PhumborBundle>`__
    - A Symfony2 Bundle providing a facade for Phumbor.
 
+Swift
+~~~~~
+
+-  `Bumbo <https://github.com/guilhermearaujo/Bumbo>`__ - A swifty client
+   for Thumbor
+
 Objective-C
 ~~~~~~~~~~~
 


### PR DESCRIPTION
Add (Bumbo)[https://github.com/guilhermearaujo/Bumbo], a Swift library, to the list of libraries in the docs.  