### PR TITLE
don't decode twice and encode if not required

### DIFF
--- a/thumbor/filters/watermark.py
+++ b/thumbor/filters/watermark.py
@@ -147,8 +147,7 @@ class Filter(BaseFilter):
         else:
             buffer = result
 
-        self.watermark_engine.load(buffer, None)
-        self.storage.put(self.url, self.watermark_engine.read())
+        self.storage.put(self.url, buffer)
         self.storage.put_crypto(self.url)
         self.on_image_ready(buffer)
 


### PR DESCRIPTION
the watermark filter was actually decoding the watermark image 2x
and in case the NoStorage was being used it was also encoding it 1x
without a real need to do so.

Test:

http://localhost:8888/unsafe/filters:watermark(https://somewhere.com/image.jpg,-10,-10,20)/https://somewhereelse.com/another_image.jpg

Before the change the following engine calls were made:

engine.create_image() # main image decode
engine.create_image() # watermark decode 1st
engine.read()         # watermark encode => storage
engine.create_image() # watermark decode 2nd
engine.read()         # final image generation

After the change (without storage):

engine.create_image() # main image decode
engine.create_image() # watermark decode
engine.read()         # final image generation