### PR TITLE
Bring back 'headers' context property as it is used by result storages

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -38,6 +38,8 @@ class ContextTestCase(TestCase):
         expect(ctx.filters_factory.filter_classes_map).to_be_empty()
         expect(ctx.request_handler).to_be_null()
         expect(ctx.thread_pool).to_be_instance_of(ThreadPool)
+        expect(ctx.headers).to_be_instance_of(dict)
+        expect(ctx.headers).to_be_empty()
 
     def test_can_create_context_with_importer(self):
         cfg = Config()

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -58,6 +58,7 @@ class Context:
         self.filters_factory = FiltersFactory(self.modules.filters if self.modules else [])
         self.request_handler = request_handler
         self.thread_pool = ThreadPool.instance(getattr(config, 'ENGINE_THREADPOOL_SIZE', 0))
+        self.headers = {}
 
     def __enter__(self):
         return self

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -85,7 +85,8 @@ class BaseHandler(tornado.web.RequestHandler):
                 self.context.metrics.incr('response.bytes{0}'.format(ext), self._response_length)
 
         self.context.request_handler = None
-        self.context.request.engine = None
+        if hasattr(self.context, 'request'):
+            self.context.request.engine = None
         self.context.modules = None
         self.context.filters_factory = None
         self.context.metrics = None
@@ -397,7 +398,7 @@ class BaseHandler(tornado.web.RequestHandler):
         result_storage = context.modules.result_storage
         metrics = context.metrics
 
-        should_store = result_from_storage is None and result_storage and not context.request.prevent_result_storage \
+        should_store = result_storage and not context.request.prevent_result_storage \
             and (context.config.RESULT_STORAGE_STORES_UNSAFE or not context.request.unsafe)
 
         def inner(future):
@@ -455,6 +456,7 @@ class BaseHandler(tornado.web.RequestHandler):
         if should_vary:
             self.set_header('Vary', 'Accept')
 
+        self.context.headers = self._headers.copy()
         self._response_ext = EXTENSION.get(content_type)
         self._response_length = len(buffer)
 

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -8,7 +8,6 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
-import gc
 import sys
 import logging
 import logging.config
@@ -123,12 +122,6 @@ def run_server(application, context):
         server.bind(context.server.port, context.server.ip)
 
     server.start(1)
-
-
-def gc_collect():
-    collected = gc.collect()
-    if collected > 0:
-        logging.warn('Garbage collector: collected %d objects.' % collected)
 
 
 def main(arguments=None):


### PR DESCRIPTION
Should fix https://github.com/thumbor/thumbor/pull/1003#issuecomment-365550122
@heynemann @bjoernhaeuser 