### PR TITLE
bad fallback variable name

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -20,7 +20,7 @@ try:
     import cv2
     import numpy
 except ImportError:
-    cv = None
+    cv2 = None
     numpy = None
 
 from thumbor.engines import BaseEngine

--- a/thumbor/loaders/file_loader.py
+++ b/thumbor/loaders/file_loader.py
@@ -14,9 +14,11 @@ from os import fstat
 from os.path import join, exists, abspath
 from tornado.concurrent import return_future
 
+from urllib import unquote
 
 @return_future
 def load(context, path, callback):
+    path = unquote(path)
     file_path = join(context.config.FILE_LOADER_ROOT_PATH.rstrip('/'), path.lstrip('/'))
     file_path = abspath(file_path)
     inside_root_path = file_path.startswith(context.config.FILE_LOADER_ROOT_PATH)


### PR DESCRIPTION
I just tripped over this on a fresh install where opencv wasn't available and I was working with tiff files.
Fix is trivial.