### PR TITLE
obvious fix for bad fallback variable name

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -20,7 +20,7 @@ try:
     import cv2
     import numpy
 except ImportError:
-    cv = None
+    cv2 = None
     numpy = None
 
 from thumbor.engines import BaseEngine


### PR DESCRIPTION
I just tripped over this on a fresh install where opencv wasn't available and I was working with tiff files.
Fix is trivial.

supersedes #1043 as that referenced the master, sorry for that