### PR TITLE
Fix posterization issues for P mode PNG without transparency (and with)

### DIFF
--- a/tests/engines/test_pil.py
+++ b/tests/engines/test_pil.py
@@ -88,17 +88,29 @@ class PilEngineTestCase(TestCase):
         with open(join(STORAGE_PATH, '1bit.png'), 'r') as im:
             buffer = im.read()
         engine.load(buffer, '.png')
+        expect(engine.original_mode).to_equal('P')  # Note that this is not a true 1bit image, it's 8bit in black/white.
+
         engine.resize(10, 10)
         mode, _ = engine.image_data_as_rgb()
-        expect(mode).to_equal('P')  # Note that this is not a true 1bit image, it's 8bit in black/white.
+        expect(mode).to_equal('RGB')
+
+        final_bytes = BytesIO(engine.read())
+        mode = Image.open(final_bytes).mode
+        expect(mode).to_equal('P')
 
     def test_convert_should_preserve_palette_mode(self):
         engine = Engine(self.context)
         with open(join(STORAGE_PATH, '256_color_palette.png'), 'r') as im:
             buffer = im.read()
         engine.load(buffer, '.png')
+        expect(engine.original_mode).to_equal('P')
+
         engine.resize(10, 10)
         mode, _ = engine.image_data_as_rgb()
+        expect(mode).to_equal('RGB')
+
+        final_bytes = BytesIO(engine.read())
+        mode = Image.open(final_bytes).mode
         expect(mode).to_equal('P')
 
     def test_can_set_resampling_filter(self):
@@ -182,9 +194,10 @@ class PilEngineTestCase(TestCase):
             buffer = im.read()
 
         engine.load(buffer, 'png')
+        expect(engine.original_mode).to_equal('P')
         engine.resize(200, 150)
 
-        img = Image.open(BytesIO(engine.read('png')))
+        img = Image.open(BytesIO(engine.read('.png')))
 
         expect(img.mode).to_equal('P')
         expect(img.format.lower()).to_equal('png')

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -60,6 +60,9 @@ Config.define('WEBP_QUALITY', None, 'Quality index used for generated WebP image
               'JPEG quality will be used.', 'Imaging')
 
 Config.define('PNG_COMPRESSION_LEVEL', 6, 'Compression level for generated PNG images.', 'Imaging')
+Config.define('PILLOW_PRESERVE_INDEXED_MODE',
+              True,
+              'Indicates if final image should preserve indexed mode (P or 1) of original image', 'Imaging')
 Config.define('AUTO_WEBP', False, 'Specifies whether WebP format should be used automatically if the request accepts it '
               '(via Accept header)', 'Imaging')
 Config.define('SVG_DPI', 150,

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -52,6 +52,7 @@ class Engine(BaseEngine):
         super(Engine, self).__init__(context)
         self.subsampling = None
         self.qtables = None
+        self.original_mode = None
 
         if self.context and self.context.config.MAX_PIXELS:
             Image.MAX_IMAGE_PIXELS = self.context.config.MAX_PIXELS
@@ -70,6 +71,7 @@ class Engine(BaseEngine):
             return None
         self.icc_profile = img.info.get('icc_profile')
         self.exif = img.info.get('exif')
+        self.original_mode = img.mode
 
         self.subsampling = JpegImagePlugin.get_sampling(img)
         if (self.subsampling == -1):  # n/a for this file
@@ -115,11 +117,15 @@ class Engine(BaseEngine):
     def resize(self, width, height):
         # Indexed color modes (such as 1 and P) will be forced to use a
         # nearest neighbor resampling algorithm. So we convert them to
-        # RGBA mode before resizing to avoid nasty scaling artifacts.
-        original_mode = self.image.mode
+        # RGB(A) mode before resizing to avoid nasty scaling artifacts.
         if self.image.mode in ['1', 'P']:
-            logger.debug('converting image from 8-bit/1-bit palette to 32-bit RGBA for resize')
-            self.image = self.image.convert('RGBA')
+            logger.debug('converting image from 8-bit/1-bit palette to 32-bit RGB(A) for resize')
+            if self.image.mode == '1':
+                target_mode = 'RGB'
+            else:
+                # convert() figures out RGB or RGBA based on palette used
+                target_mode = None
+            self.image = self.image.convert(mode=target_mode)
             # Workaround for pillow < 4.3.0. See https://github.com/python-pillow/Pillow/issues/2702
             self.image.palette = None
 
@@ -129,11 +135,6 @@ class Engine(BaseEngine):
 
         resample = self.get_resize_filter()
         self.image = self.image.resize(size, resample)
-
-        # 1 and P mode images will be much smaller if converted back to
-        # their original mode. So let's do that after resizing. Get $$.
-        if original_mode != self.image.mode:
-            self.image = self.image.convert(original_mode)
 
     def crop(self, left, top, right, bottom):
         self.image = self.image.crop((
@@ -169,8 +170,25 @@ class Engine(BaseEngine):
 
     def read(self, extension=None, quality=None):  # NOQA
         # returns image buffer in byte format.
+
         img_buffer = BytesIO()
-        ext = extension or self.extension or self.get_default_extension()
+        requested_extension = extension or self.extension
+
+        # 1 and P mode images will be much smaller if converted back to
+        # their original mode. So let's do that after resizing. Get $$.
+        if self.context.config.PILLOW_PRESERVE_INDEXED_MODE and requested_extension in [None, '.png', '.gif'] \
+                and self.original_mode in ['P', '1'] and self.original_mode != self.image.mode:
+            if self.original_mode == '1':
+                self.image = self.image.convert('1')
+            else:
+                # method=3 is using libimagequant, which might not be enabled on compile time
+                # but it's better than default octree for RGBA images, so worth a try
+                try:
+                    self.image = self.image.quantize(method=3)
+                except ValueError:
+                    self.image = self.image.quantize()
+
+        ext = requested_extension or self.get_default_extension()
 
         options = {
             'quality': quality


### PR DESCRIPTION
Fixes #1036 
The issue in #1036 is caused by Pillow can only use Fast Octree method for quantization of `RGBA` images. Images in original issue are paletted png images without transparency. Thumbor, no matter does image have transparency or not, converts image to `RGBA` mode to avoid nasty resizing artifacts caused by forced nearest neighbor method. That all worked fine until https://github.com/thumbor/thumbor/pull/873 which forced conversion back right after resize from `RGBA` to `P` image. Even if image does not have transparency (meaning that `A` channel is redundant) Pillow forces Fast Octree quantization method upon calling `self.image.convert('P')`. It produces [heavily posterized images](https://github.com/python-pillow/Pillow/issues/554). This is same effect as in #1036. 
For paletted non-transparent images that could be avoided with conversion from `P` to `RGB` instead of `RGBA` and then call `.quantize()` (or equivalent `.convert('P', palette=ADAPTIVE)`). That would fix original issue. Likely, calling `.convert()` on `P` image automatically figures out appropriate `RGB(A)` target mode.

However, looking at this at higher level, we will still have heavy artifacts on P images with transparency in many cases. 
![FF](https://cloud.githubusercontent.com/assets/1045476/15054920/2d603010-130a-11e6-99fe-cd809e39cd42.png)
vs 
![FF2](https://cloud.githubusercontent.com/assets/1045476/15054927/38900e9c-130a-11e6-97c2-bf062d5aa91f.png)


At that point, it appears that https://github.com/thumbor/thumbor/pull/873 introduced BC break, but I am not sure it would be great option to revert it back.
Instead, I am proposing new config parameter (set by default to keep existing behavior) so users can opt-out of converting images back to original paletted modes. This is useful in case they use pngquant as optimizer and would like to avoid double quantization.

Another change introduced here is to move quantization to the end of image processing cycle, so filters, calling `image_as_rgb` would actually work with `RGB(A)` image. (There should not be possible to return `P` image in `image_as_rgb`!) Then at the very end engine will quantize image to original `P` or `1` mode if desired.

Additionally, when quantizing, code tries to use libimagequant method if it's available, or fallsback to default method of quantizing. as far as I can see, there is no runtime check if libimagequant was enabled during compile time.