### PR TITLE
#1051 Adding MIN radius for avoiding Zero Division error.

### DIFF
--- a/thumbor/filters/blur.py
+++ b/thumbor/filters/blur.py
@@ -13,6 +13,7 @@ from thumbor.filters import BaseFilter, filter_method
 from thumbor.ext.filters import _convolution
 
 MAX_RADIUS = 150
+MIN_RADIUS = 1
 
 try:
     xrange          # Python 2
@@ -45,6 +46,8 @@ class Filter(BaseFilter):
             sigma = radius
         if radius > MAX_RADIUS:
             radius = MAX_RADIUS
+        if radius <= 0:
+            radius = MIN_RADIUS
         matrix, matrix_size = self.generate_1d_matrix(sigma, radius)
         mode, data = self.engine.image_data_as_rgb()
         imgdata = _convolution.apply(mode, data, self.engine.size[0], self.engine.size[1], matrix, matrix_size, True)


### PR DESCRIPTION
Currently, There is a bug , if user send filters:blur(0) , thumbor throws ZeroDivision Error, full trace is here 
================================
```2018-03-13 00:05:07 tornado.application:ERROR Future exception was never retrieved: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/tornado/gen.py", line 307, in wrapper
    yielded = next(result)
  File "/usr/local/lib/python2.7/site-packages/thumbor/transformer.py", line 138, in smart_detect
    self.do_image_operations()
  File "/usr/local/lib/python2.7/site-packages/thumbor/transformer.py", line 231, in do_image_operations
    callback=inner
  File "/usr/local/lib/python2.7/site-packages/thumbor/context.py", line 287, in queue
    self._execute_in_foreground(operation, callback)
  File "/usr/local/lib/python2.7/site-packages/thumbor/context.py", line 275, in _execute_in_foreground
    callback(result)
  File "/usr/local/lib/python2.7/site-packages/thumbor/transformer.py", line 227, in inner
    self.done_callback()
  File "/usr/local/lib/python2.7/site-packages/thumbor/handlers/__init__.py", line 247, in after_transform
    self.filters_runner.apply_filters(thumbor.filters.PHASE_POST_TRANSFORM, finish_callback)
  File "/usr/local/lib/python2.7/site-packages/thumbor/filters/__init__.py", line 91, in apply_filters
    exec_one_filter()
  File "/usr/local/lib/python2.7/site-packages/thumbor/filters/__init__.py", line 90, in exec_one_filter
    f.run(exec_one_filter)
  File "/usr/local/lib/python2.7/site-packages/thumbor/filters/__init__.py", line 198, in run
    results.append(self.runnable_method(*self.params))
  File "/usr/local/lib/python2.7/site-packages/thumbor/filters/__init__.py", line 23, in wrapper
    return fn(self, *args2)
  File "/usr/local/lib/python2.7/site-packages/thumbor/filters/blur.py", line 43, in blur
    matrix, matrix_size = self.generate_1d_matrix(sigma, radius)
  File "/usr/local/lib/python2.7/site-packages/thumbor/filters/blur.py", line 33, in generate_1d_matrix
    exp = math.e ** -(((adj_x * adj_x)) / two_sigma_squared)
ZeroDivisionError: float division by zero```
==========================================

to avoid this situation, Added MIN radius params.