### PR TITLE
Graceful shutdown support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build
 *.so
 nohup.out
 *.idea
+.vscode
 *.iml
 opencv
 

--- a/tests/test_signal_handler.py
+++ b/tests/test_signal_handler.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from unittest import TestCase
+import mock
+import signal
+
+from thumbor.signal_handler import (
+    setup_signal_handler,
+    signal_handler,
+)
+
+
+class SignalhandlerTestCase(TestCase):
+
+    @mock.patch('thumbor.signal_handler.signal')
+    def test_setup_signal_handler_sets_handler(self, signal_mock):
+        signal_mock.SIGINT = 2
+        signal_mock.SIGTERM = 15
+        setup_signal_handler(mock.Mock(), mock.Mock())
+
+        signal_mock.signal.assert_has_calls([
+            mock.call(signal_mock.SIGTERM, mock.ANY),
+            mock.call(signal_mock.SIGINT, mock.ANY),
+        ])
+
+    @mock.patch('tornado.ioloop.IOLoop.instance', create=True)
+    def test_signal_handler_calls_add_callback_from_signal(self, ioloop_mock):
+        ioloop_instance_mock = mock.Mock()
+        ioloop_mock.return_value = ioloop_instance_mock
+
+        signal_handler(mock.Mock(), mock.Mock(), signal.SIGTERM, mock.Mock())
+
+        ioloop_instance_mock.add_callback_from_signal.assert_called_with(mock.ANY)

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -392,6 +392,16 @@ Config.define(
     '(python must be able to import it)', 'Extensibility'
 )
 
+# SERVER
+Config.define(
+    'MAX_WAIT_SECONDS_BEFORE_SERVER_SHUTDOWN', 0,
+    'The amount of time to wait before shutting down the server, i.e. stop accepting requests.', 'Server'
+)
+Config.define(
+    'MAX_WAIT_SECONDS_BEFORE_IO_SHUTDOWN', 0,
+    'The amount of time to waut before shutting down all io, after the server has been stopped', 'Server'
+)
+
 Config.define(
     'APP_CLASS', 'thumbor.app.ThumborServiceApp',
     'Custom app class to override ThumborServiceApp. This config value is overridden by the -a command-line parameter.'

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -24,6 +24,7 @@ from thumbor.console import get_server_parameters
 from thumbor.config import Config
 from thumbor.importer import Importer
 from thumbor.context import Context
+from thumbor.signal_handler import setup_signal_handler
 from thumbor.utils import which
 
 from PIL import Image
@@ -122,6 +123,7 @@ def run_server(application, context):
         server.bind(context.server.port, context.server.ip)
 
     server.start(1)
+    return server
 
 
 def main(arguments=None):
@@ -139,14 +141,10 @@ def main(arguments=None):
 
     with get_context(server_parameters, config, importer) as context:
         application = get_application(context)
-        run_server(application, context)
-
-        try:
-            logging.debug('thumbor running at %s:%d' % (context.server.ip, context.server.port))
-            tornado.ioloop.IOLoop.instance().start()
-        except KeyboardInterrupt:
-            sys.stdout.write('\n')
-            sys.stdout.write("-- thumbor closed by user interruption --\n")
+        server = run_server(application, context)
+        setup_signal_handler(server, config)
+        logging.debug('thumbor running at %s:%d' % (context.server.ip, context.server.port))
+        tornado.ioloop.IOLoop.instance().start()
 
 
 if __name__ == "__main__":

--- a/thumbor/signal_handler.py
+++ b/thumbor/signal_handler.py
@@ -1,0 +1,53 @@
+import signal
+import sys
+import time
+
+from thumbor.utils import logger
+import tornado.ioloop
+
+
+def signal_handler(server, config, sig, frame):
+    io_loop = tornado.ioloop.IOLoop.instance()
+
+    def stop_loop(now, deadline):
+        if now < deadline and (io_loop._callbacks or io_loop._timeouts):
+            logger.debug('Waiting for next tick')
+            now += 1
+            io_loop.add_timeout(now, stop_loop, now, deadline)
+        else:
+            io_loop.stop()
+            logger.debug('Shutdown finally')
+
+    def stop_server(now, deadline):
+        if now < deadline:
+            logger.debug('Waiting for next tick')
+            now += 1
+            io_loop.add_timeout(now, stop_server, now, deadline)
+        else:
+            server.stop()
+            logger.debug('Stopped http server.')
+            logger.debug('Will shutdown io in maximum %d seconds ...',
+                         config.MAX_WAIT_SECONDS_BEFORE_IO_SHUTDOWN)
+            now = time.time()
+            stop_loop(now, now + config.MAX_WAIT_SECONDS_BEFORE_IO_SHUTDOWN)
+
+    def shutdown():
+        logger.debug('Stopping http server (i.e. stopping accepting new requests) in %d seconds ...',
+                     config.MAX_WAIT_SECONDS_BEFORE_SERVER_SHUTDOWN)
+        now = time.time()
+        stop_server(now, now + config.MAX_WAIT_SECONDS_BEFORE_SERVER_SHUTDOWN)
+
+    logger.warning('Caught signal: %d. Shutting down server.', sig)
+    io_loop.add_callback_from_signal(shutdown)
+
+
+def setup_signal_handler(server, config):
+
+    def server_sig_handler(sig, frame):
+        signal_handler(server, config, sig, frame)
+        if sig == signal.SIGINT:
+            sys.stdout.write('\n')
+            sys.stdout.write("-- thumbor closed by user interruption --\n")
+
+    signal.signal(signal.SIGTERM, server_sig_handler)
+    signal.signal(signal.SIGINT, server_sig_handler)


### PR DESCRIPTION
We are planning to use thumbor at Ecosia in a kubernetes cluster. For that we would like to support graceful shutdown on `SIGTERM` to ensure we have no requests that will be left unhandled / cancelled in case of a upgrade, or scale event etc.

I tried to keep the changes minimal, with one change though that the `KeyboardInterrupt` will also be handled by the signal handler. I am happy to revert that to the old behaviour if wanted.

Further there are two new configs `MAX_WAIT_SECONDS_BEFORE_SERVER_SHUTDOWN` and `MAX_WAIT_SECONDS_BEFORE_IO_SHUTDOWN` to configure the graceful shutdown. Per default they are both set to 0, which would basically keep the current shutdown behaviour.

I just added unit tests, which does not full test the signal handling behaviour, so I would also be happy to add integration tests if wanted.

Let me know if that is something you would consider merging.