### PR TITLE
allowing separate storage for the watermark filter

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -120,6 +120,10 @@ Config.define(
     'The file storage thumbor should use to store original images. This must be the full name of a python module ' +
     '(python must be able to import it)', 'Extensibility')
 Config.define(
+    'WATERMARK_STORAGE', None,
+    'The file storage thumbor should use to store watermark images (defaults to the same as for original images). ' +
+    'This must be the full name of a python module (python must be able to import it)', 'Extensibility')
+Config.define(
     'RESULT_STORAGE', None,
     'The result storage thumbor should use to store generated images. This must be the full name of a python ' +
     'module (python must be able to import it)', 'Extensibility')

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -225,6 +225,10 @@ class ContextImporter:
         if importer.storage:
             self.storage = importer.storage(context)
 
+        self.watermark_storage = self.storage
+        if importer.watermark_storage:
+            self.watermark_storage = importer.watermark_storage(context)
+
         self.result_storage = None
         if importer.result_storage:
             self.result_storage = importer.result_storage(context)

--- a/thumbor/filters/watermark.py
+++ b/thumbor/filters/watermark.py
@@ -10,6 +10,7 @@
 
 from thumbor.ext.filters import _alpha
 from thumbor.filters import BaseFilter, filter_method
+from thumbor.storages.no_storage import Storage as NoStorage
 from thumbor.loaders import LoaderResult
 from thumbor.utils import logger
 import tornado.gen
@@ -171,7 +172,7 @@ class Filter(BaseFilter):
         self.h_ratio = float(h_ratio) / 100.0 if h_ratio and h_ratio != 'none' else False
         self.callback = callback
         self.watermark_engine = self.context.modules.engine.__class__(self.context)
-        self.storage = self.context.modules.storage
+        self.storage = self.context.modules.watermark_storage
 
         try:
             buffer = yield tornado.gen.maybe_future(self.storage.get(self.url))

--- a/thumbor/importer.py
+++ b/thumbor/importer.py
@@ -32,6 +32,7 @@ class Importer:
         self.url_signer = None
         self.upload_photo_storage = None
         self.storage = None
+        self.watermark_storage = None
         self.metrics = None
         self.result_storage = None
         self.detectors = []
@@ -57,6 +58,9 @@ class Importer:
         self.import_item('FILTERS', 'Filter', is_multiple=True, ignore_errors=True)
         self.import_item('OPTIMIZERS', 'Optimizer', is_multiple=True)
         self.import_item('URL_SIGNER', 'UrlSigner')
+
+        if self.config.WATERMARK_STORAGE is not None:
+            self.import_item('WATERMARK_STORAGE', 'Storage')
 
         if self.config.RESULT_STORAGE:
             self.import_item('RESULT_STORAGE', 'Storage')


### PR DESCRIPTION
Sometimes thanks to CDNs or other caching mechanisms it makes no sense
to have a storage for the files.

This doesn't necessarily apply to watermarks if there is a default
watermark which needs to be applied to all images it makes fully sense
to cache that one because a CDN in front of Thumbor doesn't help at all.

This change won't change the default behaviour. In case
WATERMARK_STORAGE isn't set it will take the one from STORAGE.