### PR TITLE
return a 404 if a request tries to fetch a dir

### DIFF
--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 from shutil import move
 import pytz
 
-from os.path import exists, dirname, join, getmtime, abspath
+from os.path import exists, dirname, join, getmtime, abspath, isdir
 
 from thumbor.engines import BaseEngine
 from thumbor.result_storages import BaseStorage
@@ -55,7 +55,7 @@ class Storage(BaseStorage):
             return None
         logger.debug("[RESULT_STORAGE] getting from %s" % file_abspath)
 
-        if not exists(file_abspath) or self.is_expired(file_abspath):
+        if not exists(file_abspath) or isdir(file_abspath) or self.is_expired(file_abspath):
             logger.debug("[RESULT_STORAGE] image not found at %s" % file_abspath)
             callback(None)
         else:


### PR DESCRIPTION
After a successful request, when a request is made to the same path without the filename filestore attempts to load a directory from it's cache and crashes with a 500 error.

e.g.
http://domain.com/unsafe/$2x0/http://origin.com/path/to/file.jpg  ---> 200 success
followed by
http://domain.com/unsafe/$2x0/http://origin.com/path/to/  ---> 500 error