### PR TITLE
Fix expiry check in file storage

### DIFF
--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -98,7 +98,7 @@ class Storage(BaseStorage):
             return False
 
         timediff = datetime.now() - datetime.fromtimestamp(getmtime(path))
-        return timediff.seconds > expire_in_seconds
+        return timediff.total_seconds() > expire_in_seconds
 
     @deprecated("Use result's last_modified instead")
     def last_updated(self):

--- a/thumbor/storages/file_storage.py
+++ b/thumbor/storages/file_storage.py
@@ -136,4 +136,4 @@ class Storage(storages.BaseStorage):
         if self.context.config.STORAGE_EXPIRATION_SECONDS is None:
             return False
         timediff = datetime.now() - datetime.fromtimestamp(getmtime(path))
-        return timediff.seconds > self.context.config.STORAGE_EXPIRATION_SECONDS
+        return timediff.total_seconds() > self.context.config.STORAGE_EXPIRATION_SECONDS


### PR DESCRIPTION
The ``__is_expired()`` function in storage and result storage is wrongly using ``.seconds`` instead of ``.total_seconds()``.
This leads to ``STORAGE_EXPIRATION_SECONDS`` and ``RESULT_STORAGE_EXPIRATION_SECONDS`` settings not to work with value greater than a day and other odd behaviour.

Here is a comparison between ``timedelta.seconds`` and ``timedelta.total_seconds()``:
```python
>>> timestamp = 1526000000
>>> subtract = lambda a, b: datetime.fromtimestamp(a) - datetime.fromtimestamp(b)
>>> values_to_subtract = [0, 60, 60*60, 60*60*24, 60*60*24+10]
>>> [subtract(timestamp, timestamp-x).seconds for x in values_to_subtract]
[0, 60, 3600, 0, 10]
>>> [subtract(timestamp, timestamp-x).total_seconds() for x in values_to_subtract]
[0.0, 60.0, 3600.0, 86400.0, 86410.0]
>>>
```
``timedelta.seconds`` maximum value is 86400, so files will never be considered expired when ``*_EXPIRATION_SECONDS`` settings is set tot be greater or equal to a day.

Using ``timedelta.seconds`` is similar to using ``timedelta.total_seconds() % 86400``, so with an expiry set to 2h, ``__is_expired()`` will return False if the file is 25h old .
```python
>>> 60*60*25 > 60*60*2
True
>>> 60*60*25 % 86400 > 60*60*2
False
```

I've also updated the expiration test from storage and added a similar test for result storage.