### PR TITLE
fail silently on piexif errors

### DIFF
--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -292,7 +292,11 @@ class BaseEngine(object):
             exif_dict = self._get_exif_segment()
             if exif_dict and piexif.ImageIFD.Orientation in exif_dict["0th"]:
                 exif_dict["0th"][piexif.ImageIFD.Orientation] = 1
-                self.exif = piexif.dump(exif_dict)
+                try:
+                    self.exif = piexif.dump(exif_dict)
+                except Exception as e:
+                    msg = """[piexif] %s""" % e
+                    logger.error(msg)
 
     def gen_image(self, size, color):
         raise NotImplementedError()


### PR DESCRIPTION
since errors are not handled currently the server do not respond

Example:
```
2018-05-24 12:07:42 tornado.application:ERROR Future exception was never retrieved: Traceback (most recent call last):
File "/srv/thumbor/releases/thumbor-1.0.0+b7ed2e27/vendors/tornado/gen.py", line 1069, in run
yielded = self.gen.send(value)
File "/srv/thumbor/releases/thumbor-1.0.0+b7ed2e27/vendors/thumbor/handlers/__init__.py", line 224, in get_image
self.filters_runner.apply_filters(thumbor.filters.PHASE_AFTER_LOAD, transform)
File "/srv/thumbor/releases/thumbor-1.0.0+b7ed2e27/vendors/thumbor/filters/__init__.py", line 81, in apply_filters
callback()
File "/srv/thumbor/releases/thumbor-1.0.0+b7ed2e27/vendors/thumbor/handlers/__init__.py", line 222, in transform
self.context.transformer.transform(self.after_transform)
File "/srv/thumbor/releases/thumbor-1.0.0+b7ed2e27/vendors/thumbor/transformer.py", line 100, in transform
self.engine.reorientate()
File "/srv/thumbor/releases/thumbor-1.0.0+b7ed2e27/vendors/thumbor/engines/__init__.py", line 295, in reorientate
self.exif = piexif.dump(exif_dict)
File "/srv/thumbor/releases/thumbor-1.0.0+b7ed2e27/vendors/piexif/_dump.py", line 74, in dump
gps_set = _dict_to_bytes(gps_ifd, "GPS", zeroth_length + exif_length)
File "/srv/thumbor/releases/thumbor-1.0.0+b7ed2e27/vendors/piexif/_dump.py", line 337, in _dict_to_bytes
offset)
File "/srv/thumbor/releases/thumbor-1.0.0+b7ed2e27/vendors/piexif/_dump.py", line 193, in _value_to_bytes
value_str = (_pack_byte(*raw_value) +
File "/srv/thumbor/releases/thumbor-1.0.0+b7ed2e27/vendors/piexif/_dump.py", line 162, in _pack_byte
return struct.pack("B" * len(args), *args)
error: cannot convert argument to integer
```

NB: fixes https://github.com/thumbor/thumbor/issues/1066