### PR TITLE
Add absolute_import to avoid circular imports

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -8,6 +8,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
+from __future__ import absolute_import
 
 import os
 from tempfile import mkstemp


### PR DESCRIPTION
`absolute_import` is absolutely required in this places, because the line `from PIL import whatever` will try to import whatever from `pil.py` on case-insensitive file systems in Python < 3.0.