### PR TITLE
Bump minimal pillow version to 4.3 to remove 16b tiff load workaround

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
             "tornado>=4.1.0,<5.0.0",
             "pycryptodome >= 3.4.7",
             "pycurl>=7.19.0,<7.44.0",
-            "Pillow>=3.0.0,<5.2.0",
+            "Pillow>=4.3.0,<5.2.0",
             "derpconf>=0.2.0",
             "piexif>=1.0.13,<1.1.0",
             "statsd>=3.0.1",


### PR DESCRIPTION
Fixes #1060 
Workaround [code was added](https://github.com/thumbor/thumbor/pull/746), because pillow prior to version 4.3.0 [could not open](https://pillow.readthedocs.io/en/latest/releasenotes/4.3.0.html#loading-16-bit-tiff-images) 16 bit tiff images. 
I think it's now safe to remove it now and bump minimal pillow version to 4.3. [It was released Oct 1, 2018](https://github.com/python-pillow/Pillow/issues/2664)

Do you guys think it could be considered BC break?