### PR TITLE
Allow Tornado 5.

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -1,7 +1,6 @@
 import os.path
 
 from tornado.testing import AsyncHTTPTestCase
-from tornado.ioloop import IOLoop
 
 from thumbor.app import ThumborServiceApp
 from thumbor.importer import Importer
@@ -43,9 +42,6 @@ class EngineCase(AsyncHTTPTestCase):
         application = ThumborServiceApp(ctx)
 
         return application
-
-    def get_new_ioloop(self):
-        return IOLoop.instance()
 
     def retrieve(self, url):
         self.http_client.fetch(self.get_url(url), self.stop)

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
         },
 
         install_requires=[
-            "tornado>=4.1.0,<5.0.0",
+            "tornado>=4.1.0,<6.0.0",
             "pycryptodome >= 3.4.7",
             "pycurl>=7.19.0,<7.44.0",
             "Pillow>=4.3.0,<5.2.0",

--- a/tests/loaders/test_http_loader.py
+++ b/tests/loaders/test_http_loader.py
@@ -8,20 +8,22 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
+import re
 import time
 from os.path import abspath, join, dirname
-from preggy import expect
+
 import mock
-# from tornado.concurrent import Future
 import tornado.web
-from tests.base import PythonTestCase, TestCase
-from tornado.concurrent import Future
-import re
+from preggy import expect
 from six.moves.urllib.parse import quote
+from tornado.concurrent import Future
+from tornado.httpclient import AsyncHTTPClient
+from tornado.testing import AsyncHTTPTestCase
 
 import thumbor.loaders.http_loader as loader
-from thumbor.context import Context
+from tests.base import PythonTestCase
 from thumbor.config import Config
+from thumbor.context import Context
 from thumbor.loaders import LoaderResult
 
 
@@ -127,7 +129,7 @@ class ValidateUrlTestCase(PythonTestCase):
         config = Config()
         config.ALLOWED_SOURCES = [
             's.glbimg.com',
-            re.compile(r'https:\/\/www\.google\.com/img/.*')
+            re.compile(r'https://www\.google\.com/img/.*')
         ]
         ctx = Context(None, config, None)
         expect(
@@ -178,24 +180,31 @@ class NormalizeUrlTestCase(PythonTestCase):
         expect(result).to_equal(expected)
 
 
-class HttpLoaderTestCase(TestCase):
+class DummyAsyncHttpClientTestCase(AsyncHTTPTestCase):
+    # By default Tornado allows to create one (Async)HttpClient per IOLoop instance
+    # http://www.tornadoweb.org/en/stable/httpclient.html#tornado.httpclient.AsyncHTTPClient
+    # AsyncHTTPTestCase provides a lot of useful code, which starts http server listening with an app running.
+    # But it also constructs AsyncHttpClient, which then by default is getting reused upon next calls to
+    # get new AsyncHttpClient. Some test cases are requiring curl client to be initialized (see http_loader.py)
+    # but, by the time http_loader configures Tornado's AsyncHTTPClient, it's already too late,
+    # since Tornado has http client initialized for given IOLoop.
+    # Forcing new instance here, on test start up time, is ensuring that it won't be treated as singleton
+    # and rather be disposable instance.
+    def get_http_client(self):
+        return AsyncHTTPClient(force_instance=True)
 
+    def tearDown(self):
+        AsyncHTTPClient().close()  # clean up singleton instance
+        super(DummyAsyncHttpClientTestCase, self).tearDown()
+
+
+class HttpLoaderTestCase(DummyAsyncHttpClientTestCase):
     def get_app(self):
         application = tornado.web.Application([
             (r"/", MainHandler),
         ])
 
         return application
-
-    def setUp(self):
-        super(HttpLoaderTestCase, self).setUp()
-        # not sure how AsyncHTTPClient really works (see the
-        # magic regarding quasi-singleton) but I need to
-        # force the connection to be closed so that it can
-        # be configured with the right http client implementation
-        # afterwards, otherwise I will get a cached (and normally
-        # wrong) implementation
-        tornado.httpclient.AsyncHTTPClient().close()
 
     def test_load_with_callback(self):
         url = self.get_url('/')
@@ -238,7 +247,7 @@ class HttpLoaderTestCase(TestCase):
         expect(isinstance(future, Future)).to_be_true()
 
 
-class HttpLoaderWithHeadersForwardingTestCase(TestCase):
+class HttpLoaderWithHeadersForwardingTestCase(DummyAsyncHttpClientTestCase):
 
     def get_app(self):
         application = tornado.web.Application([
@@ -297,7 +306,7 @@ class HttpLoaderWithHeadersForwardingTestCase(TestCase):
         expect(result.buffer).to_include("X-Test:123\n")
 
 
-class HttpLoaderWithUserAgentForwardingTestCase(TestCase):
+class HttpLoaderWithUserAgentForwardingTestCase(DummyAsyncHttpClientTestCase):
 
     def get_app(self):
         application = tornado.web.Application([
@@ -330,7 +339,7 @@ class HttpLoaderWithUserAgentForwardingTestCase(TestCase):
         expect(result.buffer).to_equal('DEFAULT_USER_AGENT')
 
 
-class HttpCurlTimeoutLoaderTestCase(TestCase):
+class HttpCurlTimeoutLoaderTestCase(DummyAsyncHttpClientTestCase):
 
     def get_app(self):
         application = tornado.web.Application([
@@ -338,16 +347,6 @@ class HttpCurlTimeoutLoaderTestCase(TestCase):
         ])
 
         return application
-
-    def setUp(self):
-        super(HttpCurlTimeoutLoaderTestCase, self).setUp()
-        # not sure how AsyncHTTPClient really works (see the
-        # magic regarding quasi-singleton) but I need to
-        # force the connection to be closed so that it can
-        # be configured with the right http client implementation
-        # afterwards, otherwise I will get a cached (and normally
-        # wrong) implementation
-        tornado.httpclient.AsyncHTTPClient().close()
 
     def test_load_with_timeout(self):
         url = self.get_url('/')
@@ -377,7 +376,7 @@ class HttpCurlTimeoutLoaderTestCase(TestCase):
         expect(result.successful).to_be_false()
 
 
-class HttpTimeoutLoaderTestCase(TestCase):
+class HttpTimeoutLoaderTestCase(DummyAsyncHttpClientTestCase):
 
     def get_app(self):
         application = tornado.web.Application([
@@ -385,16 +384,6 @@ class HttpTimeoutLoaderTestCase(TestCase):
         ])
 
         return application
-
-    def setUp(self):
-        super(HttpTimeoutLoaderTestCase, self).setUp()
-        # not sure how AsyncHTTPClient really works (see the
-        # magic regarding quasi-singleton) but I need to
-        # force the connection to be closed so that it can
-        # be configured with the right http client implementation
-        # afterwards, otherwise I will get a cached (and normally
-        # wrong) implementation
-        tornado.httpclient.AsyncHTTPClient().close()
 
     def test_load_without_curl_but_speed_timeout(self):
         url = self.get_url('/')


### PR DESCRIPTION
This PR fixes few tests - removes magic around HttpClient instantiation in one place (fyi @Savar) and simplifies ThreadPool implementation for async case and adds a test.

Mainly this PR allows to use thumbor with Tornado 5. 
