### PR TITLE
Use -trans_color option on gifv instead of mem hungry reverse filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 cache:
   pip: true
   apt: true
-sudo: required
 matrix:
   fast_finish: true
   allow_failures:
@@ -27,6 +26,8 @@ env:
   - UNIT_TEST=1
 addons:
   apt:
+    sources:
+    - trusty-media
     packages:
     - libjpeg-progs
     - libimage-exiftool-perl
@@ -35,12 +36,8 @@ addons:
     - scons
     - libboost-python-dev
     - libexiv2-dev
-before_install:
-  - sudo add-apt-repository -y ppa:jonathonf/ffmpeg-3
-  - sudo apt-get update
-  - sudo apt-get install ffmpeg -y -f
+    - ffmpeg
 install:
-  - ffmpeg -version
   - pip install --upgrade pip
   - pip install -I https://github.com/escaped/pyexiv2/archive/69dd6448f9831bd826137b7519f9d797b23ab4ec.zip
   - cd $TRAVIS_BUILD_DIR && make setup_python

--- a/thumbor/optimizers/gifv.py
+++ b/thumbor/optimizers/gifv.py
@@ -44,18 +44,12 @@ class Optimizer(BaseOptimizer):
             self.context.config.FFMPEG_PATH,
             '-y',
             '-f',
-            'lavfi',
-            '-i',
-            'color=%s' % (bg_color_hex or 'ffffff'),
-            '-f',
             'gif',
+            '-trans_color', '0xff%s' % (bg_color_hex[1:] if bg_color_hex else 'ffffff'),
             '-i',
             input_file,
             '-filter_complex',
-            ('[1]reverse,trim=end_frame=1[t];'
-                '[1][t]concat[g];[0][g]scale2ref[bg][gif];'
-                '[bg]setsar=1[bg];[bg][gif]overlay=shortest=1,'
-                'scale=trunc(iw/2)*2:trunc(ih/2)*2'),
+            'scale=trunc(iw/2)*2:trunc(ih/2)*2',
             '-an',
             '-movflags',
             'faststart',


### PR DESCRIPTION
'reverse' complex filter has to buffer entire video content in memory
before next filter can chop off last frame. In case of long big gif
inputs, amount of memory could exceed few gigabytes. If thumbor server
at the same time tries to optimize 2 gifv files, it's likely to run out
of memory and be killed with OOM killer. When ffmpeg process killed,
optimizer throws exception, but due to the fact thumbor misuses futures,
exception is never retrieved, so request waits until timeout happens.
There is a high chance that many requests will hang at the same time,
effectively exhausting open files limit and rendering service
interruption.
Reverse filter needed to overcome issue with ffmpeg dropping last frame
duration when used with overlay filter, which, in turn, was used to add
color-background for input gifs with transparency.
Turns out, that ffmpeg's gif decoder can be supplied with [`-trans_color`](https://github.com/FFmpeg/FFmpeg/blob/cdd3048134b8b032b69d3c076d73d24e329dc9ba/libavcodec/gifdec.c#L537)
parameter, which does exactly that, but on decoding stage. This allows
to remove memory-heavy reverse filter and overlay all together.
As a side effect, previously broken ffmpeg 3.3 should also work fine.

see https://github.com/thumbor/thumbor/pull/907