### PR TITLE
Ubuntu 18.04 does not ship libvpx4 anymore, only libvpx5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ setup:
 	@$(MAKE) setup_python
 
 setup_ubuntu:
-	@sudo apt-get install -y imagemagick webp coreutils gifsicle libvpx4 \
+	@sudo apt-get install -y imagemagick webp coreutils gifsicle libvpx? \
                              libvpx-dev libimage-exiftool-perl libcairo2-dev \
                              ffmpeg libcurl4-openssl-dev libffi-dev \
                              python-dev python3-dev


### PR DESCRIPTION
Ubuntu 18.04 does not ship libvpx4 anymore, only libvpx5, and it's compatible.