### PR TITLE
Fix macOS detection and homebrew/science

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ run: compile_ext
 	@thumbor -l debug -d
 
 setup:
-    ifeq ($(OS), xx)
+    ifeq ($(OS), Darwin)
 	@$(MAKE) setup_mac
     else
 	@$(MAKE) setup_ubuntu
@@ -20,7 +20,7 @@ setup_python:
 	@pip install -e .[tests]
 
 setup_mac:
-	@brew tap homebrew/science
+	@brew tap brewsci/science
 	@brew update
 	@brew install imagemagick webp opencv coreutils gifsicle libvpx exiftool cairo
 	@brew install ffmpeg --with-libvpx


### PR DESCRIPTION
This PR fix macOS detection when `make setup` is called. And also change `brew tap homebrew/science` (that was deprecated) for `brew tap brewsci/science`. Let me know what are you think about it?