### PR TITLE
Limit highest quality to initial quality

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -507,8 +507,8 @@ class BaseHandler(tornado.web.RequestHandler):
             results = engine.read(extension, quality)
 
         prev_result = results
-        while len(results) <= max_bytes:
-            quality = int(quality * 1.1)
+        while len(results) <= max_bytes and quality < initial_quality:
+            quality = max(initial_quality, int(quality * 1.1))
             logger.debug('Trying to upsize image with quality of %d...' % quality)
             prev_result = results
             results = engine.read(extension, quality)


### PR DESCRIPTION
if we end up that far and trying to fit image into certain filesize,
that means initial save quality was already too much, so it should be
higher bound.

Fixes #1104 
@heynemann this is simple fix. Submitted just in case [binary search approach](https://github.com/thumbor/thumbor/pull/1106) is no good for some reason.