### PR TITLE
Allow all Pillow 5.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
             "tornado>=4.1.0,<6.0.0",
             "pycryptodome >= 3.4.7",
             "pycurl>=7.19.0,<7.44.0",
-            "Pillow>=4.3.0,<5.3.0",
+            "Pillow>=4.3.0,<6.0.0",
             "derpconf>=0.2.0",
             "piexif>=1.0.13,<1.1.0",
             "statsd>=3.0.1",


### PR DESCRIPTION
I don't see why not. Pillow is released once a quarter, bumping version constraint each time seems unnecessary. They are not following semver, but they do release breaking changes with new major version. 