### PR TITLE
[refactor branch] Blur filter

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -44,7 +44,7 @@ documentation](http://thumbor.readthedocs.org/en/latest/index.html "thumbor docs
 - [x] Full Fit-in
 - [x] Filters
    - [ ] background_color
-   - [ ] blur
+   - [x] blur
    - [x] brightness
    - [x] colorize
    - [ ] contrast

--- a/tests/integration/detectors/__init__.py
+++ b/tests/integration/detectors/__init__.py
@@ -44,5 +44,5 @@ class DetectorTestCase(TestCase):
     def smart_detect(self, source_image, width=300, height=200):
         'Get smart detect image bytes'
         image = yield self.get(
-            f'/v2/unsafe/{width}x{height}/smart/{source_image}')
+            f'/unsafe/{width}x{height}/smart/{source_image}')
         return image.body

--- a/tests/integration/filters/__init__.py
+++ b/tests/integration/filters/__init__.py
@@ -43,5 +43,5 @@ class FilterTestCase(TestCase):
     def get_filtered(self, filter_str, source_image):
         'Get filtered image bytes'
         image = yield self.get(
-            f'/v2/unsafe/filters:{filter_str}/{source_image}')
+            f'/unsafe/filters:{filter_str}/{source_image}')
         return image.body

--- a/tests/integration/filters/test_blur.py
+++ b/tests/integration/filters/test_blur.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from preggy import expect
+from tornado.testing import gen_test
+
+from thumbor.filters.blur import Filter as BlueFilter
+from tests.integration.filters import FilterTestCase
+
+
+class BlurFilterTestCase(FilterTestCase):
+
+    def get_filter(self):
+        return BlueFilter
+
+    @gen_test
+    def test_blur_filter_with_sigma(self):
+        filtered_image = yield self.get_filtered('blur(4,2)', 'source.jpg')
+        expected = self.get_fixture('blur.jpg')
+        
+        expect(filtered_image).to_be_similar_to(expected)
+
+    @gen_test
+    def test_blur_filter_without_sigma(self):
+        filtered_image = yield self.get_filtered('blur(8)', 'source.jpg')
+        expected = self.get_fixture('blur2.jpg')
+
+        expect(filtered_image).to_be_similar_to(expected)
+
+    @gen_test
+    def test_blur_filter_with_max_radius(self):
+        filtered_image = yield self.get_filtered('blur(500)', 'source.jpg')
+        expected = self.get_fixture('blur3.jpg')
+
+        expect(filtered_image).to_be_similar_to(expected)

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -435,6 +435,7 @@ Config.define(
 Config.define(
     'FILTERS',
     [
+        'thumbor.filters.blur',
         'thumbor.filters.brightness',
         'thumbor.filters.colorize',
         # 'thumbor.filters.contrast',
@@ -455,7 +456,6 @@ Config.define(
         # 'thumbor.filters.format',
         # 'thumbor.filters.max_bytes',
         # 'thumbor.filters.convolution',
-        # 'thumbor.filters.blur',
         # 'thumbor.filters.extract_focal',
         # 'thumbor.filters.focal',
         # 'thumbor.filters.no_upscale',

--- a/thumbor/ext/filters/_convolution.c
+++ b/thumbor/ext/filters/_convolution.c
@@ -43,7 +43,7 @@ _convolution_apply(PyObject *self, PyObject *args)
     Py_ssize_t kernel_size = 0, width = 0, height = 0;
     PyObject *kernel_tuple, *buffer, *should_normalize;
 
-    if (!PyArg_ParseTuple(args, "sOiiOiO:apply", &image_mode, &buffer, &width, &height, &kernel_tuple, &columns_count, &should_normalize)) {
+    if (!PyArg_ParseTuple(args, "s*OiiOiO:apply", &image_mode, &buffer, &width, &height, &kernel_tuple, &columns_count, &should_normalize)) {
         return NULL;
     }
 


### PR DESCRIPTION
@heynemann  what do you think about this PR for the refactor branch? I also separated some points.

Will Thumbor continue to support python 2.6?

The tests were not passing, I needed to remove /v2/ from the beginning of the url of the `__init__.py` files of the detectors and the filters, does it make sense to you? (I made a separate commit if it didn't)

I needed to modify `_convolution.c` so that it could support the mode parameter as bytes as well and not just as string.