### PR TITLE
Fixed i386 build

### DIFF
--- a/tests/loaders/test_http_loader.py
+++ b/tests/loaders/test_http_loader.py
@@ -383,7 +383,7 @@ class HttpCurlTimeoutLoaderTestCase(DummyAsyncHttpClientTestCase):
         config = Config()
         config.HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT = True
         config.HTTP_LOADER_CURL_LOW_SPEED_TIME = 1
-        config.HTTP_LOADER_CURL_LOW_SPEED_LIMIT = 1000000000000
+        config.HTTP_LOADER_CURL_LOW_SPEED_LIMIT = 1000000000
         ctx = Context(None, config, None)
 
         loader.load(ctx, url, self.stop)
@@ -406,7 +406,7 @@ class HttpTimeoutLoaderTestCase(DummyAsyncHttpClientTestCase):
         url = self.get_url('/')
         config = Config()
         config.HTTP_LOADER_CURL_LOW_SPEED_TIME = 1
-        config.HTTP_LOADER_CURL_LOW_SPEED_LIMIT = 1000000000000
+        config.HTTP_LOADER_CURL_LOW_SPEED_LIMIT = 1000000000
         ctx = Context(None, config, None)
 
         loader.load(ctx, url, self.stop)


### PR DESCRIPTION
Tests failed on i386 architecture, this PR fix it.

`TypeError: longs are not supported for this option`