### PR TITLE
Fix the bug that put method is not asynchronous which will stuck the thumbor server

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -747,6 +747,7 @@ class ImageApiHandler(ContextHandler):
             return False
         return True
 
+    @gen.coroutine
     def write_file(self, id, body):
         storage = self.context.modules.upload_photo_storage
-        storage.put(id, body)
+        yield gen.maybe_future(storage.put(id, body))

--- a/thumbor/handlers/image_resource.py
+++ b/thumbor/handlers/image_resource.py
@@ -68,7 +68,7 @@ class ImageResourceHandler(ImageApiHandler):
         # Check if image exists
         exists = yield gen.maybe_future(self.context.modules.storage.exists(id))
         if exists:
-            self.context.modules.storage.remove(id)
+            yield gen.maybe_future(self.context.modules.storage.remove(id))
             self.set_status(204)
         else:
             self._error(404, 'Image not found at the given URL')

--- a/thumbor/handlers/image_resource.py
+++ b/thumbor/handlers/image_resource.py
@@ -44,6 +44,8 @@ class ImageResourceHandler(ImageApiHandler):
         else:
             self._error(404, 'Image not found at the given URL')
 
+    @tornado.web.asynchronous
+    @tornado.gen.coroutine
     def put(self, id):
         id = id[:self.context.config.MAX_ID_LENGTH]
         # Check if image overwriting is allowed
@@ -53,7 +55,7 @@ class ImageResourceHandler(ImageApiHandler):
 
         # Check if the image uploaded is valid
         if self.validate(self.request.body):
-            self.write_file(id, self.request.body)
+            yield gen.maybe_future(self.write_file(id, self.request.body))
             self.set_status(204)
 
     @tornado.web.asynchronous


### PR DESCRIPTION
Recently, found that the put method doesn't have tornado.coroutines, which will affect the performance 
of thumbor when some put requests getting into thumbor. And delete api also doesn't have yield, here's
a simple fix for this, each method in put/delete add yield to let them to be responded asynchronously.