### PR TITLE
Add healthcheck on root url

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -546,7 +546,6 @@ Storage.
 
 i.e.: ``RESULT_STORAGE_STORES_UNSAFE = False``
 
-
 Healthcheck
 -------
 
@@ -554,10 +553,12 @@ HEALTHCHECK\_ROUTE
 ~~~~~~~~~~~~~~~~~~~~
 
 The URL path to a healthcheck.  This will return a 200 and the text 'WORKING'.
-The default value is '/healthcheck'
 
 i.e.: ``HEALTHCHECK_ROUTE = '/status'``
 
+Will put the healthcheck response on ``http://host/status``
+
+The default route is '/healthcheck'
 
 Logging
 -------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -546,6 +546,19 @@ Storage.
 
 i.e.: ``RESULT_STORAGE_STORES_UNSAFE = False``
 
+
+Healthcheck
+-------
+
+HEALTHCHECK\_ROUTE
+~~~~~~~~~~~~~~~~~~~~
+
+The URL path to a healthcheck.  This will return a 200 and the text 'WORKING'.
+The default value is '/healthcheck'
+
+i.e.: ``HEALTHCHECK_ROUTE = '/status'``
+
+
 Logging
 -------
 

--- a/tests/handlers/test_healthcheck.py
+++ b/tests/handlers/test_healthcheck.py
@@ -10,6 +10,9 @@
 
 from preggy import expect
 
+from thumbor.config import Config
+from thumbor.context import Context
+from thumbor.importer import Importer
 from tests.base import TestCase
 
 

--- a/tests/handlers/test_healthcheck.py
+++ b/tests/handlers/test_healthcheck.py
@@ -22,3 +22,23 @@ class HealthcheckHandlerTestCase(TestCase):
     def test_can_head_healthcheck(self):
         response = self.fetch('/healthcheck', method='HEAD')
         expect(response.code).to_equal(200)
+
+# Same test, but configured for the root URL
+class HealthcheckOnRootTestCase(TestCase):
+    def get_context(self):
+        cfg = Config()
+        cfg.HEALTHCHECK_ROUTE = '/'
+
+        importer = Importer(cfg)
+        importer.import_modules()
+
+        return Context(None, cfg, importer)
+
+    def test_can_get_healthcheck(self):
+        response = self.fetch('/')
+        expect(response.code).to_equal(200)
+        expect(response.body).to_equal("WORKING")
+
+    def test_can_head_healthcheck(self):
+        response = self.fetch('/', method='HEAD')
+        expect(response.code).to_equal(200)

--- a/tests/handlers/test_healthcheck.py
+++ b/tests/handlers/test_healthcheck.py
@@ -26,6 +26,7 @@ class HealthcheckHandlerTestCase(TestCase):
         response = self.fetch('/healthcheck', method='HEAD')
         expect(response.code).to_equal(200)
 
+
 # Same test, but configured for the root URL
 class HealthcheckOnRootTestCase(TestCase):
     def get_context(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -31,6 +31,7 @@ class AppTestCase(TestCase):
             config=mock.Mock(
                 UPLOAD_ENABLED=False,
                 USE_BLACKLIST=False,
+                HEALTHCHECK_ROUTE=r'/healthcheck',
             )
         )
         app = ThumborServiceApp(ctx)
@@ -39,6 +40,17 @@ class AppTestCase(TestCase):
         expect(handlers).to_length(2)
         expect(handlers[0][0]).to_equal(r'/healthcheck')
         expect(handlers[1][0]).to_equal(Url.regex())
+
+    def test_change_healthcheck_route(self):
+        ctx = mock.Mock(
+            config=mock.Mock(
+                HEALTHCHECK_ROUTE=r'/status',
+            )
+        )
+        app = ThumborServiceApp(ctx)
+
+        handlers = app.get_handlers()
+        expect(handlers[0][0]).to_equal(r'/status')
 
     def test_can_get_handlers_with_upload(self):
         ctx = mock.Mock(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -41,17 +41,6 @@ class AppTestCase(TestCase):
         expect(handlers[0][0]).to_equal(r'/healthcheck')
         expect(handlers[1][0]).to_equal(Url.regex())
 
-    def test_change_healthcheck_route(self):
-        ctx = mock.Mock(
-            config=mock.Mock(
-                HEALTHCHECK_ROUTE=r'/status',
-            )
-        )
-        app = ThumborServiceApp(ctx)
-
-        handlers = app.get_handlers()
-        expect(handlers[0][0]).to_equal(r'/status')
-
     def test_can_get_handlers_with_upload(self):
         ctx = mock.Mock(
             config=mock.Mock(

--- a/thumbor/app.py
+++ b/thumbor/app.py
@@ -27,8 +27,7 @@ class ThumborServiceApp(tornado.web.Application):
 
     def get_handlers(self):
         handlers = [
-            (r'/', HealthcheckHandler),
-            (r'/healthcheck', HealthcheckHandler),
+            (self.context.config.HEALTHCHECK_ROUTE, HealthcheckHandler),
         ]
 
         if self.context.config.UPLOAD_ENABLED:

--- a/thumbor/app.py
+++ b/thumbor/app.py
@@ -27,6 +27,7 @@ class ThumborServiceApp(tornado.web.Application):
 
     def get_handlers(self):
         handlers = [
+            (r'/', HealthcheckHandler),
             (r'/healthcheck', HealthcheckHandler),
         ]
 

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -148,6 +148,8 @@ Config.define('ENABLE_ETAGS', True, 'Enables automatically generated etags', 'HT
 Config.define('MAX_ID_LENGTH', 32, 'Set maximum id length for images when stored', 'Storage')
 Config.define('GC_INTERVAL', None, 'Set garbage collection interval in seconds', 'Performance')
 
+Config.define('HEALTHCHECK_ROUTE', r'/healthcheck', 'Healthcheck route.', 'Healthcheck')
+
 # METRICS OPTIONS
 Config.define('STATSD_HOST', None, 'Host to send statsd instrumentation to', 'Metrics')
 Config.define('STATSD_PORT', 8125, 'Port to send statsd instrumentation to', 'Metrics')


### PR DESCRIPTION
I am trying to run thumbor on google kubernetes (GKE).  The healthcheck infrastructure in gke always needs a 200 response on /

Yes it is annoying!  

This easy change makes it easy to run on GKE without extra hoops (proxy)
