### PR TITLE
Display site-packages path when setting up on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ setup_mac:
 		echo 'Enter in your site-packages directory and run the following lines:';\
 		echo "ln -s $$opencv_path/lib/python2.7/site-packages/cv.py ./";\
 		echo "ln -s $$opencv_path/lib/python2.7/site-packages/cv2.so ./"
+		echo 'Your site-packages directory seems to be:'\
+			$$(python -c "import sys; print(next(_ for _ in sys.path if 'site-packages' in _))")
 
 compile_ext:
 	@python setup.py build_ext -i


### PR DESCRIPTION
Update: do **not** merge yet, looks like that step is no longer necessary. I'll investigate further and keep you posted.

This helps the user locating the activated virtualenv's site-packages path to then link OpenCV's python script and shared object file.