### PR TITLE
Fix red-eyes slice indices

### DIFF
--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -33,17 +33,20 @@ class FocalPointTestCase(TestCase):
     def test_new_point_weighted(self):
         point = FocalPoint(x=10, y=20, height=1.0, width=3.0, weight=3.0)
         expect(point.weight).to_equal(3.0)
-        expect(str(point)).to_equal('FocalPoint(x: 10, y: 20, width: 3, height: 1, weight: 3, origin: alignment)')
+        expect(str(point)).to_equal(
+            'FocalPoint(x: 10, y: 20, width: 3, height: 1, weight: 3, origin: alignment)')
 
     def test_new_point_from_dict(self):
-        point = FocalPoint.from_dict({'x': 10.1, 'y': 20.1, 'z': 5.1})
-        expect(point.x).to_equal(10.1)
-        expect(point.y).to_equal(20.1)
-        expect(point.weight).to_equal(5.1)
+        point = FocalPoint.from_dict({'x': 10, 'y': 20, 'z': 5})
+        expect(point.x).to_equal(10)
+        expect(point.y).to_equal(20)
+        expect(point.weight).to_equal(5)
 
     def test_new_point_to_dict(self):
-        point = FocalPoint.from_dict({'x': 10.1, 'y': 20.1, 'z': 5.1})
-        expect(point.to_dict()).to_be_like({'x': 10.1, 'y': 20.1, 'z': 5.1, 'origin': 'alignment', 'width': 1.0, 'height': 1.0})
+        point = FocalPoint.from_dict(
+            {'x': 10.1, 'y': 20.1, 'z': 5.1, 'width': 1.1, 'height': 1.6})
+        expect(point.to_dict()).to_be_like(
+            {'x': 10, 'y': 20, 'z': 5, 'origin': 'alignment', 'width': 1, 'height': 1})
 
     def test_new_point_square_point(self):
         point = FocalPoint.from_square(x=350, y=50, width=110, height=110)

--- a/thumbor/point.py
+++ b/thumbor/point.py
@@ -32,11 +32,11 @@ class FocalPoint(object):
     @classmethod
     def from_dict(cls, values):
         return cls(
-            x=float(values['x']),
-            y=float(values['y']),
-            weight=float(values['z']),
-            width=float(values.get('width', 1)),
-            height=float(values.get('height', 1)),
+            x=int(values['x']),
+            y=int(values['y']),
+            weight=int(values['z']),
+            width=int(values.get('width', 1)),
+            height=int(values.get('height', 1)),
             origin=values.get('origin', 'alignment')
         )
 


### PR DESCRIPTION
Some urls for the red-eye filter cause the slice indices to float. Causing the following error:

```
2019-02-12 23:26:44 tornado.application:ERROR Future exception was never retrieved: Traceback (most recent call last):
....
  File "/Users/cristiandean/projects/thumbor/thumbor/filters/redeye.py", line 44, in red_eye
    face_image = image[face_y:(face_y + face.height), face_x:(face_x + face.width)]
```

The exception can be reproduced by accessing the following url:

http://localhost:8888/unsafe/debug/fit-in/500x500/smart/filters:red_eye()/https://peladin.files.wordpress.com/2008/01/01.jpg