### PR TITLE
Replace 'pycryptodome' with 'pycryptodomex'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ You'll need Python 2.7 and we seriously advise you to use virtualenv (http://pyp
 The following packages are required:
 
 * Tornado >= 2.3.0
-* pycryptodome >= 3.4.7
+* pycryptodomex >= 3.4.7
 * pycurl >= 7.19.0
 * Pillow >= 2.3.0
 * redis >= 2.4.11

--- a/docs/hacking_on_thumbor.rst
+++ b/docs/hacking_on_thumbor.rst
@@ -22,7 +22,7 @@ You'll also need python >= 2.6 and < 3.0.
 The following packages are required:
 
 -  Tornado >= 2.1.1
--  pycryptodome >= 3.4.7
+-  pycryptodomex >= 3.4.7
 -  pycurl >= 7.19.0
 -  Pillow >= 1.7.5
 -  redis >= 2.4.11

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
 
         install_requires=[
             "tornado>=4.1.0,<6.0.0",
-            "pycryptodome >= 3.4.7",
+            "pycryptodomex >= 3.4.7",
             "pycurl>=7.19.0,<7.44.0",
             "Pillow>=4.3.0,<6.0.0",
             "derpconf>=0.2.0",

--- a/thumbor/crypto.py
+++ b/thumbor/crypto.py
@@ -11,7 +11,7 @@
 import base64
 import hashlib
 
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 
 # Import the Signer class to support backward-compatibility
 # and existing documentation


### PR DESCRIPTION
pycryptodomex is a library independent of the old PyCrypto

And there is no pycryptodome in Ubuntu, Debian, Fedora, etc.

Thanks for the warning Florian REY.

