### PR TITLE
Prevent healthcheck from being cached

### DIFF
--- a/tests/handlers/test_healthcheck.py
+++ b/tests/handlers/test_healthcheck.py
@@ -21,10 +21,12 @@ class HealthcheckHandlerTestCase(TestCase):
         response = self.fetch('/healthcheck')
         expect(response.code).to_equal(200)
         expect(response.body).to_equal("WORKING")
+        expect(response.headers.get('Cache-Control')).to_equal('no-cache')
 
     def test_can_head_healthcheck(self):
         response = self.fetch('/healthcheck', method='HEAD')
         expect(response.code).to_equal(200)
+        expect(response.headers.get('Cache-Control')).to_equal('no-cache')
 
 
 # Same test, but configured for the root URL

--- a/thumbor/handlers/healthcheck.py
+++ b/thumbor/handlers/healthcheck.py
@@ -13,7 +13,9 @@ from thumbor.handlers import BaseHandler
 
 class HealthcheckHandler(BaseHandler):
     def get(self):
+        self.set_header('Cache-Control', 'no-cache')
         self.write('WORKING')
 
     def head(self, *args, **kwargs):
+        self.set_header('Cache-Control', 'no-cache')
         self.set_status(200)


### PR DESCRIPTION
We run thumbor behind Cloudfront to cache the output images, without a direct, open route to the thumbor instances.

To monitor the application, we'd like to ping the health check route periodically, and since the only way for external tools to reach the server is going through Cloudfront, the health check route must no be cached.

This PR adds a cache control header with the `no-cache` policy to prevent Cloudfront (or whatever other service that may cache the result) from caching the response of the health check route.