### PR TITLE
Replace piexif with custom orientation-only exif reader/writer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,6 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
             "pycurl>=7.19.0,<7.44.0",
             "Pillow>=4.3.0,<6.0.0",
             "derpconf>=0.2.0",
-            "piexif>=1.0.13,<2.0.0",
             "statsd>=3.0.1",
             "libthumbor>=1.3.2",
             "futures",

--- a/tests/engines/test_base_engine.py
+++ b/tests/engines/test_base_engine.py
@@ -12,7 +12,6 @@ from __future__ import unicode_literals, absolute_import
 from struct import pack
 from os.path import abspath, join, dirname
 
-import piexif
 from unittest import TestCase
 from xml.etree.ElementTree import ParseError
 
@@ -198,8 +197,7 @@ class BaseEngineTestCase(TestCase):
         expect(self.engine.get_orientation()).to_be_null()
 
     def test_get_orientation_without_orientation_in_exif(self):
-        self.engine.exif = piexif.load(exif_str(1))
-        self.engine.exif['0th'].pop(piexif.ImageIFD.Orientation, None)
+        self.engine.exif = b'Exif\x00\x00II*\x00\x08\x00\x00\x00\x01\x00\x1a\x01\x05\x00\x01\x00\x00\x006\x00\x00\x00'
         expect(self.engine.get_orientation()).to_be_null()
 
     def test_get_orientation(self):

--- a/thumbor/engines/extensions/exif_orientation_editor.py
+++ b/thumbor/engines/extensions/exif_orientation_editor.py
@@ -1,0 +1,75 @@
+import struct
+from io import BytesIO
+
+PREFIXES = [
+    b"MM\x00\x2A",  # Valid TIFF header with big-endian byte order
+    b"II\x2A\x00",  # Valid TIFF header with little-endian byte order
+    b"MM\x2A\x00",  # Invalid TIFF header, assume big-endian
+    b"II\x00\x2A",  # Invalid TIFF header, assume little-endian
+]
+
+EXIF_HEADER = b"Exif\x00\x00"
+
+
+class ExifOrientationEditor():
+    _endian = "<"
+    _offset = None
+
+    def __init__(self, data):
+        if data[:6] != EXIF_HEADER:
+            raise SyntaxError("not a TIFF file (header %r not valid)" % data[:4])
+
+        # Skip 6 bytes of exif header to simplify seeks in ImageFileDirectory
+        self.exif_buffer = BytesIO(data[6:])
+
+        header = self._read_header()
+        self._find_orientation_offset(header)
+
+    def _read_header(self):
+        header = self.exif_buffer.read(8)
+
+        if header[:4] not in PREFIXES:
+            raise SyntaxError("not a TIFF file (header %r not valid)" % header)
+        prefix = header[:2]
+        if prefix == b"MM":
+            self._endian = ">"
+        elif prefix == b"II":
+            self._endian = "<"
+        else:
+            raise SyntaxError("not a TIFF IFD")
+
+        return header
+
+    def _find_orientation_offset(self, header):
+        ifd_offset, = self._unpack("L", header[4:])
+        self.exif_buffer.seek(ifd_offset)
+
+        # Read tag directory
+        for _ in range(self._unpack("H", self.exif_buffer.read(2))[0]):
+            # Each tag is 12 bytes. HHL4s = tag, type, count, data
+            # Read tag and ignore the rest
+            tag, = self._unpack("H10x", self.exif_buffer.read(12))
+            if tag == 0x0112:  # Orientation tag
+                self._offset = self.exif_buffer.tell() - 4  # Back 4 bytes to the start of data
+                break
+
+    def _unpack(self, fmt, data):
+        return struct.unpack(self._endian + fmt, data)
+
+    def get_orientation(self):
+        if self._offset is None:
+            return None
+
+        self.exif_buffer.seek(self._offset)
+        return self._unpack('H', self.exif_buffer.read(2))[0]
+
+    def set_orientation(self, value):
+        if self._offset is None:
+            return
+
+        self.exif_buffer.seek(self._offset)
+        self.exif_buffer.write(struct.pack(self._endian + 'H', value))
+
+    def tobytes(self):
+        self.exif_buffer.seek(0)
+        return EXIF_HEADER + self.exif_buffer.read()


### PR DESCRIPTION
Fixes #1204  
Closes #1209
(please see both for discussions)

Replacing piexif dependency with simple orientation-only reader. It ignores all other exif tags and does not traverse through IFDs other then IFD0 where orientation supposed to be.
 
