### PR TITLE
Lossless webp when quality is 100

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -57,7 +57,7 @@ Config.define('PILLOW_RESAMPLING_FILTER', 'LANCZOS',
               'One of LANCZOS, NEAREST, BILINEAR, BICUBIC, HAMMING (Pillow>=3.4.0).', 'Imaging')
 
 Config.define('WEBP_QUALITY', None, 'Quality index used for generated WebP images. If not set (None) the same level of '
-              'JPEG quality will be used.', 'Imaging')
+              'JPEG quality will be used. If 100 the `lossless` flag will be used.', 'Imaging')
 
 Config.define('PNG_COMPRESSION_LEVEL', 6, 'Compression level for generated PNG images.', 'Imaging')
 Config.define('PILLOW_PRESERVE_INDEXED_MODE',

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -245,6 +245,10 @@ class Engine(BaseEngine):
 
         try:
             if ext == '.webp':
+                if options['quality'] == 100:
+                    logger.debug("webp quality is 100, using lossless instead")
+                    options['lossless'] = True
+                    options.pop('quality')
                 if self.image.mode not in ['RGB', 'RGBA']:
                     if self.image.mode == 'P':
                         mode = 'RGBA'


### PR DESCRIPTION
When the webp quality is set to 100, we might as well use the `lossless` flag in the conversion. If necessary, we could also do this as a separate config option, but it seems like if you're after a quality of 100, what you really want is lossless.