### PR TITLE
Optionally serve the original image if it is smaller.

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -115,6 +115,10 @@ Config.define(
     'requests timing out)', 'Imaging')
 
 Config.define(
+    'SERVE_ORIGINAL_IF_SMALLER', False,
+    'If the original image is smaller than the processed one and there are no filters set, serve the original instead.', 'Imaging')
+
+Config.define(
     'METRICS', 'thumbor.metrics.logger_metrics',
     'The metrics backend thumbor should use to measure internal actions. This must be the full name of a python module ' +
     '(python must be able to import it)', 'Extensibility')

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -66,6 +66,8 @@ class Engine(BaseEngine):
 
     def create_image(self, buffer):
         try:
+            if self.context.config.SERVE_ORIGINAL_IF_SMALLER and hasattr(self.context.request.filters, '__len__') and len(self.context.request.filters) == 0:
+                self.original = BytesIO(buffer).getvalue()
             img = Image.open(BytesIO(buffer))
         except DecompressionBombExceptions as e:
             logger.warning("[PILEngine] create_image failed: {0}".format(e))
@@ -263,6 +265,14 @@ class Engine(BaseEngine):
 
         results = img_buffer.getvalue()
         img_buffer.close()
+
+        if self.context.config.SERVE_ORIGINAL_IF_SMALLER and hasattr(self.context.request.filters, '__len__') and len(self.context.request.filters) == 0:
+            logger.debug('Original length: %s', len(self.original))
+            logger.debug('Compressed length: %s', len(results))
+
+            if len(results) >= len(self.original):
+                return self.original
+
         self.extension = ext
         return results
 

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -66,8 +66,6 @@ class Engine(BaseEngine):
 
     def create_image(self, buffer):
         try:
-            if self.context.config.SERVE_ORIGINAL_IF_SMALLER and hasattr(self.context.request.filters, '__len__') and len(self.context.request.filters) == 0:
-                self.original = BytesIO(buffer).getvalue()
             img = Image.open(BytesIO(buffer))
         except DecompressionBombExceptions as e:
             logger.warning("[PILEngine] create_image failed: {0}".format(e))
@@ -265,14 +263,6 @@ class Engine(BaseEngine):
 
         results = img_buffer.getvalue()
         img_buffer.close()
-
-        if self.context.config.SERVE_ORIGINAL_IF_SMALLER and hasattr(self.context.request.filters, '__len__') and len(self.context.request.filters) == 0:
-            logger.debug('Original length: %s', len(self.original))
-            logger.debug('Compressed length: %s', len(results))
-
-            if len(results) >= len(self.original):
-                return self.original
-
         self.extension = ext
         return results
 


### PR DESCRIPTION
If the original image is smaller, we might as well respond with that instead of the processed one as long as we didn't run it through any filters.