### PR TITLE
Allow Pillow 6.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
         install_requires=[
             "tornado>=4.1.0,<6.0.0",
             "pycurl>=7.19.0,<7.44.0",
-            "Pillow>=4.3.0,<=6.1.0",
+            "Pillow>=4.3.0,<7",
             "derpconf>=0.2.0",
             "piexif>=1.0.13,<2.0.0",
             "statsd>=3.0.1",


### PR DESCRIPTION
We should never use <= because that disallows security point releases. 6.1.x should have been allowed using `<6.2`.

It happens that 6.2.0 was also a security release, and it seems reasonable to allow all minor releases like we did in the past.

Pillow has announced that [7.0.0 will be the first release to drop Python 2 support](https://pillow.readthedocs.io/en/stable/releasenotes/6.2.1.html#python-2-7).