### PR TITLE
replace dots in original image's source with underscores

### DIFF
--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -64,7 +64,7 @@ def return_contents(response, url, callback, context, req_start=None):
         finish = datetime.datetime.now()
         res = urlparse(url)
         context.metrics.timing(
-            'original_image.fetch.{0}.{1}'.format(response.code, res.netloc),
+            'original_image.fetch.{0}.{1}'.format(response.code, res.netloc.replace('.', '_')),
             (finish - req_start).total_seconds() * 1000,
         )
 


### PR DESCRIPTION
When using the http loader each dot in the source image's host name will lead to a new hierarchy level in the metrics that are being pushed to the thumbor's stats backend. E.g. _camo.githubusercontent.com_ will lead to three extra levels in the stats or _static.img.emea.pages.mypage.com_ would lead to five new levels. 

**This brings the following problems:**
* depending on the number of domain levels in the source image you end up with different hierarchy lengths for your metrics. This makes stats aggregation extra tricky.
* Since the source hostname could potentially have tens of domain levels, this can bring scaling issues with stats backends in production

**Example**
* thumbor resizes an image from _https://static.img.emea.pages.mypage.com/img/12345.png_
* the source responds with 200
* Thumbor will push a timing metric of the format: _original_image.fetch.200.static.img.emea.pages.mypage.com.time_

The suggested change simply replaces the dots in host names with an underscore so in the example above we would end up with a metric _original_image.fetch.200.static_img_emea_pages_mypage_com.time_