### PR TITLE
Added new loader "file_loader_404_fallback.py" for inexistent files

### DIFF
--- a/docs/image_loader.rst
+++ b/docs/image_loader.rst
@@ -69,6 +69,19 @@ you'll get an error.
 To use it you should set the **LOADER** configuration to
 **'thumbor.loaders.file\_loader\_http\_fallback'**.
 
+File loader with 404.png default image fallback
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In some environments, like an e-commerce site, it is desirable to load a default
+image rather than throwing a 404 error. Yo can use this loader for this situation.
+
+This loader will try to to load the image from local storage. In case of an error, it
+will retry lo load a image called "404.png" that must be in the root of your file storage.
+If both attempts failed you will get an error. 
+
+To use it you should set the **LOADER** configuration to 
+**'thumbor.loaders.file\_loader\_404\_fallback'**.
+
 
 Custom loaders
 --------------

--- a/thumbor/loaders/file_loader_404_fallback.py
+++ b/thumbor/loaders/file_loader_404_fallback.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from . import file_loader
+from tornado.concurrent import return_future
+
+
+@return_future
+def load(context, path, callback):
+    def callback_wrapper(result):
+        if result.successful:
+            callback(result)
+        else:
+            # If file_loader failed try file_loader with fixed "404.png" callback
+            file_loader.load(context, '404.png', callback)
+
+    # First attempt to load with file_loader
+    file_loader.load(context, path, callback_wrapper)


### PR DESCRIPTION
Added a new loader "file_loader_404_fallback.py" that loads a fixed file "404.png" image in the file loader root folder if the requested image does not exist.

This is useful if you want to have a default image for all requests in a e-commerce site, for example.

closes  #1245 