### PR TITLE
[FEAT] URL Routers support

### DIFF
--- a/.commit-template
+++ b/.commit-template
@@ -8,6 +8,10 @@
 
 # Remember blank line between title and body.
 
+# Please explain whether this change is backwards compatible or not.
+# If not, please use the body below to explain why not.
+**Is backwards compatible**: yes/no
+
 # Body: Explain *what* and *why* (not *how*). Include github issue if any.
 # Wrap at 72 chars. ################################## which is here: #
 

--- a/Makefile
+++ b/Makefile
@@ -39,14 +39,17 @@ ci_test: build
 	@echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
 	@if [ "$$LINT_TEST" ]; then $(MAKE) flake; elif [ -z "$$INTEGRATION_TEST" ]; then $(MAKE) unit coverage; else $(MAKE) integration_run; fi
 
-integration_run:
+integration_run integration int:
 	@poetry run pytest -sv integration_tests/ -p no:tldr
+
+pint pintegration:
+	@poetry run pytest -sv integration_tests/ -p no:tldr -n `nproc` 
 
 coverage:
 	@coverage report -m --fail-under=10
 
 unit:
-	@pytest -n `nproc` --cov=thumbor tests/
+	@poetry run pytest -n `nproc` --cov=thumbor tests/
 
 kill_redis:
 	@-redis-cli -p 6668 -a hey_you shutdown

--- a/docs/custom_filters.rst
+++ b/docs/custom_filters.rst
@@ -37,8 +37,10 @@ Let's analyse it:
 And that's it, we got our filter. In order to use it, we need to put it in our ``thumbor.conf``:
 
 .. code:: python
-   FILTERS = [
-      # thumbor built-in filters...
+
+   from thumbor.filters import BUILTIN_FILTERS
+
+   FILTERS = BUILTIN_FILTERS + [
       'mylib.filters.quality',
    ]
 

--- a/docs/custom_routers.rst
+++ b/docs/custom_routers.rst
@@ -1,0 +1,55 @@
+Custom Routers
+==============
+
+Routers are responsible for adding new routes to thumbor. Even thumbor's own routes (other than the default image crop route)
+are added via routers (healthcheck, blacklist...).
+
+Built-in Routers
+----------------
+
+Thumbor comes with three routers built-in:
+
+* ``thumbor.routers.healthcheck.HealthcheckRouter``;
+* ``thumbor.routers.blacklist.BlacklistRouter``;
+* ``thumbor.routers.upload.UploadRouter``.
+
+The healthcheck router adds a route at whatever is in the ``HEALTHCHECK_ROUTE`` config.
+
+The blacklist router adds a ``/blacklist`` route that can be used to blacklist images.
+
+The upload router adds two routes for uploading and retrieving uploaded images.
+
+Writing a new Router
+--------------------
+
+Creating your own router is as simple as creating a new file with a class that inherits from ``thumbor.routers.base.BaseRouter``:
+
+.. code:: python
+
+   from typing import List, Optional, cast
+
+   from my.handlers.index import IndexHandler
+   from thumbor.routers.base import BaseRouter, Route
+
+
+   class MyRouter(BaseRouter):
+       def get_routes(self) -> Optional[List[Route]]:
+           something_enabled = cast(bool, self.context.config.SOMETHING_ENABLED)
+           if not something_enabled:
+               return []
+
+           return [Route(r"/my-route/?", IndexHandler, {"context": self.context})]
+
+After your router can be imported with python (check with ``python -c 'import <<your router module>>'``), just add it to thumbor's config:
+
+.. code:: python
+
+   from thumbor.routers import BUILTIN_ROUTERS
+
+   # You need to put the full name for your class: module_name.class_name
+   # Two things worth noticing here:
+   # 1) The route order indicates precedence, so whatever matches first will be executed;
+   # 2) Please do not forget thumbor's built-ins or you'll kill thumbor functionality.
+   ROUTERS = BUILTIN_ROUTERS + [
+       "my.router.MyRouter',
+   ]

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -12,5 +12,6 @@ Customizing Thumbor
    custom_detection
    custom_optimizers
    custom_error_handlers
+   custom_routers
    plugins
    libraries

--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -92,15 +92,14 @@ class BaseHandlerTestApp(tornado.web.Application):
 
 
 class BaseImagingTestCase(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.root_path = tempfile.mkdtemp()
-        cls.loader_path = abspath(join(dirname(__file__), "../fixtures/images/"))
-        cls.base_uri = "/image"
+    def setUp(self):
+        self.root_path = tempfile.mkdtemp()
+        self.loader_path = abspath(join(dirname(__file__), "../fixtures/images/"))
+        self.base_uri = "/image"
+        super(BaseImagingTestCase, self). setUp()
 
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.root_path)
+    def tearDown(self):
+        shutil.rmtree(self.root_path)
 
 
 class ImagingOperationsWithHttpLoaderTestCase(BaseImagingTestCase):
@@ -1477,15 +1476,14 @@ class TranslateCoordinatesTestCase(TestCase):
 
 
 class ImageBadRequestDecompressionBomb(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.root_path = tempfile.mkdtemp()
-        cls.loader_path = abspath(join(dirname(__file__), "../fixtures/images/"))
-        cls.base_uri = "/image"
+    def setUp(self):
+        self.root_path = tempfile.mkdtemp()
+        self.loader_path = abspath(join(dirname(__file__), "../fixtures/images/"))
+        self.base_uri = "/image"
+        super(ImageBadRequestDecompressionBomb, self).setUp()
 
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.root_path)
+    def tearDown(self):
+        shutil.rmtree(self.root_path)
 
     async def get_as_webp(self, url):
         return await self.async_fetch(url, headers={"Accept": "image/webp,*/*;q=0.8"})

--- a/tests/result_storages/test_file_storage.py
+++ b/tests/result_storages/test_file_storage.py
@@ -16,11 +16,11 @@ import mock
 from preggy import expect
 from tornado.testing import gen_test
 
-from tests.base import TestCase
 from thumbor.config import Config
-from thumbor.context import Context, RequestParameters
+from thumbor.context import RequestParameters
 from thumbor.result_storages import ResultStorageResult
 from thumbor.result_storages.file_storage import Storage as FileStorage
+from thumbor.testing import TestCase
 
 
 class BaseFileStorageTestCase(TestCase):
@@ -31,8 +31,10 @@ class BaseFileStorageTestCase(TestCase):
         super(BaseFileStorageTestCase, self).__init__(*args, **kw)
 
     def get_config(self):
+        config = super(BaseFileStorageTestCase, self).get_config()
         self.storage_path = tempfile.TemporaryDirectory()
-        return Config(RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=self.storage_path.name)
+        config.RESULT_STORAGE_FILE_STORAGE_ROOT_PATH = self.storage_path.name
+        return config
 
     def tearDown(self):
         super(BaseFileStorageTestCase, self).tearDown()
@@ -48,8 +50,9 @@ class BaseFileStorageTestCase(TestCase):
         return abspath(join(dirname(__file__), "../fixtures/result_storages"))
 
     def get_context(self):
+        ctx = super(BaseFileStorageTestCase, self).get_context()
         cfg = self.get_config()
-        ctx = Context(None, cfg, None)
+        ctx.config = cfg
         ctx.request = self.get_request()
         self.context = ctx
         self.file_storage = FileStorage(self.context)

--- a/tests/result_storages/test_no_storage.py
+++ b/tests/result_storages/test_no_storage.py
@@ -12,15 +12,13 @@ from preggy import expect
 from tornado.testing import gen_test
 
 from tests.base import TestCase
-from thumbor.config import Config
-from thumbor.context import Context, RequestParameters
+from thumbor.context import RequestParameters
 from thumbor.result_storages.no_storage import Storage as NoStorage
 
 
 class NoResultStorageTestCase(TestCase):
     def get_context(self):
-        cfg = Config()
-        ctx = Context(None, cfg, None)
+        ctx = super(NoResultStorageTestCase, self).get_context()
         ctx.request = RequestParameters(url="image.jpg")
         self.context = ctx
         return ctx

--- a/tests/routers/test_base_router.py
+++ b/tests/routers/test_base_router.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from mock import Mock
+from preggy import expect
+
+from thumbor.routers.base import Route
+from thumbor.testing import TestCase
+
+
+class BaseRouterTestCase(TestCase):
+    @staticmethod
+    def test_can_create_route():
+        url = "/qwe"
+        controller = Mock()
+        init = {"qwe": 123}
+        route = Route(url, controller, init)
+        expect(route).not_to_be_null()
+        expect(route.url).to_equal(url)
+        expect(route.handler).to_equal(controller)
+        expect(route.initialize).to_equal(init)

--- a/tests/routers/test_blacklist_router.py
+++ b/tests/routers/test_blacklist_router.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from preggy import expect
+
+from thumbor.handlers.blacklist import BlacklistHandler
+from thumbor.routers.base import Route
+from thumbor.routers.blacklist import BlacklistRouter
+from thumbor.testing import TestCase
+
+
+class UploadRouterTestCase(TestCase):
+    def test_can_get_routes(self):
+        ctx = self.get_context()
+        ctx.config.USE_BLACKLIST = True
+
+        routes = BlacklistRouter(ctx).get_routes()
+
+        expect(routes).not_to_be_null()
+        expect(routes).to_length(1)
+        expect(routes[0]).to_be_instance_of(Route)
+        expect(routes[0].url).to_equal(r"/blacklist/?")
+        expect(routes[0].handler).to_equal(BlacklistHandler)
+        expect(routes[0].initialize).to_equal({"context": ctx})
+
+    def test_can_disable_blacklist(self):
+        ctx = self.get_context()
+        ctx.config.UPLOAD_ENABLED = False
+
+        routes = BlacklistRouter(ctx).get_routes()
+
+        expect(routes).not_to_be_null()
+        expect(routes).to_be_empty()

--- a/tests/routers/test_healthcheck_router.py
+++ b/tests/routers/test_healthcheck_router.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from preggy import expect
+
+from thumbor.handlers.healthcheck import HealthcheckHandler
+from thumbor.routers.base import Route
+from thumbor.routers.healthcheck import HealthcheckRouter
+from thumbor.testing import TestCase
+
+
+class HealthcheckRouterTestCase(TestCase):
+    def test_can_get_routes(self):
+        routes = HealthcheckRouter(self.context).get_routes()
+
+        expect(routes).not_to_be_null()
+        expect(routes).to_length(1)
+        expect(routes[0]).to_be_instance_of(Route)
+        expect(routes[0].url).to_equal(r"/healthcheck/?")
+        expect(routes[0].handler).to_equal(HealthcheckHandler)
+
+    def test_can_get_routes_with_custom_url(self):
+        ctx = self.get_context()
+        ctx.config.HEALTHCHECK_ROUTE = "/health"
+        routes = HealthcheckRouter(ctx).get_routes()
+
+        expect(routes).not_to_be_null()
+        expect(routes).to_length(1)
+        expect(routes[0]).to_be_instance_of(Route)
+        expect(routes[0].url).to_equal("/health")
+        expect(routes[0].handler).to_equal(HealthcheckHandler)

--- a/tests/routers/test_upload_router.py
+++ b/tests/routers/test_upload_router.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from preggy import expect
+
+from thumbor.handlers.image_resource import ImageResourceHandler
+from thumbor.handlers.upload import ImageUploadHandler
+from thumbor.routers.base import Route
+from thumbor.routers.upload import UploadRouter
+from thumbor.testing import TestCase
+
+
+class UploadRouterTestCase(TestCase):
+    def test_can_get_routes(self):
+        ctx = self.get_context()
+        ctx.config.UPLOAD_ENABLED = True
+        routes = UploadRouter(ctx).get_routes()
+
+        expect(routes).not_to_be_null()
+        expect(routes).to_length(2)
+        expect(routes[0]).to_be_instance_of(Route)
+        expect(routes[0].url).to_equal(r"/image")
+        expect(routes[0].handler).to_equal(ImageUploadHandler)
+        expect(routes[0].initialize).to_equal({"context": ctx})
+        expect(routes[1]).to_be_instance_of(Route)
+        expect(routes[1].url).to_equal(r"/image/(.*)")
+        expect(routes[1].handler).to_equal(ImageResourceHandler)
+        expect(routes[1].initialize).to_equal({"context": ctx})
+
+    def test_can_disable_upload(self):
+        ctx = self.get_context()
+        ctx.config.UPLOAD_ENABLED = False
+        routes = UploadRouter(ctx).get_routes()
+
+        expect(routes).not_to_be_null()
+        expect(routes).to_be_empty()

--- a/tests/storages/test_no_storage.py
+++ b/tests/storages/test_no_storage.py
@@ -14,16 +14,10 @@ from preggy import expect
 from tornado.testing import gen_test
 
 from tests.base import TestCase
-from thumbor.config import Config
-from thumbor.context import Context
 from thumbor.storages.no_storage import Storage as NoStorage
 
 
 class NoStorageTestCase(TestCase):
-    def get_context(self):
-        cfg = Config()
-        return Context(None, cfg, None)
-
     def get_image_url(self, image):
         return "s.glbimg.com/some/{0}".format(image)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,46 +8,45 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
-from unittest import TestCase
 
-import mock
 from libthumbor.url import Url
 from preggy import expect
 
 from thumbor.app import ThumborServiceApp
+from thumbor.testing import TestCase
 
 
 class AppTestCase(TestCase):
     def test_can_create_app(self):
-        ctx = mock.Mock()
-        app = ThumborServiceApp(ctx)
+        app = ThumborServiceApp(self.context)
         expect(app).not_to_be_null()
-        expect(app.context).to_equal(ctx)
+        expect(app.context).to_equal(self.context)
 
     def test_can_get_handlers(self):
-        ctx = mock.Mock(
-            config=mock.Mock(
-                UPLOAD_ENABLED=False,
-                USE_BLACKLIST=False,
-                HEALTHCHECK_ROUTE=r"/healthcheck",
-            )
-        )
+        ctx = self.get_context()
+        ctx.config.UPLOAD_ENABLED = False
+        ctx.config.USE_BLACKLIST = False
+        ctx.config.HEALTHCHECK_ROUTE = "/health"
         app = ThumborServiceApp(ctx)
 
         handlers = app.get_handlers()
         expect(handlers).to_length(2)
-        expect(handlers[0][0]).to_equal(r"/healthcheck")
+        expect(handlers[0][0]).to_equal(r"/health")
         expect(handlers[1][0]).to_equal(Url.regex())
 
     def test_can_get_handlers_with_upload(self):
-        ctx = mock.Mock(config=mock.Mock(UPLOAD_ENABLED=True, USE_BLACKLIST=False,))
+        ctx = self.get_context()
+        ctx.config.UPLOAD_ENABLED = True
+        ctx.config.USE_BLACKLIST = False
         app = ThumborServiceApp(ctx)
 
         handlers = app.get_handlers()
         expect(handlers).to_length(4)
 
     def test_can_get_handlers_with_blacklist(self):
-        ctx = mock.Mock(config=mock.Mock(UPLOAD_ENABLED=False, USE_BLACKLIST=True,))
+        ctx = self.get_context()
+        ctx.config.UPLOAD_ENABLED = False
+        ctx.config.USE_BLACKLIST = True
         app = ThumborServiceApp(ctx)
 
         handlers = app.get_handlers()

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -20,6 +20,7 @@ from thumbor.filters.rgb import Filter as rgb_filter
 from thumbor.importer import Importer
 from thumbor.loaders import http_loader
 from thumbor.result_storages.file_storage import Storage as result_file_storage
+from thumbor.routers.healthcheck import HealthcheckRouter
 from thumbor.storages.file_storage import Storage as file_storage
 
 
@@ -34,6 +35,7 @@ class ImporterTestCase(TestCase):
             RESULT_STORAGE="thumbor.result_storages.file_storage",
             DETECTORS=["thumbor.detectors.face_detector"],
             FILTERS=["thumbor.filters.rgb"],
+            ROUTERS=["thumbor.routers.healthcheck.HealthcheckRouter"],
         )
 
     def test_import_item_should_be_proper_item(self):
@@ -48,6 +50,7 @@ class ImporterTestCase(TestCase):
             "RESULT_STORAGE": result_file_storage,
             "DETECTORS": (face_detector,),
             "FILTERS": (rgb_filter,),
+            "ROUTERS": (HealthcheckRouter,),
         }
 
         for key, value in data.items():
@@ -57,11 +60,9 @@ class ImporterTestCase(TestCase):
 
             if prop is tuple:
                 for index, item in enumerate(prop):
-                    expect(item).not_to_be_null()
-                    expect(item).to_equal(default_value[index])
+                    expect(item).not_to_be_null().to_equal(default_value[index])
             else:
-                expect(prop).not_to_be_null()
-                expect(prop).to_equal(default_value)
+                expect(prop).not_to_be_null().to_equal(default_value)
 
     @staticmethod
     def test_single_item_should_equal_file_storage():

--- a/thumbor/app.py
+++ b/thumbor/app.py
@@ -12,11 +12,7 @@ import tornado.ioloop
 import tornado.web
 from libthumbor.url import Url
 
-from thumbor.handlers.blacklist import BlacklistHandler
-from thumbor.handlers.healthcheck import HealthcheckHandler
-from thumbor.handlers.image_resource import ImageResourceHandler
 from thumbor.handlers.imaging import ImagingHandler
-from thumbor.handlers.upload import ImageUploadHandler
 
 
 class ThumborServiceApp(tornado.web.Application):
@@ -26,22 +22,13 @@ class ThumborServiceApp(tornado.web.Application):
         super(ThumborServiceApp, self).__init__(self.get_handlers(), debug=self.debug)
 
     def get_handlers(self):
-        handlers = [
-            (self.context.config.HEALTHCHECK_ROUTE, HealthcheckHandler),
-        ]
-
-        if self.context.config.UPLOAD_ENABLED:
-            # Handler to upload images (POST).
-            handlers.append((r"/image", ImageUploadHandler, {"context": self.context}))
-
-            # Handler to retrieve or modify existing images  (GET, PUT, DELETE)
-            handlers.append(
-                (r"/image/(.*)", ImageResourceHandler, {"context": self.context},)
-            )
-
-        if self.context.config.USE_BLACKLIST:
-            handlers.append(
-                (r"/blacklist", BlacklistHandler, {"context": self.context})
+        handlers = []
+        for router in self.context.modules.importer.routers:
+            handlers.extend(
+                [
+                    (route.url, route.handler, route.initialize)
+                    for route in router(self.context).get_routes()
+                ]
             )
 
         # Imaging handler (GET)

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -15,6 +15,8 @@ import derpconf.config as config
 from derpconf.config import Config
 
 from thumbor import __version__
+from thumbor.filters import BUILTIN_FILTERS
+from thumbor.routers import BUILTIN_ROUTERS
 
 HOME = expanduser("~")
 
@@ -296,7 +298,9 @@ Config.define(
     "GC_INTERVAL", None, "Set garbage collection interval in seconds", "Performance",
 )
 
-Config.define("HEALTHCHECK_ROUTE", r"/healthcheck", "Healthcheck route.", "Healthcheck")
+Config.define(
+    "HEALTHCHECK_ROUTE", r"/healthcheck/?", "Healthcheck route.", "Healthcheck"
+)
 
 # METRICS OPTIONS
 Config.define("STATSD_HOST", None, "Host to send statsd instrumentation to", "Metrics")
@@ -586,38 +590,7 @@ Config.define(
 # AVAILABLE FILTERS
 Config.define(
     "FILTERS",
-    [
-        "thumbor.filters.brightness",
-        "thumbor.filters.colorize",
-        "thumbor.filters.contrast",
-        "thumbor.filters.rgb",
-        "thumbor.filters.round_corner",
-        "thumbor.filters.quality",
-        "thumbor.filters.noise",
-        "thumbor.filters.watermark",
-        "thumbor.filters.equalize",
-        "thumbor.filters.fill",
-        "thumbor.filters.sharpen",
-        "thumbor.filters.strip_exif",
-        "thumbor.filters.strip_icc",
-        "thumbor.filters.frame",
-        "thumbor.filters.grayscale",
-        "thumbor.filters.rotate",
-        "thumbor.filters.format",
-        "thumbor.filters.max_bytes",
-        "thumbor.filters.convolution",
-        "thumbor.filters.blur",
-        "thumbor.filters.extract_focal",
-        "thumbor.filters.focal",
-        "thumbor.filters.no_upscale",
-        "thumbor.filters.saturation",
-        "thumbor.filters.max_age",
-        "thumbor.filters.curve",
-        "thumbor.filters.background_color",
-        "thumbor.filters.upscale",
-        "thumbor.filters.proportion",
-        "thumbor.filters.stretch",
-    ],
+    BUILTIN_FILTERS,
     "List of filters that thumbor will allow to be used in generated images. All of them must be "
     + "full names of python modules (python must be able to import it)",
     "Filters",
@@ -735,6 +708,15 @@ Config.define(
     "The amount of time to waut before shutting down all io, after the server has been stopped",
     "Server",
 )
+
+# ROUTERS
+Config.define(
+    "ROUTERS",
+    BUILTIN_ROUTERS,
+    "Routers are responsible for adding routes to thumbor app.",
+    "Routers",
+)
+
 
 Config.define(
     "APP_CLASS",

--- a/thumbor/filters/__init__.py
+++ b/thumbor/filters/__init__.py
@@ -11,6 +11,39 @@
 import collections
 import re
 
+BUILTIN_FILTERS = [
+    "thumbor.filters.brightness",
+    "thumbor.filters.colorize",
+    "thumbor.filters.contrast",
+    "thumbor.filters.rgb",
+    "thumbor.filters.round_corner",
+    "thumbor.filters.quality",
+    "thumbor.filters.noise",
+    "thumbor.filters.watermark",
+    "thumbor.filters.equalize",
+    "thumbor.filters.fill",
+    "thumbor.filters.sharpen",
+    "thumbor.filters.strip_exif",
+    "thumbor.filters.strip_icc",
+    "thumbor.filters.frame",
+    "thumbor.filters.grayscale",
+    "thumbor.filters.rotate",
+    "thumbor.filters.format",
+    "thumbor.filters.max_bytes",
+    "thumbor.filters.convolution",
+    "thumbor.filters.blur",
+    "thumbor.filters.extract_focal",
+    "thumbor.filters.focal",
+    "thumbor.filters.no_upscale",
+    "thumbor.filters.saturation",
+    "thumbor.filters.max_age",
+    "thumbor.filters.curve",
+    "thumbor.filters.background_color",
+    "thumbor.filters.upscale",
+    "thumbor.filters.proportion",
+    "thumbor.filters.stretch",
+]
+
 STRIP_QUOTE = re.compile(r"^'(.+)'$")
 PHASE_POST_TRANSFORM = "post_transform"
 PHASE_PRE_LOAD = "pre-load"

--- a/thumbor/routers/__init__.py
+++ b/thumbor/routers/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+BUILTIN_ROUTERS = [
+    "thumbor.routers.healthcheck.HealthcheckRouter",
+    "thumbor.routers.upload.UploadRouter",
+    "thumbor.routers.blacklist.BlacklistRouter",
+]

--- a/thumbor/routers/base.py
+++ b/thumbor/routers/base.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+from tornado.web import RequestHandler
+
+
+class Route:
+    def __init__(
+        self, url: str, handler: RequestHandler, initialize: Dict[str, Any] = None
+    ):
+        self.url = url
+        self.handler = handler
+        self.initialize = initialize
+
+
+class BaseRouter(ABC):
+    def __init__(self, context: Any):
+        self.context = context
+
+    @abstractmethod
+    def get_routes(self) -> Optional[List[Route]]:
+        pass

--- a/thumbor/routers/blacklist.py
+++ b/thumbor/routers/blacklist.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from typing import List, Optional, cast
+
+from thumbor.handlers.blacklist import BlacklistHandler
+from thumbor.routers.base import BaseRouter, Route
+
+
+class BlacklistRouter(BaseRouter):
+    def get_routes(self) -> Optional[List[Route]]:
+        is_blacklist_enabled = cast(bool, self.context.config.USE_BLACKLIST)
+        if not is_blacklist_enabled:
+            return []
+
+        return [Route(r"/blacklist/?", BlacklistHandler, {"context": self.context})]

--- a/thumbor/routers/healthcheck.py
+++ b/thumbor/routers/healthcheck.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from typing import List, Optional, cast
+
+from thumbor.handlers.healthcheck import HealthcheckHandler
+from thumbor.routers.base import BaseRouter, Route
+
+
+class HealthcheckRouter(BaseRouter):
+    def get_routes(self) -> Optional[List[Route]]:
+        url = cast(str, self.context.config.HEALTHCHECK_ROUTE)
+        return [Route(url, HealthcheckHandler)]

--- a/thumbor/routers/upload.py
+++ b/thumbor/routers/upload.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from typing import List, Optional, cast
+
+from thumbor.handlers.image_resource import ImageResourceHandler
+from thumbor.handlers.upload import ImageUploadHandler
+from thumbor.routers.base import BaseRouter, Route
+
+
+class UploadRouter(BaseRouter):
+    def get_routes(self) -> Optional[List[Route]]:
+        is_upload_enabled = cast(bool, self.context.config.UPLOAD_ENABLED)
+        if not is_upload_enabled:
+            return []
+
+        return [
+            Route(r"/image", ImageUploadHandler, {"context": self.context}),
+            Route(r"/image/(.*)", ImageResourceHandler, {"context": self.context}),
+        ]

--- a/thumbor/testing.py
+++ b/thumbor/testing.py
@@ -101,6 +101,7 @@ class TestCase(AsyncHTTPTestCase):
         self.request_handler = (  # This is a test case pylint: disable=attribute-defined-outside-init
             self.get_request_handler()
         )
+        self.importer.import_modules()
         return Context(self.server, self.config, self.importer, self.request_handler)
 
     async def async_fetch(self, path, method="GET", body=None, headers=None):

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -212,6 +212,10 @@ ALLOW_UNSAFE_URL = True
     #'thumbor.optimizers.gifv',
 #]
 
+from thumbor.routers import BUILTIN_ROUTERS
+
+ROUTERS = BUILTIN_ROUTERS + []
+
 #JPEGTRAN_PATH = '/usr/local/bin/jpegtran'
 
 # If the CurlAsyncHTTPClient should be used


### PR DESCRIPTION
Is Backwards Compatible: yes

This commit adds support for a new class of plugins: Routers.
Routers are responsible for integrating new routes in thumbor's
App.

This is the missing extensiblity part in thumbor and one of the
reasons scope has crept in it (upload support).
After this has been released we'll start separating some of these
into their own modules.

One example apart from upload is healthcheck. While thumbor will
ship with a default healthcheck that's backwards compatible,
it will allow plugin builders to implement their own healthcheck
module (verifies if services that thumbor depends on are
available).

Creating a router is as simple as extending an abstract
`BaseRouter` and implementing the required methods.

Configuring which routers to use should be very familiar to any
thumbor user and is just a config value with the fully qualified
name of the class.