### PR TITLE
Fix ancient 5.2 build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ http://<thumbor-server>/300x200/smart/s.glbimg.com/et/bb/f/original/2011/03/24/V
             "python-magic>=0.4.3",
             "pexif>=0.15,<1.0",
             "statsd>=3.0.1",
-            "libthumbor",
+            "libthumbor>=1.0.0,<2.0.0",
             "futures",
         ],
 


### PR DESCRIPTION
The new release of `libthumbor` breaks ancient 5.2 builds, as libthumbor is unrestricted there. This PR adds a Version Constraint.

I know, we should totally update our thumbor. :(
That being said, feel free to close this PR if you do not want to release a new 5.2.* version. I filed it anyway, so other who use 5.2 as well know how to fix it.

Thanks.