### PR TITLE
Apply embedded image profile when converting to RGB

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -358,6 +358,8 @@ class Engine(BaseEngine):
                                                             self.icc_profile,
                                                             CMS_SRGB_PROFILE,
                                                             outputMode=outmode)
+                if update_image:
+                    self.icc_profile = CMS_SRGB_PROFILE
             elif "A" in converted_image.mode:
                 converted_image = converted_image.convert("RGBA")
             elif converted_image.mode == "P":
@@ -367,8 +369,6 @@ class Engine(BaseEngine):
                 converted_image = converted_image.convert("RGB")
         if update_image:
             self.image = converted_image
-            if self.icc_profile is not None and CMS_SRGB_PROFILE is not None:
-                self.icc_profile = CMS_SRGB_PROFILE
         return converted_image.mode, converted_image.tobytes()
 
     def convert_to_grayscale(self, update_image=True, alpha=True):


### PR DESCRIPTION
This is an alternative approach for #927

Apply icc profiles embedded in images automatically when `image_data_as_rgb` is called.