### PR TITLE
[DOCS] Update instructions on installing OSX deps

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -108,9 +108,7 @@ Pyexiv2 depends on the following libraries:
 
 On OSX you can use homebrew to install the dependencies::
 
-    brew install boost --with-python
-    brew install boost-python
-    brew install exiv2
+    brew install boost boost-python3 exiv2
 
     pip install py3exiv2
 


### PR DESCRIPTION
The old instructions don't work for Python 3. Also, one command is probably a little bit easier to copy, paste and execute.