### PR TITLE
[FIX] Make fill with blur engine-agnostic

### DIFF
--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -17,7 +17,6 @@ from PIL import (
     Image,
     ImageDraw,
     ImageFile,
-    ImageFilter,
     ImageSequence,
     JpegImagePlugin,
     features as pillow_features,
@@ -415,6 +414,3 @@ class Engine(BaseEngine):
 
     def strip_exif(self):
         self.exif = None
-
-    def blur(self, radius):
-        self.image = self.image.filter(ImageFilter.GaussianBlur(radius))

--- a/thumbor/filters/blur.py
+++ b/thumbor/filters/blur.py
@@ -15,6 +15,27 @@ from thumbor.filters import BaseFilter, filter_method
 MAX_RADIUS = 150
 
 
+def generate_1d_matrix(sigma, radius):
+    matrix_size = (radius * 2) + 1
+    matrix = []
+    two_sigma_squared = float(2 * sigma * sigma)
+    for column in range(matrix_size):
+        adj_x = column - radius
+        exp = math.e ** -(((adj_x * adj_x)) / two_sigma_squared)
+        matrix.append(exp / math.sqrt(two_sigma_squared * math.pi))
+    return tuple(matrix), matrix_size
+
+
+def apply_blur(mode, data, size, radius, sigma=0):
+    if sigma == 0:
+        sigma = radius
+    if radius > MAX_RADIUS:
+        radius = MAX_RADIUS
+    matrix, matrix_size = generate_1d_matrix(sigma, radius)
+    data = _convolution.apply(mode, data, size[0], size[1], matrix, matrix_size, True)
+    return _convolution.apply(mode, data, size[0], size[1], matrix, 1, True)
+
+
 class Filter(BaseFilter):
     """
         Usage: /filters:blur(<radius> [, <sigma>])
@@ -24,34 +45,8 @@ class Filter(BaseFilter):
             /filters:blur(4, 2)/
     """
 
-    def generate_1d_matrix(self, sigma, radius):
-        matrix_size = (radius * 2) + 1
-        matrix = []
-        two_sigma_squared = float(2 * sigma * sigma)
-        for column in range(matrix_size):
-            adj_x = column - radius
-            exp = math.e ** -(((adj_x * adj_x)) / two_sigma_squared)
-            matrix.append(exp / math.sqrt(two_sigma_squared * math.pi))
-        return tuple(matrix), matrix_size
-
     @filter_method(BaseFilter.PositiveNonZeroNumber, BaseFilter.DecimalNumber)
     async def blur(self, radius, sigma=0):
-        if sigma == 0:
-            sigma = radius
-        if radius > MAX_RADIUS:
-            radius = MAX_RADIUS
-        matrix, matrix_size = self.generate_1d_matrix(sigma, radius)
-        mode, data = self.engine.image_data_as_rgb()
-        imgdata = _convolution.apply(
-            mode,
-            data,
-            self.engine.size[0],
-            self.engine.size[1],
-            matrix,
-            matrix_size,
-            True,
-        )
-        imgdata = _convolution.apply(
-            mode, imgdata, self.engine.size[0], self.engine.size[1], matrix, 1, True,
-        )
+        mode, imgdata = self.engine.image_data_as_rgb()
+        imgdata = apply_blur(mode, imgdata, self.engine.size, radius, sigma)
         self.engine.set_image_data(imgdata)

--- a/thumbor/filters/fill.py
+++ b/thumbor/filters/fill.py
@@ -10,6 +10,7 @@
 
 from thumbor.ext.filters import _fill
 from thumbor.filters import BaseFilter, filter_method
+from thumbor.filters.blur import apply_blur
 
 
 class Filter(BaseFilter):
@@ -39,9 +40,14 @@ class Filter(BaseFilter):
             color = self.get_median_color()
 
         if color == "blur":
-            self.fill_engine.image = self.engine.image
+            self.fill_engine.image = self.fill_engine.gen_image(
+                self.engine.size, "transparent"
+            )
+            self.fill_engine.paste(self.engine, (0, 0))
+            mode, data = self.fill_engine.image_data_as_rgb()
+            data = apply_blur(mode, data, self.fill_engine.size, 50)
+            self.fill_engine.set_image_data(data)
             self.fill_engine.resize(target_width, target_height)
-            self.fill_engine.blur(50)
         else:
             try:
                 self.fill_engine.image = self.fill_engine.gen_image(


### PR DESCRIPTION
The `fill` filter, when used with color set to "blur", depended on the engine having the `blur` method. That broke the filter when the engine in use doesn't fulfill such dependency.

By using the already existing blur capabilities of the `blur` filter, `fill(blur)` now wokrs for engines other than PIL.