### PR TITLE
fix(filter/proportion): Fix crash with impossible proportion constraint

### DIFF
--- a/thumbor/filters/proportion.py
+++ b/thumbor/filters/proportion.py
@@ -19,7 +19,7 @@ class Filter(BaseFilter):
         new_width = source_width * value
         new_height = source_height * value
 
-        if new_width <= 0 or new_height <= 0:
+        if new_width < 1 or new_height < 1:
             return
 
         self.engine.resize(new_width, new_height)


### PR DESCRIPTION
Given a source image at 1x100 resized by 0.5, thumbor will try to resize to 0.5x50 and trigger [this guard in PIL](https://github.com/python-pillow/Pillow/blob/2c0aa5d0b8eeaabb922317ce88159e0b6aa0b21e/src/_imaging.c#L1827-L1829)

While the request is invalid, maybe throwing PIL's error is the intended behavior?

Imo failing gracefully could be preferred. Otherwise, I believe the only way to guarantee no runtime errors from PIL is to know the image's `souce_width` and `source_height` before making the request. That would sorta eliminate the need for the `proportion` filter