### PR TITLE
Make python binary configurable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ run-prod: compile_ext
 	@thumbor -l error -c thumbor/thumbor.conf
 
 setup:
-	@pip install -e .[tests]
+	@$(PYTHON) -m pip install -e .[tests]
 
 compile_ext build:
 	@$(PYTHON) setup.py build_ext -i
@@ -56,7 +56,7 @@ pylint:
 	@pylint thumbor tests
 
 setup_docs:
-	@pip install -r docs/requirements.txt
+	@$(PYTHON) -m pip install -r docs/requirements.txt
 
 build_docs:
 	@cd docs && make html

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PYTHON = python
 .PHONY: docs build perf
 
 OS := $(shell uname)
@@ -12,7 +13,7 @@ setup:
 	@pip install -e .[tests]
 
 compile_ext build:
-	@python setup.py build_ext -i
+	@$(PYTHON) setup.py build_ext -i
 
 test: build redis
 	@$(MAKE) unit coverage


### PR DESCRIPTION
This allows overriding which version of python is run for the extension building via:

 `make PYTHON=python3 test`