### PR TITLE
Fix HTTP 500 when request path points to directory

### DIFF
--- a/thumbor/loaders/file_loader.py
+++ b/thumbor/loaders/file_loader.py
@@ -10,7 +10,7 @@
 
 from datetime import datetime
 from os import fstat
-from os.path import abspath, exists, join
+from os.path import abspath, exists, join, isfile
 from urllib.parse import unquote
 
 from thumbor.loaders import LoaderResult
@@ -35,7 +35,7 @@ async def load(context, path):
     if not exists(file_path):
         file_path = unquote(file_path)
 
-    if exists(file_path):
+    if exists(file_path) and isfile(file_path):
         with open(file_path, "rb") as source_file:
             stats = fstat(source_file.fileno())
 


### PR DESCRIPTION
Originally if request's path points to directory then the server will fail
and return HTTP 500 status code. Correct behavior is to indicate issue with
request, not the server. Thanks to this fix 404 will be returned.

Returning 5xx status code affects potential Thumbor integration to larger systems,
where 500 response may be treated as Thumbor malfunction and will cause taking it
out of load balancing pool.