### PR TITLE
Extend the PIL test timeout

### DIFF
--- a/integration_tests/pil_test.py
+++ b/integration_tests/pil_test.py
@@ -9,7 +9,7 @@ from .urls_helpers import UrlsTester, single_dataset
 class PILTest(EngineCase):
     engine = "thumbor.engines.pil"
 
-    @gen_test
+    @gen_test(timeout=30)
     async def test_single_params(self):
         if not self._app:
             return True


### PR DESCRIPTION
The default of 5 seconds can be too short for testing the underlying 472 requests.

Without this, if def_single_params times out it results in an obscure concurrent.futures._base.CancelledError just for the affected request.

I had this issue happen non-deterministically in a Docker container running the test suite.