### PR TITLE
[FEAT] Improvement of our build and CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,105 @@
+version: 2.1
+
+orbs:
+  # The python orb contains a set of prepackaged circleci configuration you can use repeatedly in your configurations files
+  # Orb commands and jobs help you with common scripting around a language/tool
+  # so you dont have to copy and paste it everywhere.
+  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
+  python: circleci/python@1.2
+
+workflows:
+  ci:
+    jobs:
+      - build-and-test-python36
+      - build-and-test-python37
+      - build-and-test-python38
+      - build-and-test-python39
+
+jobs:
+  build-and-test-python36:
+    working_directory: /app
+    docker:
+      - image: thumbororg/thumbor-test:36
+    steps:
+      - checkout
+      - run:
+          name: Compile Extensions
+          command: make compile_ext
+      - run:
+          name: Redis
+          command: make redis
+      - run:
+          name: Run Unit Tests
+          command: make sequential-unit
+      - run:
+          name: Run Integration Tests
+          command: env ASYNC_TEST_TIMEOUT=30 make integration_run
+      - run:
+          name: Lint
+          command: make flake
+
+  build-and-test-python37:
+    working_directory: /app
+    docker:
+      - image: thumbororg/thumbor-test:37
+    steps:
+      - checkout
+      - run:
+          name: Compile Extensions
+          command: make compile_ext
+      - run:
+          name: Redis
+          command: make redis
+      - run:
+          name: Run Unit Tests
+          command: make sequential-unit
+      - run:
+          name: Run Integration Tests
+          command: env ASYNC_TEST_TIMEOUT=30 make integration_run
+      - run:
+          name: Lint
+          command: make flake
+
+  build-and-test-python38:
+    working_directory: /app
+    docker:
+      - image: thumbororg/thumbor-test:38
+    steps:
+      - checkout
+      - run:
+          name: Compile Extensions
+          command: make compile_ext
+      - run:
+          name: Redis
+          command: make redis
+      - run:
+          name: Run Unit Tests
+          command: make sequential-unit
+      - run:
+          name: Run Integration Tests
+          command: env ASYNC_TEST_TIMEOUT=30 make integration_run
+      - run:
+          name: Lint
+          command: make flake
+
+  build-and-test-python39:
+    working_directory: /app
+    docker:
+      - image: thumbororg/thumbor-test:39
+    steps:
+      - checkout
+      - run:
+          name: Compile Extensions
+          command: make compile_ext
+      - run:
+          name: Redis
+          command: make redis
+      - run:
+          name: Run Unit Tests
+          command: make sequential-unit
+      - run:
+          name: Run Integration Tests
+          command: env ASYNC_TEST_TIMEOUT=30 make integration_run
+      - run:
+          name: Lint
+          command: make flake

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-3.8.2/envs/thumbor

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ coverage:
 unit:
 	@pytest -n `nproc` --cov=thumbor tests/
 
+sequential-unit:
+	@pytest -sv --cov=thumbor tests/
+
 kill_redis:
 	@-redis-cli -p 6668 -a hey_you shutdown
 
@@ -148,3 +151,49 @@ sample_images:
 	cp tests/fixtures/filters/watermark.png tests/fixtures/images/watermark.png
 	# the watermark filter's logic is too complicated to reproduce with IM, the watermark test images can't be generated here
 	# similarly, the noise, colorize, redeye and fill filters generate output too unique to be reproduce with IM and can't be generated here
+
+test-docker-build: test-docker-36-build test-docker-37-build test-docker-38-build test-docker-39-build
+
+test-docker-run: test-docker-36-run test-docker-37-run test-docker-38-run test-docker-39-run
+
+test-docker-publish: test-docker-36-publish test-docker-37-publish test-docker-38-publish test-docker-39-publish
+
+test-docker-36-build:
+	@docker build -f TestDockerfile36 -t thumbor-test-36 .
+
+test-docker-36-run:
+	@docker run -v "$$(pwd):/app" thumbororg/thumbor-test:36 make compile_ext redis sequential-unit integration flake
+
+test-docker-36-publish:
+	@docker image tag thumbor-test-36:latest thumbororg/thumbor-test:36
+	@docker push thumbororg/thumbor-test:36
+
+test-docker-37-build:
+	@docker build -f TestDockerfile37 -t thumbor-test-37 .
+
+test-docker-37-run:
+	@docker run -v "$$(pwd):/app" thumbororg/thumbor-test:37 make compile_ext redis sequential-unit integration flake
+
+test-docker-37-publish:
+	@docker image tag thumbor-test-37:latest thumbororg/thumbor-test:37
+	@docker push thumbororg/thumbor-test:37
+
+test-docker-38-build:
+	@docker build -f TestDockerfile38 -t thumbor-test-38 .
+
+test-docker-38-run:
+	@docker run -v "$$(pwd):/app" thumbororg/thumbor-test:38 make compile_ext redis sequential-unit integration flake
+
+test-docker-38-publish:
+	@docker image tag thumbor-test-38:latest thumbororg/thumbor-test:38
+	@docker push thumbororg/thumbor-test:38
+
+test-docker-39-build:
+	@docker build -f TestDockerfile39 -t thumbor-test-39 .
+
+test-docker-39-run:
+	@docker run -v "$$(pwd):/app" thumbororg/thumbor-test:39 make compile_ext redis sequential-unit integration flake
+
+test-docker-39-publish:
+	@docker image tag thumbor-test-39:latest thumbororg/thumbor-test:39
+	@docker push thumbororg/thumbor-test:39

--- a/README.mkd
+++ b/README.mkd
@@ -5,6 +5,7 @@ If you use thumbor, please take 1 minute and answer [this survey](http://t.co/qP
 [<img src="https://raw.github.com/thumbor/thumbor/master/logo-thumbor.png">](https://github.com/thumbor/thumbor)
 
 [<img src="https://secure.travis-ci.org/thumbor/thumbor.png?branch=master">](http://travis-ci.org/thumbor/thumbor)
+[![CircleCI Status](https://circleci.com/gh/thumbor/thumbor.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/thumbor/thumbor)
 [![Coverage Status](https://coveralls.io/repos/thumbor/thumbor/badge.svg?branch=master&service=github)](https://coveralls.io/github/thumbor/thumbor?branch=master)
 [![Code Climate](https://codeclimate.com/github/thumbor/thumbor/badges/gpa.svg)](https://codeclimate.com/github/thumbor/thumbor)
 [![Codacy Badge](https://api.codacy.com/project/badge/373e13c719c0417f84f0d7d363c9d539)](https://www.codacy.com/app/heynemann/thumbor)

--- a/TestDockerfile36
+++ b/TestDockerfile36
@@ -1,0 +1,13 @@
+FROM python:3.6-slim
+WORKDIR /app
+RUN apt-get update -y && apt-get install -y python3-dev libcurl4-openssl-dev libgnutls28-dev libjpeg-progs libimage-exiftool-perl gifsicle scons python3-all-dev libboost-python-dev libexiv2-dev ffmpeg make zlib1g-dev gcc libssl-dev libjpeg-dev libwebp-dev redis && apt-get clean
+RUN apt-get update -y && apt-get install --reinstall -y build-essential && apt-get clean
+RUN pip install --upgrade pip
+COPY setup.py /app/setup.py
+RUN mkdir -p /app/thumbor
+RUN touch /app/thumbor/__init__.py
+RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python3-py37.so /usr/lib/libboost_python36.so
+RUN python -m pip install -e .[tests] && rm -rf ~/.cache/pip
+RUN pip install coveralls
+RUN pip install --upgrade pytest
+RUN rm -rf /app

--- a/TestDockerfile37
+++ b/TestDockerfile37
@@ -1,0 +1,13 @@
+FROM python:3.7-slim
+WORKDIR /app
+RUN apt-get update -y && apt-get install -y python3-dev libcurl4-openssl-dev libgnutls28-dev libjpeg-progs libimage-exiftool-perl gifsicle scons python3-all-dev libboost-python-dev libexiv2-dev ffmpeg make zlib1g-dev gcc libssl-dev libjpeg-dev libwebp-dev redis && apt-get clean
+RUN apt-get update -y && apt-get install --reinstall -y build-essential && apt-get clean
+RUN pip install --upgrade pip
+COPY setup.py /app/setup.py
+RUN mkdir -p /app/thumbor
+RUN touch /app/thumbor/__init__.py
+RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python3-py37.so /usr/lib/libboost_python37.so
+RUN python -m pip install -e .[tests] && rm -rf ~/.cache/pip
+RUN pip install coveralls
+RUN pip install --upgrade pytest
+RUN rm -rf /app

--- a/TestDockerfile38
+++ b/TestDockerfile38
@@ -1,0 +1,13 @@
+FROM python:3.8-slim
+WORKDIR /app
+RUN apt-get update -y && apt-get install -y python3-dev libcurl4-openssl-dev libgnutls28-dev libjpeg-progs libimage-exiftool-perl gifsicle scons python3-all-dev libboost-python-dev libexiv2-dev ffmpeg make zlib1g-dev gcc libssl-dev libjpeg-dev libwebp-dev redis && apt-get clean
+RUN apt-get update -y && apt-get install --reinstall -y build-essential && apt-get clean
+RUN pip install --upgrade pip
+COPY setup.py /app/setup.py
+RUN mkdir -p /app/thumbor
+RUN touch /app/thumbor/__init__.py
+RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python3-py37.so /usr/lib/libboost_python38.so
+RUN python -m pip install -e .[tests] && rm -rf ~/.cache/pip
+RUN pip install coveralls
+RUN pip install --upgrade pytest
+RUN rm -rf /app

--- a/TestDockerfile39
+++ b/TestDockerfile39
@@ -1,0 +1,13 @@
+FROM python:3.9-slim
+WORKDIR /app
+RUN apt-get update -y && apt-get install -y python3-dev libcurl4-openssl-dev libgnutls28-dev libjpeg-progs libimage-exiftool-perl gifsicle scons python3-all-dev libboost-python-dev libexiv2-dev ffmpeg make zlib1g-dev gcc libssl-dev libjpeg-dev libwebp-dev redis && apt-get clean
+RUN apt-get update -y && apt-get install --reinstall -y build-essential && apt-get clean
+RUN pip install --upgrade pip
+COPY setup.py /app/setup.py
+RUN mkdir -p /app/thumbor
+RUN touch /app/thumbor/__init__.py
+RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python3-py37.so /usr/lib/libboost_python39.so
+RUN python -m pip install -e .[tests] && rm -rf ~/.cache/pip
+RUN pip install coveralls
+RUN pip install --upgrade pytest
+RUN rm -rf /app

--- a/docs/hacking_on_thumbor.rst
+++ b/docs/hacking_on_thumbor.rst
@@ -78,3 +78,29 @@ To merge thumbor's master with your fork::
 
 If there was anything to merge, just run your tests again. If they pass,
 `send a pull request <http://help.github.com/send-pull-requests/>`__.
+
+Introducing a new Dependency
+----------------------------
+
+If we introduce a new dependency, the testing docker images need to be updated. 
+
+If the new dependency requires changes to the docker image, make sure to update the TestDockerfile36, TestDockerfile37, TestDockerfile38 and TestDockerfile39 files.
+
+Then build and publish with::
+
+    make test-docker-build test-docker-publish
+
+Remember that you must be logged in with your docker hub account and you must be part of the `thumbororg <https://hub.docker.com/repository/docker/thumbororg/thumbor-test>` team of administrators.
+
+Running tests in docker
+-----------------------
+
+If you do not wish to configure your environment with thumbor's dependencies, you can use our docker image to run tests with::
+
+    make test-docker-run
+
+Or if you want to run a specific python version with your tests::
+
+    make test-docker-39-run
+
+Just replace '39' with the python version you want: 36, 37, 38 or 39.

--- a/integration_tests/urls_helpers.py
+++ b/integration_tests/urls_helpers.py
@@ -124,7 +124,7 @@ class UrlsTester:
         failed = False
 
         try:
-            result = await self.http_client.fetch(url, request_timeout=30)
+            result = await self.http_client.fetch(url, request_timeout=60)
         except Exception as err:  # pylint: disable=broad-except
             logging.exception("Error in %s: %s", url, err)
             error = err

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,10 @@ import os
 
 from setuptools import Extension, setup
 
-from thumbor import __version__
+try:
+    from thumbor import __version__
+except ImportError:
+    __version__ = "0.0.0"
 
 TESTS_REQUIREMENTS = [
     "cairosvg!=1.0.21,<2.0.0,>=1.0.0",


### PR DESCRIPTION
**Is backwards compatible**: yes

This commit adds CircleCI and creates a new testing docker image for
Thumbor allowing our contributors to run tests easily without the
requirements leaking to their own environment.

Build passing: https://app.circleci.com/pipelines/github/thumbor/thumbor/22/workflows/383eefba-232b-453f-880b-3c9057b67371