### PR TITLE
[IMPR] Compatibility loader,storage,res storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update dependencies
+          command: make setup
+      - run:
           name: Compile Extensions
           command: make compile_ext
       - run:
@@ -48,6 +51,9 @@ jobs:
       - image: thumbororg/thumbor-test:37
     steps:
       - checkout
+      - run:
+          name: Update dependencies
+          command: make setup
       - run:
           name: Compile Extensions
           command: make compile_ext
@@ -79,6 +85,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update dependencies
+          command: make setup
+      - run:
           name: Compile Extensions
           command: make compile_ext
       - run:
@@ -108,6 +117,9 @@ jobs:
       - image: thumbororg/thumbor-test:39
     steps:
       - checkout
+      - run:
+          name: Update dependencies
+          command: make setup
       - run:
           name: Compile Extensions
           command: make compile_ext

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ opencv
 .venv
 docs/_build
 test-results
+.coverage*

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ sample_images:
 	cp tests/fixtures/images/image.jpg tests/fixtures/images/alabama1_ap620é.jpg
 	mkdir -p tests/fixtures/result_storages/v2/im/ag/
 	cp tests/fixtures/images/image.jpg tests/fixtures/result_storages/v2/im/ag/image.jpg
+	mkdir -p tests/fixtures/filters
 	curl -s https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Katherine_Maher.jpg/800px-Katherine_Maher.jpg -o tests/fixtures/filters/source.jpg
 	convert tests/fixtures/filters/source.jpg -quality 10 tests/fixtures/filters/quality-10%.jpg
 	convert tests/fixtures/filters/source.jpg -rotate 180 tests/fixtures/filters/rotate.jpg

--- a/docs/image_loader.rst
+++ b/docs/image_loader.rst
@@ -68,3 +68,16 @@ you'll get an error.
 
 To use it you should set the **LOADER** configuration to
 **'thumbor.loaders.file\_loader\_http\_fallback'**.
+
+Compatibility Loader
+~~~~~~~~~~~~~~~~~~~~
+
+The compatibility loader allows you to use legacy loaders (that do not support AsyncIO)
+in order to make it easier to transition to thumbor's Python 3 version.
+
+To use it you should set the **LOADER** configuration to
+**'thumbor.compatibility.loader'**.
+
+You also need to specify what's the legacy loader that the compatibility loader will use.
+Just set the **COMPATIBILITY_LEGACY_LOADER** configuration to the full name of the legacy
+loader you want to use. i.e.: COMPATIBILITY_LEGACY_LOADER = 'tc_aws.loaders.s3_loader'

--- a/docs/image_storage.rst
+++ b/docs/image_storage.rst
@@ -72,3 +72,16 @@ configuration:
 
 As you can see, you still have to tell thumbor the specific
 configurations for each storage you choose.
+
+Compatibility Storage
+~~~~~~~~~~~~~~~~~~~~~
+
+The compatibility storage allows you to use legacy storages (that do not support AsyncIO)
+in order to make it easier to transition to thumbor's Python 3 version.
+
+To use it you should set the **STORAGE** configuration to
+**'thumbor.compatibility.storage'**.
+
+You also need to specify what's the legacy storage that the compatibility storage will use.
+Just set the **COMPATIBILITY_LEGACY_STORAGE** configuration to the full name of the legacy
+storage you want to use. i.e.: COMPATIBILITY_LEGACY_STORAGE = 'tc_aws.storages.s3_storage'

--- a/docs/result_storage.rst
+++ b/docs/result_storage.rst
@@ -33,3 +33,16 @@ implies, it specifies the number of seconds with which files expire.
 
 To use it you should set the ``RESULT_STORAGE`` configuration to
 ``'thumbor.result_storages.file_storage'``.
+
+Compatibility Result Storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The compatibility result storage allows you to use legacy result storages (that do not support AsyncIO)
+in order to make it easier to transition to thumbor's Python 3 version.
+
+To use it you should set the **RESULT_STORAGE** configuration to
+**'thumbor.compatibility.result_storage'**.
+
+You also need to specify what's the legacy result storage that the compatibility result storage will use.
+Just set the **COMPATIBILITY_LEGACY_RESULT_STORAGE** configuration to the full name of the legacy
+result storage you want to use. i.e.: COMPATIBILITY_LEGACY_RESULT_STORAGE = 'tc_aws.result_storages.s3_storage'

--- a/tests/compatibility/legacy_file_loader.py
+++ b/tests/compatibility/legacy_file_loader.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from os import fstat
+from datetime import datetime
+from os.path import join, exists, abspath
+
+from six.moves.urllib.parse import unquote
+from tornado.concurrent import return_future
+
+from thumbor.loaders import LoaderResult
+
+
+@return_future
+def load(context, path, callback):
+    file_path = join(context.config.FILE_LOADER_ROOT_PATH.rstrip("/"), path.lstrip("/"))
+    file_path = abspath(file_path)
+    inside_root_path = file_path.startswith(
+        abspath(context.config.FILE_LOADER_ROOT_PATH)
+    )
+
+    result = LoaderResult()
+
+    if not inside_root_path:
+        result.error = LoaderResult.ERROR_NOT_FOUND
+        result.successful = False
+        callback(result)
+        return
+
+    # keep backwards compatibility, try the actual path first
+    # if not found, unquote it and try again
+    if not exists(file_path):
+        file_path = unquote(file_path)
+
+    if exists(file_path):
+        with open(file_path, "rb") as f:
+            stats = fstat(f.fileno())
+
+            result.successful = True
+            result.buffer = f.read()
+
+            result.metadata.update(
+                size=stats.st_size, updated_at=datetime.utcfromtimestamp(stats.st_mtime)
+            )
+    else:
+        result.error = LoaderResult.ERROR_NOT_FOUND
+        result.successful = False
+
+    callback(result)

--- a/tests/compatibility/legacy_file_result_storage.py
+++ b/tests/compatibility/legacy_file_result_storage.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com timehome@corp.globo.com
+
+# This file is copied from legacy way of using thumbor result storages,
+# thus we did not fix lint errors
+# pylint: disable=invalid-overridden-method,redefined-builtin,arguments-differ,logging-not-lazy,inconsistent-return-statements,invalid-name,deprecated-method
+
+from datetime import datetime
+from os.path import abspath, dirname, exists, getmtime, join
+from shutil import move
+from uuid import uuid4
+
+import pytz
+
+from thumbor.engines import BaseEngine
+from thumbor.result_storages import BaseStorage, ResultStorageResult
+from thumbor.utils import deprecated, logger
+
+
+class Storage(BaseStorage):
+    PATH_FORMAT_VERSION = "v2"
+
+    @property
+    def is_auto_webp(self):
+        return self.context.config.AUTO_WEBP and self.context.request.accepts_webp
+
+    def put(self, bytes):
+        file_abspath = self.normalize_path(self.context.request.url)
+        if not self.validate_path(file_abspath):
+            logger.warn(
+                "[RESULT_STORAGE] unable to write outside root path: %s" % file_abspath
+            )
+            return
+        temp_abspath = "%s.%s" % (file_abspath, str(uuid4()).replace("-", ""))
+        file_dir_abspath = dirname(file_abspath)
+        logger.debug(
+            "[RESULT_STORAGE] putting at %s (%s)" % (file_abspath, file_dir_abspath)
+        )
+
+        self.ensure_dir(file_dir_abspath)
+
+        with open(temp_abspath, "wb") as _file:
+            _file.write(bytes)
+
+        move(temp_abspath, file_abspath)
+
+    def get(self, callback):
+        path = self.context.request.url
+        file_abspath = self.normalize_path(path)
+        if not self.validate_path(file_abspath):
+            logger.warn(
+                "[RESULT_STORAGE] unable to read from outside root path: %s"
+                % file_abspath
+            )
+            return None
+        logger.debug("[RESULT_STORAGE] getting from %s" % file_abspath)
+
+        if not exists(file_abspath) or self.is_expired(file_abspath):
+            logger.debug("[RESULT_STORAGE] image not found at %s" % file_abspath)
+            callback(None)
+        else:
+            with open(file_abspath, "rb") as f:
+                buffer = f.read()
+
+            result = ResultStorageResult(
+                buffer=buffer,
+                metadata={
+                    "LastModified": datetime.fromtimestamp(
+                        getmtime(file_abspath)
+                    ).replace(tzinfo=pytz.utc),
+                    "ContentLength": len(buffer),
+                    "ContentType": BaseEngine.get_mimetype(buffer),
+                },
+            )
+
+            callback(result)
+
+    def validate_path(self, path):
+        return abspath(path).startswith(
+            self.context.config.RESULT_STORAGE_FILE_STORAGE_ROOT_PATH
+        )
+
+    def normalize_path(self, path):
+        path_segments = [
+            self.context.config.RESULT_STORAGE_FILE_STORAGE_ROOT_PATH.rstrip("/"),
+            Storage.PATH_FORMAT_VERSION,
+        ]
+        if self.is_auto_webp:
+            path_segments.append("webp")
+
+        path_segments.extend(
+            [
+                self.partition(path),
+                path.lstrip("/"),
+            ]
+        )
+
+        normalized_path = join(*path_segments).replace("http://", "")
+        return normalized_path
+
+    def partition(self, path_raw):
+        path = path_raw.lstrip("/")
+        return join("".join(path[0:2]), "".join(path[2:4]))
+
+    def is_expired(self, path):
+        expire_in_seconds = self.context.config.get(
+            "RESULT_STORAGE_EXPIRATION_SECONDS", None
+        )
+
+        if expire_in_seconds is None or expire_in_seconds == 0:
+            return False
+
+        timediff = datetime.now() - datetime.fromtimestamp(getmtime(path))
+        return timediff.seconds > expire_in_seconds
+
+    @deprecated("Use result's last_modified instead")
+    def last_updated(self):
+        path = self.context.request.url
+        file_abspath = self.normalize_path(path)
+        if not self.validate_path(file_abspath):
+            logger.warn(
+                "[RESULT_STORAGE] unable to read from outside root path: %s"
+                % file_abspath
+            )
+            return True
+        logger.debug("[RESULT_STORAGE] getting from %s" % file_abspath)
+
+        if not exists(file_abspath) or self.is_expired(file_abspath):
+            logger.debug("[RESULT_STORAGE] image not found at %s" % file_abspath)
+            return True
+
+        return datetime.fromtimestamp(getmtime(file_abspath)).replace(tzinfo=pytz.utc)

--- a/tests/compatibility/legacy_file_storage.py
+++ b/tests/compatibility/legacy_file_storage.py
@@ -1,0 +1,147 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+import os
+from shutil import move
+from json import dumps, loads
+from datetime import datetime
+from os.path import exists, dirname, getmtime, splitext
+import hashlib
+from uuid import uuid4
+
+import thumbor.storages as storages
+from thumbor.utils import logger
+from tornado.concurrent import return_future
+
+
+class Storage(storages.BaseStorage):
+    def put(self, path, bytes):
+        file_abspath = self.path_on_filesystem(path)
+        temp_abspath = "%s.%s" % (file_abspath, str(uuid4()).replace("-", ""))
+        file_dir_abspath = dirname(file_abspath)
+
+        logger.debug("creating tempfile for %s in %s..." % (path, temp_abspath))
+
+        self.ensure_dir(file_dir_abspath)
+
+        with open(temp_abspath, "wb") as _file:
+            _file.write(bytes)
+
+        logger.debug("moving tempfile %s to %s..." % (temp_abspath, file_abspath))
+        move(temp_abspath, file_abspath)
+
+        return path
+
+    def put_crypto(self, path):
+        if not self.context.config.STORES_CRYPTO_KEY_FOR_EACH_IMAGE:
+            return
+
+        file_abspath = self.path_on_filesystem(path)
+        file_dir_abspath = dirname(file_abspath)
+
+        self.ensure_dir(file_dir_abspath)
+
+        if not self.context.server.security_key:
+            raise RuntimeError(
+                "STORES_CRYPTO_KEY_FOR_EACH_IMAGE can't be True if no SECURITY_KEY specified"
+            )
+
+        crypto_path = "%s.txt" % splitext(file_abspath)[0]
+        temp_abspath = "%s.%s" % (crypto_path, str(uuid4()).replace("-", ""))
+        with open(temp_abspath, "w") as _file:
+            _file.write(self.context.server.security_key)
+
+        move(temp_abspath, crypto_path)
+        logger.debug(
+            "Stored crypto at %s (security key: %s)"
+            % (crypto_path, self.context.server.security_key)
+        )
+
+        return file_abspath
+
+    def put_detector_data(self, path, data):
+        file_abspath = self.path_on_filesystem(path)
+
+        path = "%s.detectors.txt" % splitext(file_abspath)[0]
+        temp_abspath = "%s.%s" % (path, str(uuid4()).replace("-", ""))
+
+        file_dir_abspath = dirname(file_abspath)
+        self.ensure_dir(file_dir_abspath)
+
+        with open(temp_abspath, "w") as _file:
+            _file.write(dumps(data))
+
+        move(temp_abspath, path)
+
+        return file_abspath
+
+    @return_future
+    def get(self, path, callback):
+        abs_path = self.path_on_filesystem(path)
+
+        def file_exists(resource_available):
+            if not resource_available:
+                callback(None)
+            else:
+                with open(self.path_on_filesystem(path), "rb") as f:
+                    callback(f.read())
+
+        self.exists(None, file_exists, path_on_filesystem=abs_path)
+
+    @return_future
+    def get_crypto(self, path, callback):
+        file_abspath = self.path_on_filesystem(path)
+        crypto_file = "%s.txt" % (splitext(file_abspath)[0])
+
+        if not exists(crypto_file):
+            callback(None)
+        else:
+            with open(crypto_file, "rb") as crypto_f:
+                callback(crypto_f.read())
+
+    @return_future
+    def get_detector_data(self, path, callback):
+        file_abspath = self.path_on_filesystem(path)
+        path = "%s.detectors.txt" % splitext(file_abspath)[0]
+
+        def file_exists(resource_available):
+            if not resource_available:
+                callback(None)
+            else:
+                callback(loads(open(path, "rb").read()))
+
+        self.exists(None, file_exists, path_on_filesystem=path)
+
+    def path_on_filesystem(self, path):
+        digest = hashlib.sha1(path.encode("utf-8")).hexdigest()
+        return "%s/%s/%s" % (
+            self.context.config.FILE_STORAGE_ROOT_PATH.rstrip("/"),
+            digest[:2],
+            digest[2:],
+        )
+
+    @return_future
+    def exists(self, path, callback, path_on_filesystem=None):
+        if path_on_filesystem is None:
+            path_on_filesystem = self.path_on_filesystem(path)
+        callback(
+            os.path.exists(path_on_filesystem)
+            and not self.__is_expired(path_on_filesystem)
+        )
+
+    def remove(self, path):
+        n_path = self.path_on_filesystem(path)
+        return os.remove(n_path)
+
+    def __is_expired(self, path):
+        if self.context.config.STORAGE_EXPIRATION_SECONDS is None:
+            return False
+        timediff = datetime.now() - datetime.fromtimestamp(getmtime(path))
+        return timediff.total_seconds() > self.context.config.STORAGE_EXPIRATION_SECONDS

--- a/tests/compatibility/test_compatibility_loader.py
+++ b/tests/compatibility/test_compatibility_loader.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from os.path import abspath, dirname, join
+
+from preggy import expect
+from tornado.testing import gen_test
+
+from tests.base import TestCase
+from thumbor.config import Config
+from thumbor.context import Context
+from thumbor.importer import Importer
+from thumbor.loaders import LoaderResult
+
+STORAGE_PATH = abspath(join(dirname(__file__), "../fixtures/images/"))
+
+
+class CompatibilityLoaderTestCase(TestCase):
+    def get_context(self):
+        config = Config(
+            FILE_LOADER_ROOT_PATH=STORAGE_PATH,
+            COMPATIBILITY_LEGACY_LOADER="tests.compatibility.legacy_file_loader",
+        )
+        importer = Importer(config)
+        importer.import_modules()
+        return Context(config=config, importer=importer)
+
+    async def load_file(self, context, file_name):
+        Importer.deprecated_monkey_patch_tornado_return_future()
+        from thumbor.compatibility.loader import load
+
+        return await load(context, file_name)
+
+    @gen_test
+    async def test_should_raise_for_invalid_compatibility_loader(self):
+        config = Config(
+            FILE_LOADER_ROOT_PATH=STORAGE_PATH,
+        )
+        importer = Importer(config)
+        importer.import_modules()
+        ctx = Context(config=config, importer=importer)
+
+        with expect.error_to_happen(
+            RuntimeError,
+            message=(
+                "The 'COMPATIBILITY_LEGACY_LOADER' configuration should point "
+                "to a valid loader when using compatibility loader."
+            ),
+        ):
+            await self.load_file(ctx, "image.jpg")
+
+    @gen_test
+    async def test_should_load_file(self):
+        result = await self.load_file(self.context, "image.jpg")
+        expect(result).to_be_instance_of(LoaderResult)
+        expect(result.buffer).to_equal(
+            open(join(STORAGE_PATH, "image.jpg"), "rb").read()
+        )
+        expect(result.successful).to_be_true()

--- a/tests/compatibility/test_compatibility_result_storage.py
+++ b/tests/compatibility/test_compatibility_result_storage.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from os.path import abspath, dirname, join
+
+from preggy import expect
+from tornado.testing import gen_test
+
+from tests.base import TestCase
+from thumbor.compatibility.result_storage import Storage
+from thumbor.config import Config
+from thumbor.context import Context, RequestParameters, ServerParameters
+from thumbor.importer import Importer
+
+STORAGE_PATH = abspath(join(dirname(__file__), "../fixtures/images/"))
+
+
+class CompatibilityResultStorageTestCase(TestCase):
+    def get_image_path(self, name):
+        return "./tests/fixtures/images/{0}".format(name)
+
+    def get_image_bytes(self, name):
+        with open(self.get_image_path(name), "rb") as img:
+            return img.read()
+
+    def get_image_url(self, name):
+        return "s.glbimg.com/some/{0}".format(name)
+
+    def get_context(self):
+        config = Config(
+            FILE_LOADER_ROOT_PATH=STORAGE_PATH,
+            COMPATIBILITY_LEGACY_RESULT_STORAGE="tests.compatibility.legacy_file_result_storage",
+            STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True,
+        )
+        self.importer = Importer(config)
+        self.importer.import_modules()
+        server = ServerParameters(8889, "localhost", "thumbor.conf", None, "info", None)
+        server.security_key = "ACME-SEC"
+        return Context(server, config=config, importer=self.importer)
+
+    @gen_test
+    async def test_should_raise_for_invalid_compatibility_storage(self):
+        request = RequestParameters(
+            url="/image.jpg",
+        )
+        config = Config(
+            FILE_LOADER_ROOT_PATH=STORAGE_PATH,
+            STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True,
+        )
+        importer = Importer(config)
+        importer.import_modules()
+        image_bytes = self.get_image_bytes("image.jpg")
+        ctx = Context(self.context.server, config, importer)
+        ctx.request = request
+        storage = Storage(ctx)
+
+        with expect.error_to_happen(
+            RuntimeError,
+            message=(
+                "The 'COMPATIBILITY_LEGACY_RESULT_STORAGE' configuration should point "
+                "to a valid result storage when using compatibility result storage."
+            ),
+        ):
+            await storage.get()
+
+        with expect.error_to_happen(
+            RuntimeError,
+            message=(
+                "The 'COMPATIBILITY_LEGACY_RESULT_STORAGE' configuration should point "
+                "to a valid result storage when using compatibility result storage."
+            ),
+        ):
+            await storage.put(image_bytes)
+
+    @gen_test
+    async def test_should_put_and_get(self):
+        request = RequestParameters(
+            url="/image.jpg",
+        )
+        image_bytes = self.get_image_bytes("image.jpg")
+        ctx = Context(self.context.server, self.context.config, self.importer)
+        ctx.request = request
+        storage = Storage(ctx)
+
+        await storage.put(image_bytes)
+
+        result = await storage.get()
+        expect(result).not_to_be_null()
+        expect(result).not_to_be_an_error()
+        expect(result.successful).to_be_true()
+        expect(result.buffer).to_equal(image_bytes)

--- a/tests/compatibility/test_compatibility_storage.py
+++ b/tests/compatibility/test_compatibility_storage.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from os.path import abspath, dirname, join
+
+from preggy import expect
+from tornado.testing import gen_test
+
+from tests.base import TestCase
+from thumbor.compatibility.storage import Storage
+from thumbor.config import Config
+from thumbor.context import Context, ServerParameters
+from thumbor.importer import Importer
+
+STORAGE_PATH = abspath(join(dirname(__file__), "../fixtures/images/"))
+
+
+class CompatibilityStorageTestCase(TestCase):
+    def get_image_path(self, name):
+        return "./tests/fixtures/images/{0}".format(name)
+
+    def get_image_bytes(self, name):
+        with open(self.get_image_path(name), "rb") as img:
+            return img.read()
+
+    def get_image_url(self, name):
+        return "s.glbimg.com/some/{0}".format(name)
+
+    def get_context(self):
+        config = Config(
+            FILE_LOADER_ROOT_PATH=STORAGE_PATH,
+            COMPATIBILITY_LEGACY_STORAGE="tests.compatibility.legacy_file_storage",
+            STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True,
+        )
+        importer = Importer(config)
+        importer.import_modules()
+        server = ServerParameters(8889, "localhost", "thumbor.conf", None, "info", None)
+        server.security_key = "ACME-SEC"
+        return Context(server, config=config, importer=importer)
+
+    @gen_test
+    async def test_should_raise_for_invalid_compatibility_storage(self):
+        config = Config(
+            FILE_LOADER_ROOT_PATH=STORAGE_PATH,
+            STORES_CRYPTO_KEY_FOR_EACH_IMAGE=True,
+        )
+        importer = Importer(config)
+        importer.import_modules()
+        server = ServerParameters(8889, "localhost", "thumbor.conf", None, "info", None)
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, config=config, importer=importer)
+        storage = Storage(ctx)
+
+        with expect.error_to_happen(
+            RuntimeError,
+            message=(
+                "The 'COMPATIBILITY_LEGACY_STORAGE' configuration should "
+                "point to a valid storage when using compatibility storage."
+            ),
+        ):
+            await storage.get("invalid-path")
+
+    @gen_test
+    async def test_should_return_none_for_invalid_image(self):
+        storage = Storage(self.context)
+
+        result = await storage.get("invalid-path")
+
+        expect(result).to_be_null()
+
+    @gen_test
+    async def test_should_get(self):
+        url = self.get_image_url("image.jpg")
+        image_bytes = self.get_image_bytes("image.jpg")
+        storage = Storage(self.context)
+        await storage.put(url, image_bytes)
+
+        result = await storage.get(url)
+
+        expect(result).not_to_be_null()
+        expect(result).not_to_be_an_error()
+        expect(result).to_equal(image_bytes)
+
+    @gen_test
+    async def test_should_put(self):
+        url = self.get_image_url("image.jpg")
+        image_bytes = self.get_image_bytes("image.jpg")
+        storage = Storage(self.context)
+
+        await storage.put(url, image_bytes)
+
+        result = await storage.get(url)
+        expect(result).not_to_be_null()
+        expect(result).not_to_be_an_error()
+        expect(result).to_equal(image_bytes)
+
+    @gen_test
+    async def test_should_put_detector_data(self):
+        iurl = self.get_image_url("image_7.jpg")
+        ibytes = self.get_image_bytes("image.jpg")
+        storage = Storage(self.context)
+        await storage.put(iurl, ibytes)
+
+        await storage.put_detector_data(iurl, "some-data")
+
+        got = await storage.get_detector_data(iurl)
+        expect(got).not_to_be_null()
+        expect(got).not_to_be_an_error()
+        expect(got).to_equal("some-data")
+
+    @gen_test
+    async def test_should_put_crypto(self):
+        iurl = self.get_image_url("image_7.jpg")
+        ibytes = self.get_image_bytes("image.jpg")
+        storage = Storage(self.context)
+        await storage.put(iurl, ibytes)
+
+        await storage.put_crypto(iurl)
+
+        got = await storage.get_crypto(iurl)
+        expect(got).not_to_be_null()
+        expect(got).not_to_be_an_error()
+        expect(got).to_equal("ACME-SEC")
+
+    @gen_test
+    async def test_exists(self):
+        iurl = self.get_image_url("image_7.jpg")
+        ibytes = self.get_image_bytes("image.jpg")
+        storage = Storage(self.context)
+        await storage.put(iurl, ibytes)
+
+        exists = await storage.exists(iurl)
+        not_exists = await storage.exists("some-invalid-random-file.jpg")
+
+        expect(exists).to_be_true()
+        expect(not_exists).to_be_false()
+
+    @gen_test
+    async def test_remove(self):
+        iurl = self.get_image_url("image_7.jpg")
+        ibytes = self.get_image_bytes("image.jpg")
+        storage = Storage(self.context)
+        await storage.put(iurl, ibytes)
+        exists = await storage.exists(iurl)
+        expect(exists).to_be_true()
+
+        await storage.remove(iurl)
+
+        not_exists = await storage.exists(iurl)
+        expect(not_exists).to_be_false()

--- a/tests/compatibility/test_file_loader.py
+++ b/tests/compatibility/test_file_loader.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from os.path import abspath, dirname, join
+
+from preggy import expect
+from tornado.testing import gen_test
+
+from tests.base import TestCase
+from thumbor.compatibility import compatibility_get
+from thumbor.config import Config
+from thumbor.context import Context
+from thumbor.importer import Importer
+from thumbor.loaders import LoaderResult
+
+STORAGE_PATH = abspath(join(dirname(__file__), "../fixtures/images/"))
+
+
+class SimpleCompatibilityTestCase(TestCase):
+    @gen_test
+    async def test_can_get_result(self):
+        Importer.deprecated_monkey_patch_tornado_return_future()
+        from tests.compatibility.legacy_file_loader import load
+
+        config = Config(FILE_LOADER_ROOT_PATH=STORAGE_PATH)
+        ctx = Context(config=config)
+        result = await compatibility_get(ctx, "image.jpg", func=load)
+        expect(result).to_be_instance_of(LoaderResult)
+        expect(result.buffer).to_equal(
+            open(join(STORAGE_PATH, "image.jpg"), "rb").read()
+        )
+        expect(result.successful).to_be_true()

--- a/tests/compatibility/test_simple_compatibility.py
+++ b/tests/compatibility/test_simple_compatibility.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from preggy import expect
+from tornado.testing import gen_test
+
+from tests.base import TestCase
+from thumbor.compatibility import compatibility_get
+
+
+def get_result(first, second, callback):
+    callback(first, second, True)
+
+
+class SimpleCompatibilityTestCase(TestCase):
+    @gen_test
+    async def test_can_get_result(self):
+        first, second, response = await compatibility_get(1, second=2, func=get_result)
+        expect(first).to_equal(1)
+        expect(second).to_equal(2)
+        expect(response).to_be_true()
+
+    @gen_test
+    async def test_fails_without_func(self):
+        with expect.error_to_happen(
+            RuntimeError,
+            message="'func' argument can't be None when calling thumbor's compatibility layer.",
+        ):
+            await compatibility_get(1, second=2)

--- a/thumbor/compatibility/__init__.py
+++ b/thumbor/compatibility/__init__.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from thumbor.compatibility.compat import (  # NOQA pylint: disable=unused-import
+    compatibility_get,
+)

--- a/thumbor/compatibility/compat.py
+++ b/thumbor/compatibility/compat.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+import asyncio
+
+
+async def compatibility_get(*args, **kw):
+    func = kw.pop("func", None)
+    if func is None:
+        raise RuntimeError(
+            "'func' argument can't be None when calling thumbor's compatibility layer."
+        )
+
+    loop = asyncio.get_event_loop()
+    queue = asyncio.Queue()
+
+    def put(*args):
+        loop.call_soon_threadsafe(queue.put_nowait, args)
+
+    func(*args, **kw, callback=put)
+
+    result = await queue.get()
+    if isinstance(result, (tuple, list)) and len(result) == 1:
+        result = result[0]
+
+    return result

--- a/thumbor/compatibility/loader.py
+++ b/thumbor/compatibility/loader.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from thumbor.compatibility import compatibility_get
+
+
+async def load(context, path):
+    loader = context.modules.compatibility_legacy_loader
+    if loader is None:
+        raise RuntimeError(
+            "The 'COMPATIBILITY_LEGACY_LOADER' configuration should point "
+            "to a valid loader when using compatibility loader."
+        )
+
+    return await compatibility_get(context, path, func=loader.load)

--- a/thumbor/compatibility/result_storage.py
+++ b/thumbor/compatibility/result_storage.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+import thumbor.result_storages as storages
+from thumbor.compatibility import compatibility_get
+
+
+class Storage(storages.BaseStorage):
+    @property
+    def storage(self):
+        storage = self.context.modules.compatibility_legacy_result_storage
+        if storage is None:
+            raise RuntimeError(
+                "The 'COMPATIBILITY_LEGACY_RESULT_STORAGE' configuration should point "
+                "to a valid result storage when using compatibility result storage."
+            )
+        return storage
+
+    async def put(self, image_bytes):
+        if self.storage is None:
+            return
+        return self.storage.put(image_bytes)
+
+    async def get(self):
+        if self.storage is None:
+            return
+        return await compatibility_get(func=self.storage.get)

--- a/thumbor/compatibility/storage.py
+++ b/thumbor/compatibility/storage.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+import thumbor.storages as storages
+from thumbor.compatibility import compatibility_get
+
+
+class Storage(storages.BaseStorage):
+    @property
+    def storage(self):
+        storage = self.context.modules.compatibility_legacy_storage
+        if storage is None:
+            raise RuntimeError(
+                "The 'COMPATIBILITY_LEGACY_STORAGE' configuration should point to "
+                "a valid storage when using compatibility storage."
+            )
+        return storage
+
+    async def put(self, path, file_bytes):
+        return self.storage.put(path, file_bytes)
+
+    async def put_crypto(self, path):
+        return self.storage.put_crypto(path)
+
+    async def put_detector_data(self, path, data):
+        return self.storage.put_detector_data(path, data)
+
+    async def get(self, path):
+        return await compatibility_get(path, func=self.storage.get)
+
+    async def get_crypto(self, path):
+        return await compatibility_get(path, func=self.storage.get_crypto)
+
+    async def get_detector_data(self, path):
+        return await compatibility_get(path, func=self.storage.get_detector_data)
+
+    async def exists(self, path, *args, **kw):
+        return await compatibility_get(path, func=self.storage.exists, *args, **kw)
+
+    async def remove(self, path):
+        return self.storage.remove(path)

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -292,10 +292,16 @@ Config.define(
 )
 Config.define("ENABLE_ETAGS", True, "Enables automatically generated etags", "HTTP")
 Config.define(
-    "MAX_ID_LENGTH", 32, "Set maximum id length for images when stored", "Storage",
+    "MAX_ID_LENGTH",
+    32,
+    "Set maximum id length for images when stored",
+    "Storage",
 )
 Config.define(
-    "GC_INTERVAL", None, "Set garbage collection interval in seconds", "Performance",
+    "GC_INTERVAL",
+    None,
+    "Set garbage collection interval in seconds",
+    "Performance",
 )
 
 Config.define(
@@ -377,7 +383,10 @@ Config.define(
     "HTTP Loader",
 )
 Config.define(
-    "HTTP_LOADER_PROXY_PORT", None, "The proxy port for the proxy host", "HTTP Loader",
+    "HTTP_LOADER_PROXY_PORT",
+    None,
+    "The proxy port for the proxy host",
+    "HTTP Loader",
 )
 Config.define(
     "HTTP_LOADER_PROXY_USERNAME",
@@ -404,7 +413,10 @@ Config.define(
     "HTTP Loader",
 )
 Config.define(
-    "HTTP_LOADER_CLIENT_KEY", None, "The filename for client SSL key", "HTTP Loader",
+    "HTTP_LOADER_CLIENT_KEY",
+    None,
+    "The filename for client SSL key",
+    "HTTP Loader",
 )
 Config.define(
     "HTTP_LOADER_CLIENT_CERT",
@@ -458,7 +470,10 @@ Config.define(
 
 # PHOTO UPLOAD OPTIONS
 Config.define(
-    "UPLOAD_MAX_SIZE", 0, "Max size in bytes for images uploaded to thumbor", "Upload",
+    "UPLOAD_MAX_SIZE",
+    0,
+    "Max size in bytes for images uploaded to thumbor",
+    "Upload",
 )
 Config.define(
     "UPLOAD_ENABLED",
@@ -485,7 +500,10 @@ Config.define(
     "Upload",
 )
 Config.define(
-    "UPLOAD_DEFAULT_FILENAME", "image", "Default filename for image uploaded", "Upload",
+    "UPLOAD_DEFAULT_FILENAME",
+    "image",
+    "Default filename for image uploaded",
+    "Upload",
 )
 
 # ALIASES FOR OLD PHOTO UPLOAD OPTIONS
@@ -569,7 +587,10 @@ Config.define(
 
 # OPTIMIZER CONFIGURATIONS
 Config.define(
-    "JPEGTRAN_PATH", "/usr/bin/jpegtran", "Path for the jpegtran binary", "Optimizers",
+    "JPEGTRAN_PATH",
+    "/usr/bin/jpegtran",
+    "Path for the jpegtran binary",
+    "Optimizers",
 )
 
 Config.define(
@@ -673,7 +694,10 @@ Config.define(
 
 # SENTRY REPORTING MODULE
 Config.define(
-    "SENTRY_ENVIRONMENT", None, "Sentry environment i.e.: staging ", "Errors - Sentry",
+    "SENTRY_ENVIRONMENT",
+    None,
+    "Sentry environment i.e.: staging ",
+    "Errors - Sentry",
 )
 
 # FILE REPORTING MODULE
@@ -723,6 +747,34 @@ Config.define(
     "thumbor.app.ThumborServiceApp",
     "Custom app class to override ThumborServiceApp. "
     "This config value is overridden by the -a command-line parameter.",
+)
+
+
+# COMPATIBILITY
+
+Config.define(
+    "COMPATIBILITY_LEGACY_LOADER",
+    None,
+    "Loader that will be used with the compatibility layer, instead of the "
+    "compatibility loader. Please only use this if you can't use up-to-date loaders.",
+    "Compatibility",
+)
+
+Config.define(
+    "COMPATIBILITY_LEGACY_STORAGE",
+    None,
+    "Storage that will be used with the compatibility layer, instead of the "
+    "compatibility storage. Please only use this if you can't use up-to-date storages.",
+    "Compatibility",
+)
+
+Config.define(
+    "COMPATIBILITY_LEGACY_RESULT_STORAGE",
+    None,
+    "Result Storage that will be used with the compatibility layer, instead of the "
+    "compatibility result storage. Please only use this if you can't use "
+    "up-to-date result storages.",
+    "Compatibility",
 )
 
 

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -265,6 +265,20 @@ class ContextImporter:  # pylint: disable=too-few-public-methods,too-many-instan
         self.optimizers = importer.optimizers
         self.url_signer = importer.url_signer
 
+        self.compatibility_legacy_loader = importer.compatibility_legacy_loader
+
+        self.compatibility_legacy_storage = None
+        if importer.compatibility_legacy_storage is not None:
+            self.compatibility_legacy_storage = importer.compatibility_legacy_storage(
+                context
+            )
+
+        self.compatibility_legacy_result_storage = None
+        if importer.compatibility_legacy_result_storage is not None:
+            self.compatibility_legacy_result_storage = (
+                importer.compatibility_legacy_result_storage(context)
+            )
+
     def cleanup(self):
         if self.engine:
             self.engine.cleanup()

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -62,6 +62,7 @@ SEND_IF_MODIFIED_LAST_MODIFIED_HEADERS = False
 # the way images are to be loaded
 LOADER = 'thumbor.loaders.http_loader'
 #LOADER = 'thumbor.loaders.file_loader'
+#LOADER = 'thumbor.compatibility.loader'
 
 # the path to find images
 #FILE_LOADER_ROOT_PATH = './tests/fixtures/images'
@@ -89,6 +90,7 @@ UPLOAD_DEFAULT_FILENAME = 'image'
 # STORAGE = 'thumbor.storages.no_storage'
 STORAGE = 'thumbor.storages.file_storage'
 #STORAGE = 'thumbor.storages.mixed_storage'
+# STORAGE = 'thumbor.compatibility.storage'
 
 # root path of the file storage
 FILE_STORAGE_ROOT_PATH = join(home, 'thumbor', 'storage' )
@@ -96,6 +98,7 @@ FILE_STORAGE_ROOT_PATH = join(home, 'thumbor', 'storage' )
 # If you want to cache results, use this options to specify how to cache it
 # Set Expiration seconds to ZERO if you want them not to expire.
 RESULT_STORAGE = 'thumbor.result_storages.file_storage'
+#RESULT_STORAGE = 'thumbor.compatibility.result_storage'
 RESULT_STORAGE_EXPIRATION_SECONDS = 60 * 60 * 24  # one day
 RESULT_STORAGE_FILE_STORAGE_ROOT_PATH = join(home, 'thumbor', 'result_storage')
 
@@ -230,5 +233,28 @@ HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT = False
 # Dfaults to: 0 (no timeout)
 #HTTP_LOADER_CURL_LOW_SPEED_TIME = 0
 #HTTP_LOADER_CURL_LOW_SPEED_LIMIT = 0
+
+################################# Compatibility #################################
+
+## Loader that will be used with the compatibility layer, instead of the
+## compatibility loader. Please only use this if you can't use up-to-date
+## loaders.
+## Defaults to: None
+# COMPATIBILITY_LEGACY_LOADER = None
+
+## Storage that will be used with the compatibility layer, instead of the
+## compatibility storage. Please only use this if you can't use up-to-date
+## storages.
+## Defaults to: None
+# COMPATIBILITY_LEGACY_STORAGE = None
+
+## Result Storage that will be used with the compatibility layer, instead of the
+## compatibility result storage. Please only use this if you can't use up-to-
+## date result storages.
+## Defaults to: None
+# COMPATIBILITY_LEGACY_RESULT_STORAGE = None
+
+################################################################################
+
 
 


### PR DESCRIPTION
**Is backwards compatible**: yes

With this change we introduce compatibility loader, storage and
result storage.

Users can now keep using the libraries they are already used to
(like tc_aws) to load, store and cache results.

At the same time, thumbor's codebase can keep clean with async
functions in all these structures.

We have, intentionally, skipped providing compatibility layers for
filters and detectors as these are not in the way of adopting
thumbor in Python 3, but may review this decision in the future.

Successful Build: https://app.circleci.com/pipelines/github/thumbor/thumbor/30/workflows/3a2e79db-73bc-4942-8b84-72ec4c2f4e3a