### PR TITLE
Update atime in file-based result storage

### DIFF
--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -371,6 +371,9 @@ Config.define(
 Config.define(
     'RESULT_STORAGE_STORES_UNSAFE', False,
     'Indicates whether unsafe requests should also be stored in the Result Storage', 'Result Storage')
+Config.define(
+    'RESULT_STORAGE_TOUCH_FILES', False,
+    'When enabled, files retrieved from the result storage will have their "last accessed" file information updated', 'Result Storage')
 
 # QUEUED DETECTOR REDIS OPTIONS
 Config.define('REDIS_QUEUE_SERVER_HOST', 'localhost', 'Server host for the queued redis detector', 'Queued Redis Detector')

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -13,8 +13,10 @@ from uuid import uuid4
 from shutil import move
 import pytz
 import hashlib
+import time
 
 from os.path import exists, dirname, join, getmtime, abspath, isdir, isfile
+from os import utime
 
 from thumbor.engines import BaseEngine
 from thumbor.result_storages import BaseStorage
@@ -79,10 +81,13 @@ class Storage(BaseStorage):
         with open(file_abspath, 'r') as f:
             buffer = f.read()
 
+        mtime = getmtime(file_abspath);
+        utime(file_abspath, (time.time(), mtime));
+        
         result = ResultStorageResult(
             buffer=buffer,
             metadata={
-                'LastModified': datetime.fromtimestamp(getmtime(file_abspath)).replace(tzinfo=pytz.utc),
+                'LastModified': datetime.fromtimestamp(mtime).replace(tzinfo=pytz.utc),
                 'ContentLength': len(buffer),
                 'ContentType': BaseEngine.get_mimetype(buffer)
             }

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -82,8 +82,10 @@ class Storage(BaseStorage):
             buffer = f.read()
 
         mtime = getmtime(file_abspath);
-        utime(file_abspath, (time.time(), mtime));
-        
+
+        if self.context.config.RESULT_STORAGE_TOUCH_FILES:
+            utime(file_abspath, (time.time(), mtime));
+
         result = ResultStorageResult(
             buffer=buffer,
             metadata={


### PR DESCRIPTION
I am using Thumbor with the file-based result storage. A "M/Monit" job monitors the `result_storage` directory size and will remove files when its size exceeds a given threshold.

This PR proposes to "touch" files in the result storage every time they are used to serve a response. This will change the "access" timestamp only, not the "modified" timestamp.

With this change, the files least recently used (LRU) could easily be found by looking at the `atime` timestamps. Deleting these files first would help to improve cache efficiency.

