### PR TITLE
Preserves image metadata (exif, iptc, xmp and comment)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -856,6 +856,11 @@ Example of Configuration File
    ## Defaults to: False
    #PRESERVE_EXIF_INFO = False
 
+   ## Preserves image metadata (exif, iptc, xmp and comment) in generated images. Increases image size in
+   ## kbytes, use with caution.
+   ## Defaults to: False
+   #PRESERVE_IMAGE_METADATA = False
+
    ## Indicates whether thumbor should enable the EXPERIMENTAL support for animated
    ## gifs.
    ## Defaults to: True

--- a/perf/thumbor.conf
+++ b/perf/thumbor.conf
@@ -137,6 +137,11 @@ AUTO_WEBP = True
 ## Defaults to: False
 #PRESERVE_EXIF_INFO = False
 
+## Preserves image metadata (exif, iptc, xmp and comment) in generated images. Increases image size in
+## kbytes, use with caution.
+## Defaults to: False
+#PRESERVE_IMAGE_METADATA = False
+
 ## Indicates whether thumbor should enable the EXPERIMENTAL support for animated
 ## gifs.
 ## Defaults to: True

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -193,6 +193,14 @@ Config.define(
 )
 
 Config.define(
+    "PRESERVE_IMAGE_METADATA",
+    False,
+    "Preserves image metadata (exif, iptc, xmp and comment) in generated images. "
+    "Increases image size in kbytes, use with caution.",
+    "Imaging",
+)
+
+Config.define(
     "ALLOW_ANIMATED_GIFS",
     True,
     "Indicates whether thumbor should enable the EXPERIMENTAL support for animated gifs.",

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -286,7 +286,7 @@ class Engine(BaseEngine):
         if METADATA_AVAILABLE and self.context.config.PRESERVE_IMAGE_METADATA:
             results_metadata = ImageMetadata.from_buffer(results)
             results_metadata.read()
-            self.metadata.copy(results_metadata)
+            self.metadata.copy(results_metadata, exif=False)
             results_metadata.write()
             results = results_metadata.buffer
 

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -27,6 +27,13 @@ try:
 except ImportError:
     FILTERS_AVAILABLE = False
 
+try:
+    from pyexiv2 import ImageMetadata
+
+    METADATA_AVAILABLE = True
+except ImportError:
+    METADATA_AVAILABLE = False
+
 FORMATS = {
     ".tif": "PNG",  # serve tif as png
     ".jpg": "JPEG",
@@ -275,6 +282,14 @@ class Engine(BaseEngine):
 
         results = img_buffer.getvalue()
         img_buffer.close()
+
+        if METADATA_AVAILABLE and self.context.config.PRESERVE_IMAGE_METADATA:
+            results_metadata = ImageMetadata.from_buffer(results)
+            results_metadata.read()
+            self.metadata.copy(results_metadata)
+            results_metadata.write()
+            results = results_metadata.buffer
+
         self.extension = ext
         return results
 

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -284,11 +284,14 @@ class Engine(BaseEngine):
         img_buffer.close()
 
         if METADATA_AVAILABLE and self.context.config.PRESERVE_IMAGE_METADATA:
-            results_metadata = ImageMetadata.from_buffer(results)
-            results_metadata.read()
-            self.metadata.copy(results_metadata, exif=False)
-            results_metadata.write()
-            results = results_metadata.buffer
+            try:
+                results_metadata = ImageMetadata.from_buffer(results)
+                results_metadata.read()
+                self.metadata.copy(results_metadata, exif=False)
+                results_metadata.write()
+                results = results_metadata.buffer
+            except Exception as error:
+                logger.error("Error writing image metadata: %s", error)
 
         self.extension = ext
         return results

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -50,6 +50,10 @@ home = expanduser("~")
 # Preserves exif information in generated images. Increases image size in kbytes, use with caution.
 PRESERVE_EXIF_INFO = False
 
+# Preserves image metadata (exif, iptc, xmp and comment) in generated images.
+# Increases image size in kbytes, use with caution.
+PRESERVE_IMAGE_METADATA = True
+
 # enable this options to specify client-side cache in seconds
 MAX_AGE = 24 * 60 * 60
 


### PR DESCRIPTION
Added a way to preserves image metadata (exif, iptc, xmp and comment) in Pillow engine using the exiv2. If there is exiv2 in the environment and the configuration PRESERVE_IMAGE_METADATA is enabled, the image metadata read in the load method will be copy to the new image generated. So, the result of read method will be the buffer of ImageMetadata.