### PR TITLE
Allow sending a `Access-Control-Allow-Origin` CORS header

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -375,6 +375,11 @@ class BaseHandler(tornado.web.RequestHandler):
             self.set_header('Cache-Control', 'max-age=' + str(max_age) + ',public')
             self.set_header('Expires', datetime.datetime.utcnow() + datetime.timedelta(seconds=max_age))
 
+        if hasattr(self.context.config, 'ACCESS_CONTROL_ALLOW_ORIGIN_HEADER'):
+            ac_header = self.context.config.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER
+            self.set_header('Access-Control-Allow-Origin', ac_header)
+            logger.debug('CORS header found. Set to: %s' % ac_header)
+
         self.set_header('Server', 'Thumbor/%s' % __version__)
         self.set_header('Content-Type', content_type)
 

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -52,6 +52,9 @@ MAX_AGE_TEMP_IMAGE = 0
 # Sends If-Modified-Since & Last-Modified headers; requires support from result storage
 SEND_IF_MODIFIED_LAST_MODIFIED_HEADERS = False
 
+# Sets the  Access-Control-Allow-Origin header
+# ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = '*'
+
 # the way images are to be loaded
 LOADER = 'thumbor.loaders.http_loader'
 #LOADER = 'thumbor.loaders.file_loader'


### PR DESCRIPTION
This builds on the work done by @christianjgreen in #845.

Add a new `ACCESS_CONTROL_ALLOW_ORIGIN_HEADER` setting in the `thumbor.conf` file. If set, the value will be sent as the `Access-Control-Allow-Origin` header. 

This allows to configure Thumbor in a way that allows cross-origin requests initiated by scripts.

TODO:
- [x] ~Waiting for a decision in #1371 whether this should be against 6.x or 7.x~ For now, hoping that this is "useful enough" to be accepted on `6.x`
- [ ] Write tests