### PR TITLE
Allow sending a `Access-Control-Allow-Origin` header (6.7.x branch)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -188,6 +188,25 @@ ALLOWED\_SOURCES = ['.+.globo.com', '.+.glbimg.com']
 This is to get any images that are in *.globo.com or *.glbimg.com and it
 will fail with any other domains.
 
+ACCESS\_CONTROL\_ALLOW\_ORIGIN\_HEADER
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This allows to send the ACCESS_CONTROL_ALLOW_ORIGIN header. For example,
+if you want to tell the browser to allow code from any origin to
+access your thumbor resources:
+
+.. code:: python
+
+   ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = '*'
+
+If you want restrict access to a certain resource:
+
+.. code:: python
+
+   ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = 'https://www.example.com'
+
+Not set by default.
+
 MAX\_WIDTH and MAX\_HEIGHT
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -738,6 +757,9 @@ Example of Configuration File
     ## gifs.
     ## Defaults to: True
     #ALLOW_ANIMATED_GIFS = True
+
+    ## Sends the Access-Control-Allow-Origin header
+    #ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = '*'
 
     ################################################################################
 

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -430,6 +430,11 @@ Config.define(
     'Custom app class to override ThumborServiceApp. This config value is overridden by the -a command-line parameter.'
 )
 
+Config.define(
+    'ACCESS_CONTROL_ALLOW_ORIGIN_HEADER', False,
+    'Sends Access-Control-Allow-Origin header'
+)
+
 
 def generate_config():
     config.generate_config()

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -449,6 +449,12 @@ class BaseHandler(tornado.web.RequestHandler):
             self.set_header('Cache-Control', 'max-age=' + str(max_age) + ',public')
             self.set_header('Expires', datetime.datetime.utcnow() + datetime.timedelta(seconds=max_age))
 
+        if hasattr(self.context.config, 'ACCESS_CONTROL_ALLOW_ORIGIN_HEADER'):
+            ac_header = self.context.config.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER
+            if ac_header is not False:
+                self.set_header('Access-Control-Allow-Origin', ac_header)
+                logger.debug('CORS header found. Set to: %s' % ac_header)
+
         self.set_header('Server', 'Thumbor/%s' % __version__)
         self.set_header('Content-Type', content_type)
 

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -59,7 +59,7 @@ MAX_AGE_TEMP_IMAGE = 0
 # Sends If-Modified-Since & Last-Modified headers; requires support from result storage
 SEND_IF_MODIFIED_LAST_MODIFIED_HEADERS = False
 
-# Sets the  Access-Control-Allow-Origin header
+# Sends the Access-Control-Allow-Origin header
 # ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = '*'
 
 # the way images are to be loaded

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -59,6 +59,9 @@ MAX_AGE_TEMP_IMAGE = 0
 # Sends If-Modified-Since & Last-Modified headers; requires support from result storage
 SEND_IF_MODIFIED_LAST_MODIFIED_HEADERS = False
 
+# Sets the  Access-Control-Allow-Origin header
+# ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = '*'
+
 # the way images are to be loaded
 LOADER = 'thumbor.loaders.http_loader'
 #LOADER = 'thumbor.loaders.file_loader'


### PR DESCRIPTION
This commit takes #845 and adds tests and config support

Co-authored-by: Christian Green <christian@fanhero.com>