### PR TITLE
fix(gifv): Adding webm required bitrate parameter

### DIFF
--- a/tests/handlers/test_fetch_result.py
+++ b/tests/handlers/test_fetch_result.py
@@ -13,7 +13,7 @@ from tests.base import TestCase
 from preggy import expect
 from mock import Mock
 
-from thumbor.handlers import BaseHandler, FetchResult
+from thumbor.handlers import FetchResult
 
 # pylint: disable=broad-except,abstract-method,attribute-defined-outside-init,line-too-long,too-many-public-methods
 # pylint: disable=too-many-lines

--- a/thumbor/optimizers/gifv.py
+++ b/thumbor/optimizers/gifv.py
@@ -84,7 +84,7 @@ class Optimizer(BaseOptimizer):
     def set_format(self):
         if "webm" in self.context.request.filters:
             file_format = "webm"
-            command_params = ["-quality", "good", "-cpu-used", "4"]
+            command_params = ["-quality", "good", "-cpu-used", "4", "-b:v", "500k"]
         else:
             file_format = "mp4"
             command_params = ["-profile:v", "baseline", "-level", "4.0"]


### PR DESCRIPTION
The bitrate parameter was missing when converting Gif to Webm.