### PR TITLE
Allowed sources work in file_loader_http_fallback

### DIFF
--- a/thumbor/loaders/__init__.py
+++ b/thumbor/loaders/__init__.py
@@ -8,14 +8,24 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
+from typing import Dict
+
 
 class LoaderResult:
 
     ERROR_NOT_FOUND = "not_found"
     ERROR_UPSTREAM = "upstream"
     ERROR_TIMEOUT = "timeout"
+    ERROR_BAD_REQUEST = "bad_request"
 
-    def __init__(self, buffer=None, successful=True, error=None, metadata=None):
+    def __init__(
+        self,
+        buffer: bytes = None,
+        successful: bool = True,
+        error: str = None,
+        metadata: Dict[str, any] = None,
+        extras: Dict[str, any] = None,
+    ):
         """
         :param buffer: The media buffer
 
@@ -27,12 +37,19 @@ class LoaderResult:
 
         :param metadata: Dictionary of metadata about the buffer
         :type metadata: dict
+
+        :param extras: Dictionary of extra information about the error
+        :type metadata: dict
         """
 
         if metadata is None:
             metadata = {}
 
+        if extras is None:
+            extras = {}
+
         self.buffer = buffer
         self.successful = successful
         self.error = error
         self.metadata = metadata
+        self.extras = extras

--- a/thumbor/loaders/file_loader_http_fallback.py
+++ b/thumbor/loaders/file_loader_http_fallback.py
@@ -8,14 +8,25 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
-from thumbor.loaders import file_loader, http_loader
+from thumbor.loaders import LoaderResult, file_loader, http_loader
 
 
 async def load(context, path):
     # First attempt to load with file_loader
     result = await file_loader.load(context, path)
+
     if result.successful:
         return result
 
     # If file_loader failed try http_loader
+
+    if not http_loader.validate(context, path):
+        result = LoaderResult()
+        result.successful = False
+        result.error = LoaderResult.ERROR_BAD_REQUEST
+        result.extras["reason"] = "Unallowed domain"
+        result.extras["source"] = path
+
+        return result
+
     return await http_loader.load(context, path)


### PR DESCRIPTION
This commit fixes a bug with the
file_loader_http_fallback loader in that it
would not validate the requests being made