### PR TITLE
Build test image on Github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Create pip cache folder
         run: |
           mkdir -p ~/.cache/pip
-          ls -lah
+          ls -lah ~/.cache/pip
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Test cache folder
         run: |
           docker exec thumbor_test ls -lah /root/.cache/pip
-          touch /root/.cache/pip/a
+          docker exec thumbor_test touch /root/.cache/pip/a
       - name: Setup
         run: docker exec thumbor_test make setup
       - name: Compile Extensions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:
-          key: thumbor-${{ matrix.image-tag }}
+          key: thumbor-${{ matrix.image-tag }}-{hash}
+          restore-keys: |
+            thumbor-
       - uses: actions/checkout@v2
       - name: Build test image
         run: docker build -t test_image -f TestDockerfile${{ matrix.image-tag }} .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Create pip cache folder
         run: |
           mkdir -p ~/.cache/pip
-          ls -lah ~/.cache/pip
+          chmod 777 ~/.cache/pip
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,26 +21,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build test image
         run: docker build -t test_image -f TestDockerfile${{ matrix.image-tag }} .
-      - name: Create pip cache folder
-        run: |
-          mkdir -p ~/.cache/pip
-          chmod -R 774 ~/.cache
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.image-tag }}-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.image-tag }}-
       - name: Start test container
         run: |
-          docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip test_image
+          docker run -dt --name thumbor_test -v $(pwd):/app test_image
       - name: Fire up Redis
         run: docker exec thumbor_test make redis
-      - name: Test cache folder
-        run: |
-          docker exec thumbor_test ls -lah /root/.cache/pip
-          docker exec thumbor_test touch /root/.cache/pip/a
       - name: Setup
         run: docker exec thumbor_test make setup
       - name: Compile Extensions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,27 +15,15 @@ jobs:
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
         with:
-          key: thumbor-${{ matrix.image-tag }}-{hash}
+          key: thumbor-docker-${{ matrix.image-tag }}-{hash}
           restore-keys: |
-            thumbor-${{ matrix.image-tag }}-
+            thumbor-docker-${{ matrix.image-tag }}-
       - uses: actions/checkout@v2
       - name: Build test image
         run: docker build -t test_image -f TestDockerfile${{ matrix.image-tag }} .
-      - name: Create pip cache folder
-        run: |
-          mkdir -p ~/.cache/pip
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.image-tag }}-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.image-tag }}-
       - name: Start test container
         run: |
-          docker run -dt --user 1001:121 --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip:rw test_image
-      - name: Check folder permission
-        run: docker exec thumbor_test ls -lah /root/.cache/pip
+          docker run -dt --name thumbor_test -v $(pwd):/app test_image
       - name: Fire up Redis
         run: docker exec thumbor_test make redis
       - name: Setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip test_image
       - name: Change cache folder permission
         run: |
-          docker exec thumbor_test chown -R 0:0 /root/.cache/pip
+          docker exec thumbor_test -u 1001 chown -R 0:0 /root/.cache/pip
       - name: Fire up Redis
         run: docker exec thumbor_test make redis
       - name: Setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Start test container
-        run: docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip:rw test_image
+        run: |
+          ls -lah ~/.cache/pip
+          docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip:rw test_image
       - name: Check folder permission
         run: docker exec thumbor_test ls -lah /root/.cache/pip
       - name: Fire up Redis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,7 @@ jobs:
             ${{ runner.os }}-pip-${{ matrix.image-tag }}-
       - name: Start test container
         run: |
-          chmod 777 ~/.cache
-          chmod 777 ~/.cache/pip
-          ls -lah ~/.cache/pip
-          docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip:rw test_image
+          docker run -dt --user 1001:121 --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip:rw test_image
       - name: Check folder permission
         run: docker exec thumbor_test ls -lah /root/.cache/pip
       - name: Fire up Redis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,21 +19,23 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build test image
         run: docker build -t test_image -f TestDockerfile${{ matrix.image-tag }} .
+      - name: Start test container
+        run: docker run -dt -v $(pwd):/app test_image --name thumbor_test
       - name: Fire up Redis
-        run: docker run -v $(pwd):/app test_image /bin/bash -c "make redis"
+        run: docker exec thumbor_test make redis
       - name: Setup
-        run: docker run -v $(pwd):/app test_image /bin/bash -c "make setup"
+        run: docker exec thumbor_test make setup
       - name: Compile Extensions
-        run: docker run -v $(pwd):/app test_image /bin/bash -c "make compile_ext"
+        run: docker exec thumbor_test make compile_ext
       - name: Run Unit Tests
-        run: docker run -v $(pwd):/app test_image /bin/bash -c "make sequential-unit"
+        run: docker exec thumbor_test make sequential-unit
       - name: Run Integration Tests
-        run: docker run -v $(pwd):/app -e ASYNC_TEST_TIMEOUT=30 test_image /bin/bash -c "make integration_run"
+        run: docker exec -e ASYNC_TEST_TIMEOUT=30 thumbor_test make integration_run
       - name: Lint
-        run: docker run -v $(pwd):/app -e ASYNC_TEST_TIMEOUT=30 test_image /bin/bash -c "make flake pylint"
+        run: docker exec thumbor_test make flake pylint
       - name: Coveralls
         if: matrix.image-tag == '39'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker run -v $(pwd):/app -e ASYNC_TEST_TIMEOUT=30 test_image /bin/bash -c "pip install --upgrade coveralls && coveralls --service=github"
+          docker exec thumbor_test /bin/bash -c "pip install --upgrade coveralls && coveralls --service=github"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip test_image
       - name: Change cache folder permission
         run: |
-          docker exec thumbor_test -u 1001 chown -R 0:0 /root/.cache/pip
+          docker exec -u 1001 thumbor_test chown -R 0:0 /root/.cache/pip
       - name: Fire up Redis
         run: docker exec thumbor_test make redis
       - name: Setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,18 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build test image
         run: docker build -t test_image -f TestDockerfile${{ matrix.image-tag }} .
+      - name: Create pip cache folder
+        run: |
+          mkdir -p ~/.cache/pip
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.image-tag }}-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Start test container
-        run: docker run -dt --name thumbor_test -v $(pwd):/app test_image
+        run: docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip test_image
       - name: Fire up Redis
         run: docker exec thumbor_test make redis
       - name: Setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-pip-${{ matrix.image-tag }}-
       - name: Start test container
         run: |
-          chwon -R 0:0 ~/.cache/pip
+          chown -R 0:0 ~/.cache/pip
           docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/home/runner/.cache/pip test_image
       - name: Fire up Redis
         run: docker exec thumbor_test make redis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,19 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build test image
         run: docker build -t test_image -f TestDockerfile${{ matrix.image-tag }} .
+      - name: Create pip cache folder
+        run: |
+          mkdir -p ~/.cache/pip
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.image-tag }}-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.image-tag }}-
       - name: Start test container
         run: |
-          docker run -dt --name thumbor_test -v $(pwd):/app test_image
+          docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/home/runner/.cache/pip test_image
       - name: Fire up Redis
         run: docker exec thumbor_test make redis
       - name: Setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Create pip cache folder
         run: |
           mkdir -p ~/.cache/pip
-          chmod 777 ~/.cache/pip
-          ls -lah ~/.cache/pip
       - name: Cache pip
         uses: actions/cache@v2
         with:
@@ -36,6 +34,7 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Start test container
         run: |
+          chmod 777 ~/.cache/pip
           ls -lah ~/.cache/pip
           docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip:rw test_image
       - name: Check folder permission

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Create pip cache folder
         run: |
           mkdir -p ~/.cache/pip
+          ls -lah
       - name: Cache pip
         uses: actions/cache@v2
         with:
@@ -31,6 +32,8 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Start test container
         run: docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip test_image
+      - name: Check folder permission
+        run: docker exec thumbor_test ls -lah /root/.cache/pip
       - name: Fire up Redis
         run: docker exec thumbor_test make redis
       - name: Setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,21 @@ jobs:
         run: docker exec -e ASYNC_TEST_TIMEOUT=30 thumbor_test make integration_run
       - name: Lint
         run: docker exec thumbor_test make flake pylint
+      - name: Generate lcov
+        run: docker exec thumbor_test coverage lcov
       - name: Coveralls
-        if: matrix.image-tag == '39'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker exec thumbor_test /bin/bash -c "pip install --upgrade coveralls && coveralls --service=github"
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage.lcov
+          flag-name: run-${{ matrix.image-tag }}
+          parallel: true
+  finish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@1.1.3
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           key: thumbor-${{ matrix.image-tag }}-{hash}
           restore-keys: |
+            thumbor-${{ matrix.image-tag }}-
             thumbor-
       - uses: actions/checkout@v2
       - name: Build test image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,12 @@ jobs:
       - name: Start test container
         run: |
           docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip test_image
-      - name: Change cache folder permission
-        run: |
-          docker exec -u 1001 thumbor_test chown -R 0:0 /root/.cache/pip
       - name: Fire up Redis
         run: docker exec thumbor_test make redis
+      - name: Test cache folder
+        run: |
+          docker exec thumbor_test ls -lah /root/.cache/pip
+          touch /root/.cache/pip/a
       - name: Setup
         run: docker exec thumbor_test make setup
       - name: Compile Extensions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
           key: thumbor-${{ matrix.image-tag }}-{hash}
           restore-keys: |
             thumbor-${{ matrix.image-tag }}-
-            thumbor-
       - uses: actions/checkout@v2
       - name: Build test image
         run: docker build -t test_image -f TestDockerfile${{ matrix.image-tag }} .
@@ -31,9 +30,10 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.image-tag }}-${{ hashFiles('**/setup.py') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-pip-${{ matrix.image-tag }}-
       - name: Start test container
         run: |
+          chmod 777 ~/.cache
           chmod 777 ~/.cache/pip
           ls -lah ~/.cache/pip
           docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip:rw test_image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build test image
         run: docker build -t test_image -f TestDockerfile${{ matrix.image-tag }} .
       - name: Start test container
-        run: docker run -dt -v $(pwd):/app test_image --name thumbor_test
+        run: docker run -dt --name thumbor_test -v $(pwd):/app test_image
       - name: Fire up Redis
         run: docker exec thumbor_test make redis
       - name: Setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           mkdir -p ~/.cache/pip
           chmod 777 ~/.cache/pip
+          ls -lah ~/.cache/pip
       - name: Cache pip
         uses: actions/cache@v2
         with:
@@ -34,7 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Start test container
-        run: docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip test_image
+        run: docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip:rw test_image
       - name: Check folder permission
         run: docker exec thumbor_test ls -lah /root/.cache/pip
       - name: Fire up Redis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Create pip cache folder
         run: |
           mkdir -p ~/.cache/pip
+          chmod -R 774 ~/.cache
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,10 @@ jobs:
             ${{ runner.os }}-pip-${{ matrix.image-tag }}-
       - name: Start test container
         run: |
-          chown -R 0:0 ~/.cache/pip
-          docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/home/runner/.cache/pip test_image
+          docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip test_image
+      - name: Change cache folder permission
+        run: |
+          docker exec thumbor_test chown -R /root/.cache/pip
       - name: Fire up Redis
         run: docker exec thumbor_test make redis
       - name: Setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
             ${{ runner.os }}-pip-${{ matrix.image-tag }}-
       - name: Start test container
         run: |
+          chwon -R 0:0 ~/.cache/pip
           docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/home/runner/.cache/pip test_image
       - name: Fire up Redis
         run: docker exec thumbor_test make redis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           docker run -dt --name thumbor_test -v $(pwd):/app -v ~/.cache/pip:/root/.cache/pip test_image
       - name: Change cache folder permission
         run: |
-          docker exec thumbor_test chown -R /root/.cache/pip
+          docker exec thumbor_test chown -R 0:0 /root/.cache/pip
       - name: Fire up Redis
         run: docker exec thumbor_test make redis
       - name: Setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           key: thumbor-${{ matrix.image-tag }}
       - uses: actions/checkout@v2
       - name: Build test image
-        run: docker build -t test_image -f TestDockerfile${{ matrix.image-tag }}
+        run: docker build -t test_image -f TestDockerfile${{ matrix.image-tag }} .
       - name: Fire up Redis
         run: docker run -v $(pwd):/app test_image /bin/bash -c "make redis"
       - name: Setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,25 +11,29 @@ jobs:
           - 38
           - 39
           - 310
-    container: thumbororg/thumbor-test:${{ matrix.image-tag }}
     steps:
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+        with:
+          key: thumbor-${{ matrix.image-tag }}
       - uses: actions/checkout@v2
+      - name: Build test image
+        run: docker build -t test_image -f TestDockerfile${{ matrix.image-tag }}
       - name: Fire up Redis
-        run: make redis
+        run: docker run -v $(pwd):/app test_image /bin/bash -c "make redis"
       - name: Setup
-        run: make setup
+        run: docker run -v $(pwd):/app test_image /bin/bash -c "make setup"
       - name: Compile Extensions
-        run: make compile_ext
+        run: docker run -v $(pwd):/app test_image /bin/bash -c "make compile_ext"
       - name: Run Unit Tests
-        run: make sequential-unit
+        run: docker run -v $(pwd):/app test_image /bin/bash -c "make sequential-unit"
       - name: Run Integration Tests
-        run: env ASYNC_TEST_TIMEOUT=30 make integration_run
+        run: docker run -v $(pwd):/app -e ASYNC_TEST_TIMEOUT=30 test_image /bin/bash -c "make integration_run"
       - name: Lint
-        run: make flake pylint
+        run: docker run -v $(pwd):/app -e ASYNC_TEST_TIMEOUT=30 test_image /bin/bash -c "make flake pylint"
       - name: Coveralls
         if: matrix.image-tag == '39'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip install --upgrade coveralls
-          coveralls --service=github
+          docker run -v $(pwd):/app -e ASYNC_TEST_TIMEOUT=30 test_image /bin/bash -c "pip install --upgrade coveralls && coveralls --service=github"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    types: [ opened, reopened ]
     # The branches below must be a subset of the branches above
     branches: [ master ]
   schedule:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
+    types: [ opened, reopened ]
     # The branches below must be a subset of the branches above
     branches: [ master ]
   schedule:

--- a/TestDockerfile310
+++ b/TestDockerfile310
@@ -1,7 +1,7 @@
 FROM python:3.10-slim
 WORKDIR /app
 RUN apt-get update -y && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends --no-install-suggests \
         python3-dev \
         libcurl4-openssl-dev \
         libgnutls28-dev \
@@ -20,7 +20,7 @@ RUN apt-get update -y && \
         libjpeg-dev \
         libwebp-dev \
         redis && \
-    apt-get install --reinstall -y build-essential && \
+    apt-get install --reinstall -y --no-install-recommends --no-install-suggests build-essential && \
     apt-get clean
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so

--- a/TestDockerfile310
+++ b/TestDockerfile310
@@ -26,6 +26,3 @@ RUN apt-get update -y && \
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
 
 RUN pip install --upgrade pip
-
-RUN groupadd -g 121 github_actions && \
-    usermod -a -G github_actions root

--- a/TestDockerfile310
+++ b/TestDockerfile310
@@ -20,7 +20,7 @@ RUN apt-get update -y && \
         libjpeg-dev \
         libwebp-dev \
         redis && \
-    apt-get install --reinstall -y --no-install-recommends --no-install-suggests build-essential && \
+    apt-get install -y --reinstall --no-install-recommends --no-install-suggests build-essential && \
     apt-get clean
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so

--- a/TestDockerfile310
+++ b/TestDockerfile310
@@ -1,13 +1,28 @@
 FROM python:3.10-slim
 WORKDIR /app
-RUN apt-get update -y && apt-get install -y python3-dev libcurl4-openssl-dev libgnutls28-dev libjpeg-progs libimage-exiftool-perl gifsicle scons python3-all-dev libboost-python-dev libexiv2-dev ffmpeg make zlib1g-dev gcc libssl-dev libjpeg-dev libwebp-dev redis && apt-get clean
-RUN apt-get update -y && apt-get install --reinstall -y build-essential && apt-get clean
-RUN pip install --upgrade pip
-COPY setup.py /app/setup.py
-RUN mkdir -p /app/thumbor
-RUN touch /app/thumbor/__init__.py
+RUN apt-get update -y && \
+    apt-get install -y \
+        python3-dev \
+        libcurl4-openssl-dev \
+        libgnutls28-dev \
+        libjpeg-progs \
+        libimage-exiftool-perl \
+        gifsicle \
+        scons \
+        python3-all-dev \
+        libboost-python-dev \
+        libexiv2-dev \
+        ffmpeg \
+        make \
+        zlib1g-dev \
+        gcc \
+        libssl-dev \
+        libjpeg-dev \
+        libwebp-dev \
+        redis && \
+    apt-get install --reinstall -y build-essential && \
+    apt-get clean
+
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
-RUN python -m pip install -e .[tests] && rm -rf ~/.cache/pip
-RUN pip install coveralls
-RUN pip install --upgrade pytest
-RUN rm -rf /app
+
+RUN pip install --upgrade pip

--- a/TestDockerfile310
+++ b/TestDockerfile310
@@ -27,5 +27,5 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_pytho
 
 RUN pip install --upgrade pip
 
-RUN useradd -r -m --uid 1001 runner
-USER runner
+RUN groupadd -g 121 github_actions && \
+    usermod -a -G github_actions root

--- a/TestDockerfile310
+++ b/TestDockerfile310
@@ -26,3 +26,6 @@ RUN apt-get update -y && \
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
 
 RUN pip install --upgrade pip
+
+RUN useradd -r -m --uid 1001 runner
+USER runner

--- a/TestDockerfile37
+++ b/TestDockerfile37
@@ -1,5 +1,6 @@
 FROM python:3.7-slim
 WORKDIR /app
+
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends --no-install-suggests \
         python3-dev \
@@ -27,3 +28,6 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_pytho
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
 
 RUN pip install --upgrade pip
+
+RUN useradd -r -m --uid 1001 runner
+USER runner

--- a/TestDockerfile37
+++ b/TestDockerfile37
@@ -28,6 +28,3 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_pytho
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
 
 RUN pip install --upgrade pip
-
-RUN groupadd -g 121 github_actions && \
-    usermod -a -G github_actions root

--- a/TestDockerfile37
+++ b/TestDockerfile37
@@ -20,7 +20,7 @@ RUN apt-get update -y && \
         libjpeg-dev \
         libwebp-dev \
         redis && \
-    apt-get install --reinstall --no-install-recommends --no-install-suggests -y build-essential && \
+    apt-get install -y --reinstall --no-install-recommends --no-install-suggests  build-essential && \
     apt-get clean
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python37.so

--- a/TestDockerfile37
+++ b/TestDockerfile37
@@ -1,7 +1,7 @@
 FROM python:3.7-slim
 WORKDIR /app
 RUN apt-get update -y && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends --no-install-suggests \
         python3-dev \
         libcurl4-openssl-dev \
         libgnutls28-dev \
@@ -20,7 +20,7 @@ RUN apt-get update -y && \
         libjpeg-dev \
         libwebp-dev \
         redis && \
-    apt-get install --reinstall -y build-essential && \
+    apt-get install --reinstall --no-install-recommends --no-install-suggests -y build-essential && \
     apt-get clean
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python37.so

--- a/TestDockerfile37
+++ b/TestDockerfile37
@@ -28,3 +28,6 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_pytho
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
 
 RUN pip install --upgrade pip
+
+RUN groupadd -g 121 github_actions && \
+    usermod -a -G github_actions root

--- a/TestDockerfile37
+++ b/TestDockerfile37
@@ -1,14 +1,29 @@
 FROM python:3.7-slim
 WORKDIR /app
-RUN apt-get update -y && apt-get install -y python3-dev libcurl4-openssl-dev libgnutls28-dev libjpeg-progs libimage-exiftool-perl gifsicle scons python3-all-dev libboost-python-dev libexiv2-dev ffmpeg make zlib1g-dev gcc libssl-dev libjpeg-dev libwebp-dev redis && apt-get clean
-RUN apt-get update -y && apt-get install --reinstall -y build-essential && apt-get clean
-RUN pip install --upgrade pip
-COPY setup.py /app/setup.py
-RUN mkdir -p /app/thumbor
-RUN touch /app/thumbor/__init__.py
+RUN apt-get update -y && \
+    apt-get install -y \
+        python3-dev \
+        libcurl4-openssl-dev \
+        libgnutls28-dev \
+        libjpeg-progs \
+        libimage-exiftool-perl \
+        gifsicle \
+        scons \
+        python3-all-dev \
+        libboost-python-dev \
+        libexiv2-dev \
+        ffmpeg \
+        make \
+        zlib1g-dev \
+        gcc \
+        libssl-dev \
+        libjpeg-dev \
+        libwebp-dev \
+        redis && \
+    apt-get install --reinstall -y build-essential && \
+    apt-get clean
+
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python37.so
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
-RUN python -m pip install -e .[tests] && rm -rf ~/.cache/pip
-RUN pip install coveralls
-RUN pip install --upgrade pytest
-RUN rm -rf /app
+
+RUN pip install --upgrade pip

--- a/TestDockerfile37
+++ b/TestDockerfile37
@@ -28,6 +28,3 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_pytho
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
 
 RUN pip install --upgrade pip
-
-RUN useradd -r -m --uid 1001 runner
-USER runner

--- a/TestDockerfile38
+++ b/TestDockerfile38
@@ -27,6 +27,3 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_pytho
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
 
 RUN pip install --upgrade pip
-
-RUN groupadd -g 121 github_actions && \
-    usermod -a -G github_actions root

--- a/TestDockerfile38
+++ b/TestDockerfile38
@@ -28,5 +28,5 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_pytho
 
 RUN pip install --upgrade pip
 
-RUN useradd -r -m --uid 1001 runner
-USER runner
+RUN groupadd -g 121 github_actions && \
+    usermod -a -G github_actions root

--- a/TestDockerfile38
+++ b/TestDockerfile38
@@ -27,3 +27,6 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_pytho
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
 
 RUN pip install --upgrade pip
+
+RUN useradd -r -m --uid 1001 runner
+USER runner

--- a/TestDockerfile38
+++ b/TestDockerfile38
@@ -1,7 +1,7 @@
 FROM python:3.8-slim
 WORKDIR /app
 RUN apt-get update -y && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends --no-install-suggests \
         python3-dev \
         libcurl4-openssl-dev \
         libgnutls28-dev \
@@ -20,7 +20,7 @@ RUN apt-get update -y && \
         libjpeg-dev \
         libwebp-dev \
         redis && \
-    apt-get install --reinstall -y build-essential && \
+    apt-get install --reinstall -y --no-install-recommends --no-install-suggests build-essential && \
     apt-get clean
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python38.so

--- a/TestDockerfile38
+++ b/TestDockerfile38
@@ -1,14 +1,29 @@
 FROM python:3.8-slim
 WORKDIR /app
-RUN apt-get update -y && apt-get install -y python3-dev libcurl4-openssl-dev libgnutls28-dev libjpeg-progs libimage-exiftool-perl gifsicle scons python3-all-dev libboost-python-dev libexiv2-dev ffmpeg make zlib1g-dev gcc libssl-dev libjpeg-dev libwebp-dev redis && apt-get clean
-RUN apt-get update -y && apt-get install --reinstall -y build-essential && apt-get clean
-RUN pip install --upgrade pip
-COPY setup.py /app/setup.py
-RUN mkdir -p /app/thumbor
-RUN touch /app/thumbor/__init__.py
+RUN apt-get update -y && \
+    apt-get install -y \
+        python3-dev \
+        libcurl4-openssl-dev \
+        libgnutls28-dev \
+        libjpeg-progs \
+        libimage-exiftool-perl \
+        gifsicle \
+        scons \
+        python3-all-dev \
+        libboost-python-dev \
+        libexiv2-dev \
+        ffmpeg \
+        make \
+        zlib1g-dev \
+        gcc \
+        libssl-dev \
+        libjpeg-dev \
+        libwebp-dev \
+        redis && \
+    apt-get install --reinstall -y build-essential && \
+    apt-get clean
+
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python38.so
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
-RUN python -m pip install -e .[tests] && rm -rf ~/.cache/pip
-RUN pip install coveralls
-RUN pip install --upgrade pytest
-RUN rm -rf /app
+
+RUN pip install --upgrade pip

--- a/TestDockerfile38
+++ b/TestDockerfile38
@@ -20,7 +20,7 @@ RUN apt-get update -y && \
         libjpeg-dev \
         libwebp-dev \
         redis && \
-    apt-get install --reinstall -y --no-install-recommends --no-install-suggests build-essential && \
+    apt-get install -y --reinstall --no-install-recommends --no-install-suggests build-essential && \
     apt-get clean
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python38.so

--- a/TestDockerfile39
+++ b/TestDockerfile39
@@ -1,7 +1,7 @@
 FROM python:3.9-slim
 WORKDIR /app
 RUN apt-get update -y && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends --no-install-suggests \
         python3-dev \
         libcurl4-openssl-dev \
         libgnutls28-dev \
@@ -20,7 +20,7 @@ RUN apt-get update -y && \
         libjpeg-dev \
         libwebp-dev \
         redis && \
-    apt-get install --reinstall -y build-essential && \
+    apt-get install --reinstall --no-install-recommends --no-install-suggests -y build-essential && \
     apt-get clean
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so

--- a/TestDockerfile39
+++ b/TestDockerfile39
@@ -26,6 +26,3 @@ RUN apt-get update -y && \
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
 
 RUN pip install --upgrade pip
-
-RUN groupadd -g 121 github_actions && \
-    usermod -a -G github_actions root

--- a/TestDockerfile39
+++ b/TestDockerfile39
@@ -27,5 +27,5 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_pytho
 
 RUN pip install --upgrade pip
 
-RUN useradd -r -m --uid 1001 runner
-USER runner
+RUN groupadd -g 121 github_actions && \
+    usermod -a -G github_actions root

--- a/TestDockerfile39
+++ b/TestDockerfile39
@@ -1,13 +1,28 @@
 FROM python:3.9-slim
 WORKDIR /app
-RUN apt-get update -y && apt-get install -y python3-dev libcurl4-openssl-dev libgnutls28-dev libjpeg-progs libimage-exiftool-perl gifsicle scons python3-all-dev libboost-python-dev libexiv2-dev ffmpeg make zlib1g-dev gcc libssl-dev libjpeg-dev libwebp-dev redis && apt-get clean
-RUN apt-get update -y && apt-get install --reinstall -y build-essential && apt-get clean
-RUN pip install --upgrade pip
-COPY setup.py /app/setup.py
-RUN mkdir -p /app/thumbor
-RUN touch /app/thumbor/__init__.py
+RUN apt-get update -y && \
+    apt-get install -y \
+        python3-dev \
+        libcurl4-openssl-dev \
+        libgnutls28-dev \
+        libjpeg-progs \
+        libimage-exiftool-perl \
+        gifsicle \
+        scons \
+        python3-all-dev \
+        libboost-python-dev \
+        libexiv2-dev \
+        ffmpeg \
+        make \
+        zlib1g-dev \
+        gcc \
+        libssl-dev \
+        libjpeg-dev \
+        libwebp-dev \
+        redis && \
+    apt-get install --reinstall -y build-essential && \
+    apt-get clean
+
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
-RUN python -m pip install -e .[tests] && rm -rf ~/.cache/pip
-RUN pip install coveralls
-RUN pip install --upgrade pytest
-RUN rm -rf /app
+
+RUN pip install --upgrade pip

--- a/TestDockerfile39
+++ b/TestDockerfile39
@@ -26,3 +26,6 @@ RUN apt-get update -y && \
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so
 
 RUN pip install --upgrade pip
+
+RUN useradd -r -m --uid 1001 runner
+USER runner

--- a/TestDockerfile39
+++ b/TestDockerfile39
@@ -20,7 +20,7 @@ RUN apt-get update -y && \
         libjpeg-dev \
         libwebp-dev \
         redis && \
-    apt-get install --reinstall --no-install-recommends --no-install-suggests -y build-essential && \
+    apt-get install -y --reinstall --no-install-recommends --no-install-suggests build-essential && \
     apt-get clean
 
 RUN ln -s /usr/lib/x86_64-linux-gnu/libboost_python39.so /usr/lib/libboost_python3.so

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except ImportError:
 
 TESTS_REQUIREMENTS = [
     "colorama==0.*,>=0.4.3",
-    "coverage==5.*,>=5.0.3",
+    "coverage==6.*,>=6.3.2",
     "flake8==3.*,>=3.7.9",
     "isort==4.*,>=4.3.21",
     "preggy==1.*,>=1.4.4",


### PR DESCRIPTION
This PR will change how tests run on Github Actions, 
ensuring a cleaner environment and removing the need 
of pushing new images when changing build dependencies.

To reduce the build time, all images are cached.