### PR TITLE
fix(docs): Use blocks for URLs breaking docs layout

### DIFF
--- a/docs/autojpg.rst
+++ b/docs/autojpg.rst
@@ -16,4 +16,6 @@ Arguments
 Example
 -------
 
-`<http://localhost:8888/unsafe/300x300/filters:autojpg()/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/300x300/filters:autojpg()/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg

--- a/docs/background_color.rst
+++ b/docs/background_color.rst
@@ -26,17 +26,23 @@ The original image is:
 .. image:: images/dice_transparent_background.png
     :alt: Original picture
 
-`<http://localhost:8888/unsafe/fit-in/300x300/filters:background_color(blue)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fdocs%2Fimages%2Fdice_transparent_background.png>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x300/filters:background_color(blue)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fdocs%2Fimages%2Fdice_transparent_background.png
 
 .. image:: images/dice_blue_background.png
     :alt: Picture after the background_color(blue) filter
 
-`<http://localhost:8888/unsafe/fit-in/300x300/filters:background_color(f00)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fdocs%2Fimages%2Fdice_transparent_background.png>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x300/filters:background_color(f00)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fdocs%2Fimages%2Fdice_transparent_background.png
 
 .. image:: images/dice_red_background.png
     :alt: Picture after the background_color(f00) filter
 
-`<http://localhost:8888/unsafe/fit-in/300x300/filters:background_color(add8e6)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fdocs%2Fimages%2Fdice_transparent_background.png>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x300/filters:background_color(add8e6)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fdocs%2Fimages%2Fdice_transparent_background.png
 
 .. image:: images/dice_lightblue_background.png
     :alt: Picture after the background_color(add8e6)

--- a/docs/blur.rst
+++ b/docs/blur.rst
@@ -23,7 +23,9 @@ Example
 .. image:: images/blur_before.jpg
     :alt: Picture before the blur filter
 
-`<http://localhost:8888/unsafe/filters:blur(7)/http%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2F8%2F8a%2F2006_Ojiya_balloon_festival_011.jpg%2F159px-2006_Ojiya_balloon_festival_011.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:blur(7)/http%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2F8%2F8a%2F2006_Ojiya_balloon_festival_011.jpg%2F159px-2006_Ojiya_balloon_festival_011.jpg
 
 .. image:: images/blur_after.jpg
     :alt: Picture after the blur filter

--- a/docs/brightness.rst
+++ b/docs/brightness.rst
@@ -19,7 +19,9 @@ Example
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the brightness
 
-`<http://localhost:8888/unsafe/filters:brightness(40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:brightness(40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/tom_after_brightness.jpg
     :alt: Picture after the brightness

--- a/docs/contrast.rst
+++ b/docs/contrast.rst
@@ -19,12 +19,16 @@ Example
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the contrast filter
 
-`<http://localhost:8888/unsafe/filters:contrast(40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:contrast(40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/tom_after_positive_contrast.jpg
     :alt: Picture after positive contrast
 
-`<http://localhost:8888/unsafe/filters:contrast(-40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:contrast(-40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/tom_after_negative_contrast.jpg
     :alt: Picture after negative contrast

--- a/docs/convolution.rst
+++ b/docs/convolution.rst
@@ -33,7 +33,9 @@ Normalized Matrix:
     2 4 2
     2 1 2
 
-`<http://localhost:8888/unsafe/filters:convolution(1;2;1;2;4;2;1;2;1,3,true)/http://upload.wikimedia.org/wikipedia/commons/5/50/Vd-Orig.png>`_
+::
+
+    http://localhost:8888/unsafe/filters:convolution(1;2;1;2;4;2;1;2;1,3,true)/http://upload.wikimedia.org/wikipedia/commons/5/50/Vd-Orig.png
 
 .. image:: images/after_convolution1.png
     :alt: Picture after the convolution filter
@@ -46,7 +48,9 @@ Matrix:
     -1  8 -1
     -1 -1 -1
 
-`<http://localhost:8888/unsafe/filters:convolution(-1;-1;-1;-1;8;-1;-1;-1;-1,3,false)/http://upload.wikimedia.org/wikipedia/commons/5/50/Vd-Orig.png>`_
+::
+
+    http://localhost:8888/unsafe/filters:convolution(-1;-1;-1;-1;8;-1;-1;-1;-1,3,false)/http://upload.wikimedia.org/wikipedia/commons/5/50/Vd-Orig.png
 
 .. image:: images/after_convolution2.png
     :alt: Picture after the convolution filter

--- a/docs/equalize.rst
+++ b/docs/equalize.rst
@@ -19,7 +19,9 @@ Example
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the equalize filter
 
-`<http://localhost:8888/unsafe/filters:equalize()/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:equalize()/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/tom_after_equalize.jpg
     :alt: Picture after the equalize filter

--- a/docs/extract_focal_points.rst
+++ b/docs/extract_focal_points.rst
@@ -23,11 +23,15 @@ was the original for the segment with the manual cropping.
 
 This means that for an URL like:
 
-`<http://localhost:8888/unsafe/300x100/filters:extract_focal()/localhost:8888/unsafe/100x150:300x200/https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Turkish_Van_Cat.jpg/546px-Turkish_Van_Cat.jpg>`_
+::
+
+    http://localhost:8888/unsafe/300x100/filters:extract_focal()/localhost:8888/unsafe/100x150:300x200/https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Turkish_Van_Cat.jpg/546px-Turkish_Van_Cat.jpg
 
 Thumbor will use as original the following image URL:
 
-`<https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Turkish_Van_Cat.jpg/546px-Turkish_Van_Cat.jpg>`_
+::
+
+    https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Turkish_Van_Cat.jpg/546px-Turkish_Van_Cat.jpg
 
 Example
 -------
@@ -38,18 +42,24 @@ Original Image:
 
 Cat's eye cropped:
 
-`<http://localhost:8888/unsafe/100x150:300x200/https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Turkish_Van_Cat.jpg/546px-Turkish_Van_Cat.jpg>`_
+::
+
+    http://localhost:8888/unsafe/100x150:300x200/https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Turkish_Van_Cat.jpg/546px-Turkish_Van_Cat.jpg
 
 .. image:: images/extract1.jpg
 
 A bigger image based on above's crop with the extract\_focal() filter:
 
-`<http://localhost:8888/unsafe/300x100/filters:extract_focal()/localhost:8888/unsafe/100x150:300x200/https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Turkish_Van_Cat.jpg/546px-Turkish_Van_Cat.jpg>`_
+::
+
+    http://localhost:8888/unsafe/300x100/filters:extract_focal()/localhost:8888/unsafe/100x150:300x200/https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Turkish_Van_Cat.jpg/546px-Turkish_Van_Cat.jpg
 
 .. image:: images/extract2.jpg
 
 Without the filter that would be the result:
 
-`<http://localhost:8888/unsafe/300x100/localhost:8888/unsafe/100x150:300x200/https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Turkish_Van_Cat.jpg/546px-Turkish_Van_Cat.jpg>`_
+::
+
+    http://localhost:8888/unsafe/300x100/localhost:8888/unsafe/100x150:300x200/https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Turkish_Van_Cat.jpg/546px-Turkish_Van_Cat.jpg
 
 .. image:: images/extract3.jpg

--- a/docs/filling.rst
+++ b/docs/filling.rst
@@ -41,27 +41,37 @@ The original image is:
 .. image:: images/tom_before_brightness.jpg
     :alt: Original picture
 
-`<http://localhost:8888/unsafe/fit-in/300x300/filters:fill(blue)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x300/filters:fill(blue)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/fillblue.jpg
     :alt: Picture after the fill(blue) filter
 
-`<http://localhost:8888/unsafe/fit-in/300x300/filters:fill(f00)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x300/filters:fill(f00)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/fillred.jpg
     :alt: Picture after the fill(f00) filter
 
-`<http://localhost:8888/unsafe/fit-in/300x300/filters:fill(add8e6)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x300/filters:fill(add8e6)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/filllightblue.jpg
     :alt: Picture after the fill(add8e6)
 
-`<http://localhost:8888/unsafe/fit-in/300x300/filters:fill(auto)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x300/filters:fill(auto)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/fillauto.jpg
     :alt: Picture after the fill(auto) filter (since 3.7.1)
 
-`<http://localhost:8888/unsafe/fit-in/300x300/filters:fill(blur)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x300/filters:fill(blur)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/fillblur.jpg
     :alt: Picture after the fill(blur) filter (since 6.7.1)
@@ -74,27 +84,37 @@ The original image is:
 .. image:: images/dice_transparent_background.png
     :alt: Original picture
 
-`<http://localhost:8888/unsafe/fit-in/300x225/filters:fill(blue,1)/https://github.com/thumbor/thumbor/wiki/dice_transparent_background.png>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x225/filters:fill(blue,1)/https://github.com/thumbor/thumbor/wiki/dice_transparent_background.png
 
 .. image:: images/dice_blue_background.png
     :alt: Picture after the fill(blue) filter
 
-`<http://localhost:8888/unsafe/fit-in/300x225/filters:fill(f00,true)/https://github.com/thumbor/thumbor/wiki/dice_transparent_background.png>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x225/filters:fill(f00,true)/https://github.com/thumbor/thumbor/wiki/dice_transparent_background.png
 
 .. image:: images/dice_red_background.png
     :alt: Picture after the fill(f00) filter
 
-`<http://localhost:8888/unsafe/fit-in/300x225/filters:fill(add8e6,1)/https://github.com/thumbor/thumbor/wiki/dice_transparent_background.png>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x225/filters:fill(add8e6,1)/https://github.com/thumbor/thumbor/wiki/dice_transparent_background.png
 
 .. image:: images/dice_lightblue_background.png
     :alt: Picture after the fill(add8e6)
 
-`<http://localhost:8888/unsafe/fit-in/300x225/filters:fill(auto,true)/https://github.com/thumbor/thumbor/wiki/dice_transparent_background.png>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x225/filters:fill(auto,true)/https://github.com/thumbor/thumbor/wiki/dice_transparent_background.png
 
 .. image:: images/dice_auto_background.png
     :alt: Picture after the fill(auto) filter (since 3.7.1)
 
-`<http://localhost:8888/unsafe/fit-in/300x225/filters:fill(blur,true)/https://github.com/thumbor/thumbor/wiki/dice_transparent_background.png>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/300x225/filters:fill(blur,true)/https://github.com/thumbor/thumbor/wiki/dice_transparent_background.png
 
 .. image:: images/dice_blur_background.png
     :alt: Picture after the fill(blur) filter (since 6.7.1)

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -7,7 +7,7 @@ How Filters Work
 Thumbor handles filters in a pipeline. This means that they
 run sequentially in the order they are specified!
 Given an original image with size :math:`60x40` and the
-following transformations:
+following transformations::
 
    http://localhost:8888/fit-in/100x100/filters:watermark(..):blur(..):fill(red,1):upscale()/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 

--- a/docs/focal.rst
+++ b/docs/focal.rst
@@ -22,7 +22,9 @@ Before cropping with specific focal point:
 .. image:: images/tom_before_brightness.jpg
     :alt: Original picture
 
-`<http://localhost:8888/unsafe/400x100/filters:focal(146x206:279x360)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/400x100/filters:focal(146x206:279x360)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 After specifying the focal point:
 

--- a/docs/format.rst
+++ b/docs/format.rst
@@ -17,4 +17,6 @@ Arguments
 Example
 -------
 
-`<http://localhost:8888/unsafe/filters:format(webp)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:format(webp)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg

--- a/docs/grayscale.rst
+++ b/docs/grayscale.rst
@@ -19,7 +19,9 @@ Example
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the grayscale filter
 
-`<http://localhost:8888/unsafe/filters:grayscale()/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:grayscale()/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/tom_after_grayscale.jpg
     :alt: Picture after the grayscale filter

--- a/docs/max_bytes.rst
+++ b/docs/max_bytes.rst
@@ -22,7 +22,9 @@ Compressing the original image to less than 7.5k (ended up with ~7kb):
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the max_bytes filter
 
-`<http://localhost:8888/unsafe/filters:max_bytes(7500)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:max_bytes(7500)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/tom_after_max_bytes.jpg
     :alt: Picture after 7500 max_bytes filter

--- a/docs/no_upscale.rst
+++ b/docs/no_upscale.rst
@@ -19,4 +19,6 @@ No arguments allowed.
 Example
 -------
 
-`<http://localhost:8888/unsafe/filters:no_upscale()/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:no_upscale()/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg

--- a/docs/noise.rst
+++ b/docs/noise.rst
@@ -19,7 +19,9 @@ Example
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the noise filter
 
-`<http://localhost:8888/unsafe/filters:noise(40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:noise(40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/tom_after_noise.jpg
     :alt: Picture after noise of 40%

--- a/docs/proportion.rst
+++ b/docs/proportion.rst
@@ -20,7 +20,9 @@ Example
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the percentage crop
 
-`<http://localhost:8888/unsafe/filters:proportion(0.5)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:proportion(0.5)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/proportion.jpg
     :alt: Picture with 50% crop

--- a/docs/quality.rst
+++ b/docs/quality.rst
@@ -21,7 +21,9 @@ Example
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the quality filter
 
-`<http://localhost:8888/unsafe/filters:quality(40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:quality(40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/tom_after_quality.jpg
     :alt: Picture after 10% quality

--- a/docs/rgb.rst
+++ b/docs/rgb.rst
@@ -24,7 +24,9 @@ Example
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the RGB filter
 
-`<http://localhost:8888/unsafe/filters:rgb(20,-20,40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:rgb(20,-20,40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/tom_after_rgb.jpg
     :alt: Picture after the RGB filter

--- a/docs/rotate.rst
+++ b/docs/rotate.rst
@@ -23,7 +23,9 @@ Example
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the rotate filter
 
-`<http://localhost:8888/unsafe/filters:rotate(90)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:rotate(90)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/tom_after_rotate.jpg
     :alt: Picture after the 90 degrees rotate

--- a/docs/round_corners.rst
+++ b/docs/round_corners.rst
@@ -21,17 +21,23 @@ Examples
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the round corners filter filter
 
-`<http://localhost:8888/unsafe/filters:round_corner(20,255,255,255)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:round_corner(20,255,255,255)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/rounded1.jpg
     :alt: Picture after rounded corners
 
-`<http://localhost:8888/unsafe/filters:round_corner(20|40,0,0,0)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:round_corner(20|40,0,0,0)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/rounded2.jpg
     :alt: Picture after rounded corners
 
-`<http://localhost:8888/unsafe/filters:round_corner(30,0,0,0,1)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:round_corner(30,0,0,0,1)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/rounded3.png
     :alt: Picture after rounded corners (transparent)

--- a/docs/sharpen.rst
+++ b/docs/sharpen.rst
@@ -26,7 +26,9 @@ Example 1
 .. image:: images/man_before_sharpen.png
     :alt: Picture before the sharpen filter
 
-`<http://localhost:8888/unsafe/filters:sharpen(2,1.0,true)/http://videoprocessing.ucsd.edu/~stanleychan/research/pix/Blurred_foreman_0005.png>`_
+::
+
+    http://localhost:8888/unsafe/filters:sharpen(2,1.0,true)/http://videoprocessing.ucsd.edu/~stanleychan/research/pix/Blurred_foreman_0005.png
 
 .. image:: images/man_after_sharpen.png
     :alt: Picture after the sharpen filter
@@ -37,7 +39,9 @@ Example 2
 .. image:: images/eagle_before_sharpen.jpg
     :alt: Picture before the sharpen filter
 
-`<http://localhost:8888/unsafe/filters:sharpen(1.5,0.5,true)/http://images.cambridgeincolour.com/tutorials/sharpening_eagle2-original.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:sharpen(1.5,0.5,true)/http://images.cambridgeincolour.com/tutorials/sharpening_eagle2-original.jpg
 
 .. image:: images/eagle_after_sharpen.jpg
     :alt: Picture after the sharpen filter

--- a/docs/stretch.rst
+++ b/docs/stretch.rst
@@ -14,7 +14,9 @@ Example
 .. image:: images/tom_before_brightness.jpg
     :alt: Picture before the stretch filter
 
-`<http://localhost:8888/unsafe/200x100/filters:stretch()/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg>`_
+::
+
+    http://localhost:8888/unsafe/200x100/filters:stretch()/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
 
 .. image:: images/stretch_after.jpg
     :alt: Picture after the stretch filter

--- a/docs/strip_exif.rst
+++ b/docs/strip_exif.rst
@@ -8,7 +8,7 @@ Description
 
 This filter removes any Exif information in the resulting image.
 
-This is useful if you have set the configuration ``PRESERVE_EXIF_INFO = True`` but still wish to overwrite this behavior in some cases 
+This is useful if you have set the configuration ``PRESERVE_EXIF_INFO = True`` but still wish to overwrite this behavior in some cases
 (e.g. for image icons)
 
 
@@ -20,4 +20,6 @@ No arguments
 Example
 -------
 
-`<http://localhost:8888/unsafe/filters:strip\_exif()/http://www.arte.tv/static-epgapi/057460-011-A.jpg>`_
+::
+
+    http://localhost:8888/unsafe/filters:strip\_exif()/http://www.arte.tv/static-epgapi/057460-011-A.jpg

--- a/docs/strip_icc.rst
+++ b/docs/strip_icc.rst
@@ -18,4 +18,6 @@ No arguments
 Example
 -------
 
-`<http://localhost:8888/unsafe/filters:strip\_icc()/http://videoprocessing.ucsd.edu/~stanleychan/research/pix/Blurred_foreman_0005.png>`_
+::
+
+    http://localhost:8888/unsafe/filters:strip\_icc()/http://videoprocessing.ucsd.edu/~stanleychan/research/pix/Blurred_foreman_0005.png

--- a/docs/upscale.rst
+++ b/docs/upscale.rst
@@ -20,4 +20,6 @@ No arguments allowed.
 Example
 -------
 
-`<http://localhost:8888/unsafe/fit-in/600x500/filters:upscale()/https://raw.githubusercontent.com/thumbor/thumbor/e86324e49d7e53acc2a8057e43f3fdd2ca5cea75/docs/images/dice_transparent_background.png>`_
+::
+
+    http://localhost:8888/unsafe/fit-in/600x500/filters:upscale()/https://raw.githubusercontent.com/thumbor/thumbor/e86324e49d7e53acc2a8057e43f3fdd2ca5cea75/docs/images/dice_transparent_background.png

--- a/docs/watermark.rst
+++ b/docs/watermark.rst
@@ -43,11 +43,15 @@ Arguments
 Example
 -------
 
-`<http://thumbor-server/filters:watermark(http://my.site.com/img.png,-10,-10,50)/some/image.jpg>`_
+::
+
+    http://thumbor-server/filters:watermark(http://my.site.com/img.png,-10,-10,50)/some/image.jpg
 
 |watermark|
 
-`<http://thumbor-server/filters:watermark(http://my.site.com/img.png,10p,-20p,50)/some/image.jpg>`_
+::
+
+    http://thumbor-server/filters:watermark(http://my.site.com/img.png,10p,-20p,50)/some/image.jpg
 
 |watermark_relative|
 


### PR DESCRIPTION
Currently the Filters documentation have all links breaking the layout. This PR uses blocks (like in Getting Started page) to fix it.

E.g.

![image](https://user-images.githubusercontent.com/604917/155842889-0fb83bd7-e8a6-444b-9429-23bfa635b6a9.png)

Fixed:

![image](https://user-images.githubusercontent.com/604917/155842899-eb328b8a-5bc1-4032-98f5-87bfeac4e472.png)

