### PR TITLE
Fix TypeError in sentry error handler

### DIFF
--- a/thumbor/error_handlers/sentry.py
+++ b/thumbor/error_handlers/sentry.py
@@ -39,7 +39,7 @@ SENTRY_DSN_URL configuration."
             **kwargs
         )
 
-    def handle_error(self, _, handler, exception):
+    def handle_error(self, context, handler, exception):
         req = handler.request
 
         exc_info = exc_info_from_error(exception)


### PR DESCRIPTION
Error handler sends the context parameter
https://github.com/thumbor/thumbor/blob/a0a1338d328d6c0ecbd9eeaf510882313dca2764/thumbor/handlers/__init__.py#L928-L930
but sentry handle_error method does not have this parameter
https://github.com/thumbor/thumbor/blob/a0a1338d328d6c0ecbd9eeaf510882313dca2764/thumbor/error_handlers/sentry.py#L42
("_" as parameter is bad idea in python..)