### PR TITLE
Remove socketfromfd dependency to be able to launch thumbor with the --fd option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,6 @@ http://<thumbor-server>/300x200/smart/thumbor.readthedocs.io/en/latest/_images/l
             "Pillow>=9.0.0",
             "pytz>=2019.3.0",
             "statsd==3.*,>=3.3.0",
-            "socketfromfd>=0.2.0",
             "tornado==6.*,>=6.0.3",
             "webcolors==1.*,>=1.10.0",
             "colorful==0.*,>=0.5.4",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -196,7 +196,7 @@ class ServerTestCase(TestCase):
         server_instance_mock.start.assert_called_with(5)
 
     @mock.patch.object(thumbor.server, "HTTPServer")
-    @mock.patch.object(thumbor.server, "socket_from_fd")
+    @mock.patch.object(thumbor.server, "socket")
     def test_can_run_server_with_fd(self, socket_from_fd_mock, server_mock):
         application = mock.Mock()
         context = mock.Mock()

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -15,6 +15,7 @@ import sys
 import warnings
 from os.path import dirname, expanduser
 from shutil import which
+from socket import socket
 
 import tornado.ioloop
 from PIL import Image
@@ -112,10 +113,7 @@ def run_server(application, context):
         fd_number = get_as_integer(context.server.fd)
 
         if fd_number is not None:
-            # TODO: replace with socket.socket(fileno=fd_number) when we require Python>=3.7
-            sock = socket_from_fd(  # pylint: disable=too-many-function-args
-                fd_number, True
-            )
+            sock = socket(fileno=fd_number)
         else:
             sock = bind_unix_socket(context.server.fd)
 

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -19,7 +19,6 @@ from socket import socket
 
 import tornado.ioloop
 from PIL import Image
-from socketfromfd import fromfd as socket_from_fd
 from tornado.httpserver import HTTPServer
 from tornado.netutil import bind_unix_socket
 


### PR DESCRIPTION
Closes #1418 