### PR TITLE
py3exiv2 0.11.0 breaks python3.10 unit test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ EXTRA_LIBS_REQUIREMENTS = [
     # Going to update in a proper commit
     "cairosvg>=2.5.2",
     "pycurl==7.*,>=7.43.0",
-    "py3exiv2==0.*,>=0.7.1,!=0.7.2,!=0.8.0,!=0.9.3",
+    "py3exiv2>=0.*,<0.7.2",
 ]
 
 ALL_REQUIREMENTS = OPENCV_REQUIREMENTS + EXTRA_LIBS_REQUIREMENTS


### PR DESCRIPTION
The [new version](https://pypi.org/project/py3exiv2/0.11.0/#history) of `py3exiv2 0.11.0` was released today and it breaks python 3.10 Thumbor unit test.

This new version was not excluded on `setup.py` `py3exiv2==0.*,>=0.7.1,!=0.7.2,!=0.8.0,!=0.9.3`, so instead of include `0.11.0` on excluded list, we changed `setup.py` to `py3exiv2>=0.*,<0.7.2`, to avoiding future breaks.

`py3exiv2` depends on `libboost-python-dev` with shared lib `boost_python310` and this version does not exists on Debian bullseye version, as you can see [here](https://packages.debian.org/bullseye/amd64/libboost-python1.74-dev/filelist).


