### PR TITLE
Ensure socket from file descriptor is non-blocking

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,6 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
-
 from unittest import TestCase, mock
 
 from preggy import expect
@@ -196,8 +195,8 @@ class ServerTestCase(TestCase):
         server_instance_mock.start.assert_called_with(5)
 
     @mock.patch.object(thumbor.server, "HTTPServer")
-    @mock.patch.object(thumbor.server, "socket")
-    def test_can_run_server_with_fd(self, socket_from_fd_mock, server_mock):
+    @mock.patch.object(thumbor.server, "socket", autospec=True)
+    def test_can_run_server_with_fd(self, socket_mock, server_mock):
         application = mock.Mock()
         context = mock.Mock()
         context.server = mock.Mock(fd=11, port=1234, ip="0.0.0.0", processes=1)
@@ -205,10 +204,11 @@ class ServerTestCase(TestCase):
         server_instance_mock = mock.Mock()
         server_mock.return_value = server_instance_mock
 
-        socket_from_fd_mock.return_value = "socket mock"
-
         run_server(application, context)
-        server_instance_mock.add_socket.assert_called_with("socket mock")
+        socket_mock.assert_called_with(fileno=11)
+        server_instance_mock.add_socket.assert_called_with(
+            socket_mock.return_value
+        )
         server_instance_mock.start.assert_called_with(1)
 
     @mock.patch.object(thumbor.server, "HTTPServer")

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -790,6 +790,13 @@ Config.define(
     "The amount of time to waut before shutting down all io, after the server has been stopped",
     "Server",
 )
+Config.define(
+    "NON_BLOCKING_SOCKETS",
+    False,
+    "If True, thumbor will ensure that the socket from the file descriptor number passed using"
+    " the --fd flag is non-blocking. This setting has no effect if the --fd flag is a path,"
+    " sockets created that way are always non-blocking.",
+)
 
 # HANDLER LISTS
 Config.define(

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -113,7 +113,8 @@ def run_server(application, context):
 
         if fd_number is not None:
             sock = socket(fileno=fd_number)
-            sock.setblocking(False)
+            if context.config.NON_BLOCKING_SOCKETS:
+                sock.setblocking(False)
         else:
             sock = bind_unix_socket(context.server.fd)
 

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -105,19 +105,27 @@ def get_application(context):
     return context.modules.importer.import_class(context.app_class)(context)
 
 
+def get_socket_from_fd(fname_or_fd, *, non_blocking=False):
+    fd_number = get_as_integer(fname_or_fd)
+
+    if fd_number is not None:
+        sock = socket(fileno=fd_number)
+        if non_blocking:
+            sock.setblocking(False)
+    else:
+        sock = bind_unix_socket(fname_or_fd)
+
+    return sock
+
+
 def run_server(application, context):
     server = HTTPServer(application, xheaders=True)
 
     if context.server.fd is not None:
-        fd_number = get_as_integer(context.server.fd)
-
-        if fd_number is not None:
-            sock = socket(fileno=fd_number)
-            if context.config.NON_BLOCKING_SOCKETS:
-                sock.setblocking(False)
-        else:
-            sock = bind_unix_socket(context.server.fd)
-
+        sock = get_socket_from_fd(
+            context.server.fd,
+            non_blocking=context.config.NON_BLOCKING_SOCKETS,
+        )
         server.add_socket(sock)
 
         logging.debug("thumbor starting at fd %s", context.server.fd)

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -113,6 +113,7 @@ def run_server(application, context):
 
         if fd_number is not None:
             sock = socket(fileno=fd_number)
+            sock.setblocking(False)
         else:
             sock = bind_unix_socket(context.server.fd)
 


### PR DESCRIPTION
Yesterday I spent several hours figuring out why nginx would timeout when trying to communicate with Thumbor over a socket managed by supervisord. In the end I noticed a subtle difference in how supervisord creates a socket compared to how Tornado's `bind_unix_socket` does it. It all comes down to one line: `sock.setblocking(False)`.

In my case I need to use supervisord to manage the socket, simply because the socket needs to be owned by a specific group and needs to be group readable/writable. This is not possible if Thumbor/Tornado manages the socket, as there is no way to configure socket permissions in Thumbor.

My setup is as follows:

nginx proxies Thumbor:

```nginx
server {
  ...

  location / {
    try_files $uri @thumbor;
  }

  location @thumbor {
    proxy_pass http://unix:/var/www/thumbor/run/thumbor.sock;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $real_scheme;
  }
}
```

supervisord manages Thumbor:

```ini
[fcgi-program:thumbor]
command = /var/www/thumbor/private/venv/bin/thumbor --conf /var/www/thumbor/etc/thumbor.conf --fd 0 --processes 0 --log-level info

socket = unix:///var/www/thumbor/run/thumbor.sock
socket_owner = thumbor:webserver
socket_mode = 660
socket_backlog = 128

stdout_logfile = /var/www/thumbor/logs/thumbor.log
stderr_logfile = /var/www/thumbor/logs/thumbor-error.log
stopasgroup = true
```

Thumbor itself is configured to use local files, nothing fancy:

```conf
ALLOW_UNSAFE_URL = False
SECURITY_KEY = "{{ thumbor_security_key }}"

AUTO_WEBP = True
WEBP_QUALITY = 85

ALLOW_ANIMATED_GIFS = False
RESPECT_ORIENTATION = True
SEND_IF_MODIFIED_LAST_MODIFIED_HEADERS = True

LOADER = 'thumbor.loaders.file_loader'
FILE_LOADER_ROOT_PATH = "{{ thumbor_file_loader_root }}"

DETECTORS = [
  'thumbor.detectors.face_detector',
  'thumbor.detectors.profile_detector',
  'thumbor.detectors.glasses_detector',
  'thumbor.detectors.feature_detector'
]

RESULT_STORAGE = 'thumbor.result_storages.file_storage'
RESULT_STORAGE_EXPIRATION_SECONDS = {{ thumbor_result_expiration_seconds }}
RESULT_STORAGE_FILE_STORAGE_ROOT_PATH = "{{ thumbor_result_storage_root }}"

USE_CUSTOM_ERROR_HANDLING = True
ERROR_HANDLER_MODULE = 'thumbor.error_handlers.sentry'
SENTRY_DSN_URL = "{{ thumbor_sentry_dsn }}"
SENTRY_ENVIRONMENT = "{{ thumbor_sentry_environment }}"

HANDLER_LISTS = [
    'thumbor.handler_lists.healthcheck',
]
```