### PR TITLE
Fix library test example in docs and use python3

### DIFF
--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -124,7 +124,7 @@ Here's how it was implemented in Ruby:
 
     def sign_in_thumbor(key, str)
         #bash command to call thumbor's decrypt method
-        command = "python -c 'from thumbor.crypto import Signer; signer = Signer(\"" << key << "\"); print signer.signature(\"" << str << "\")'"
+        command = "python3 -c 'from libthumbor.url_signers.base64_hmac_sha1 import UrlSigner; signer = UrlSigner(\"" << key << "\"); print(signer.signature(\"" << str << "\").decode(\"utf-8\"))'"
 
         #execute it in the shell using ruby's popen mechanism
         result = Array.new


### PR DESCRIPTION
The signing code has moved in thumbor and it no longer supports Python 2

```
% python3 -c 'from thumbor.crypto import Signer; signer = Signer("secret"); print(signer.signature("url"))'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'thumbor.crypto'
```
```
% python3 -c 'from libthumbor.url_signers.base64_hmac_sha1 import UrlSigner; signer = UrlSigner("secret"); print(signer.signature("url").decode("utf-8"))'
jjTzhyRdkQ3WHRCJofpLTjuYCZI=

```