### PR TITLE
Fixed pylint execution error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ flake:
 	@flake8 --config .flake8
 
 pylint:
-	@pylint thumbor tests
+	@pylint --load-plugins=pylint.extensions.no_self_use thumbor tests
 
 setup_docs:
 	@$(PYTHON) -m pip install -r docs/requirements.txt

--- a/pylintrc
+++ b/pylintrc
@@ -16,7 +16,6 @@ disable=
       missing-function-docstring,
       missing-module-docstring,
       missing-class-docstring,
-      bad-continuation,
       c-extension-no-member,
       too-many-arguments,
       assignment-from-none,


### PR DESCRIPTION
Fix pylint execution error after update.

Was removed `bad-continuation` from `pylintrc`, see [here](https://github.com/PyCQA/pylint/pull/3571) for more information.
Was added `--load-plugins=pylint.extensions.no_self_use` on `Makefile`, see [here](https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers) for more information

```sh
************* Module /app/pylintrc
[5](https://github.com/thumbor/thumbor/runs/7222161381?check_suite_focus=true#step:11:6)
pylintrc:1:0: R0022: Useless option value for '--disable', 'bad-continuation' was removed from pylint, see https://github.com/PyCQA/pylint/pull/3571. (useless-option-value)
[6](https://github.com/thumbor/thumbor/runs/7222161381?check_suite_focus=true#step:11:7)
pylintrc:1:0: R0022: Useless option value for '--disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers. (useless-option-value)
```