### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/whos_using_it.rst
+++ b/docs/whos_using_it.rst
@@ -142,7 +142,7 @@ slogan into an original tee and order it immediately.
 
 `HeyCar <https://hey.car/>`__
 
-    HeyCar is using Thumbor to optmize images for each customers device, taking network and screen sizes into account.
+    HeyCar is using Thumbor to optimize images for each customers device, taking network and screen sizes into account.
 
     Our Thumbor instances run on our Kubernetes Cluster, served behind a CloudFront instance for caching purposes.
 

--- a/thumbor/engines/extensions/pil.py
+++ b/thumbor/engines/extensions/pil.py
@@ -91,7 +91,7 @@ def int2long(i):
 # getheader gives a 87a header and a color palette (two elements in a list).
 # getdata()[0] gives the Image Descriptor up to (including)
 # "LZW min code size".
-# getdatas()[1:] is the image data itself in chuncks of 256 bytes (well
+# getdatas()[1:] is the image data itself in chunks of 256 bytes (well
 # technically the first byte says how many bytes follow, after which that
 # amount (max 255) follows).
 
@@ -387,7 +387,7 @@ class GifWriter:
         Given a set of images writes the bytes to the specified stream.
 
         """
-        # Obtain palette for all images and count each occurance
+        # Obtain palette for all images and count each occurrence
         palettes, occur = [], []
         for im in images:
             header, usedPaletteColors = getheader(im)
@@ -484,7 +484,7 @@ def writeGif(
     duration : scalar or list of scalars
         The duration for all frames, or (if a list) for each frame.
     repeat : bool or integer
-        The amount of loops. If True, loops infinitetely.
+        The amount of loops. If True, loops infinitely.
     dither : bool
         Whether to apply dithering
     nq : integer


### PR DESCRIPTION
There are small typos in:
- docs/whos_using_it.rst
- thumbor/engines/extensions/pil.py

Fixes:
- Should read `optimize` rather than `optmize`.
- Should read `occurrence` rather than `occurance`.
- Should read `infinitely` rather than `infinitetely`.
- Should read `chunks` rather than `chuncks`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md