### PR TITLE
fix spurious write errors when STORES_CRYPTO_KEY_FOR_EACH_IMAGE is set to True

### DIFF
--- a/thumbor/storages/file_storage.py
+++ b/thumbor/storages/file_storage.py
@@ -55,8 +55,13 @@ class Storage(storages.BaseStorage):
 
         crypto_path = f"{splitext(file_abspath)[0]}.txt"
         temp_abspath = f"{crypto_path}.{str(uuid4()).replace('-', '')}"
-        with open(temp_abspath, "w", encoding="utf-8") as _file:
-            _file.write(self.context.server.security_key)
+        with open(temp_abspath, "wb") as _file:
+            try:
+                security_key = self.context.server.security_key.encode()
+            except (UnicodeDecodeError, AttributeError):
+                security_key = self.context.server.security_key
+                pass
+            _file.write(security_key)
 
         move(temp_abspath, crypto_path)
         logger.debug(


### PR DESCRIPTION
### Description

When requesting an image for the first time, Thumbor fails to create the file which should contain the security key:

```
May 16 15:57:01 thumbor[804812]: 2022-05-16 15:57:01 thumbor:ERROR ERROR: Traceback (most recent call last):
May 16 15:57:01 thumbor[804812]:  File "/opt/thumbor/venv/lib64/python3.8/site-packages/thumbor/handlers/__init__.py", line 212, in get_image
May 16 15:57:01 thumbor[804812]:    result = await self._fetch(self.context.request.image_url)
May 16 15:57:01 thumbor[804812]:  File "/opt/thumbor/venv/lib64/python3.8/site-packages/thumbor/handlers/__init__.py", line 876, in _fetch
May 16 15:57:01 thumbor[804812]:    raise fetch_result.exception
May 16 15:57:01 thumbor[804812]:  File "/opt/thumbor/venv/lib64/python3.8/site-packages/thumbor/handlers/__init__.py", line 870, in _fetch
May 16 15:57:01 thumbor[804812]:    await storage.put_crypto(url)
May 16 15:57:01 thumbor[804812]:  File "/opt/thumbor/venv/lib64/python3.8/site-packages/thumbor/storages/file_storage.py", line 59, in put_crypto
May 16 15:57:01 thumbor[804812]:    _file.write(self.context.server.security_key)
May 16 15:57:01 thumbor[804812]: TypeError: write() argument must be str, not bytes
May 16 15:57:01 thumbor[804812]: 2022-05-16 15:57:01 thumbor:ERROR [BaseHandler] get_image failed for url `path/to/testimage`. error: `write() argument must be str, not bytes`
May 16 15:57:01 thumbor[804812]: 2022-05-16 15:57:01 tornado.access:ERROR 500 GET /HASH/fit-in/750x589/path/to/testimage (172.16.1.1) 78.97ms
```

Instead of creating the file that holds the security key for this image, Thumbor will only create a temp file with a size of 0 bytes:

```
-rw-r--r-- 1 thumbor thumbor  76124 Jul 22 09:29 abcfef0123456789abcfef0123456789abcdef
-rw-r--r-- 1 thumbor thumbor      0 Jul 22 09:29 abcfef0123456789abcfef0123456789abcdef.txt.0123456789abcdef0123456789abcfef
```

Once this file exists, the next request for the same image will succeed.

Changing the file mode in Thumbor to "binary" immediately solves this issue for me (#1445).

Side note: initially I thought that this was related to NFS storage (see https://github.com/thumbor/thumbor/issues/1445), but even after disabling NFS caches (options: sync,lookupcache=positive) this issue still exists. So I assume this is a general issue when STORES_CRYPTO_KEY_FOR_EACH_IMAGE is set to `True`.

### Additional context

Opening the file in binary mode fixes the issue. Binary mode was initially enabled when adding compatibility for Python 3 in https://github.com/thumbor/thumbor/commit/2f15b1550c386bfe31719c5eafc419d30dd8a4cc#diff-2b9fb4283a3954ea078e794730383e71dacbe0db73e11a4a8d5d8ff695792f67. However, it was removed with https://github.com/thumbor/thumbor/commit/0630641077d28456b77e9548cb13fcdf06a97005#diff-2b9fb4283a3954ea078e794730383e71dacbe0db73e11a4a8d5d8ff695792f67 in an attempt to fix pylint errors.

### Environment

STORES_CRYPTO_KEY_FOR_EACH_IMAGE set to `True`

Rocky Linux 8.6 (rebuild of RHEL 8)
Python 3.8.12
Thumbor 7.0.x (tested multiple versions)
NFS v4 storage
