### PR TITLE
Use random and srandom instead of rand and srand

### DIFF
--- a/thumbor/ext/filters/_noise.c
+++ b/thumbor/ext/filters/_noise.c
@@ -24,11 +24,11 @@ _noise_apply(PyObject *self, PyObject *args)
         size -= num_bytes;
 
         if (seed_int > 0) {
-            srand(seed_int);
+            srandom(seed_int);
         }
 
         for (; i <= size; i += num_bytes) {
-            rand_val = (rand() % amount_int) - (amount_int >> 1);
+            rand_val = (random() % amount_int) - (amount_int >> 1);
 
             r = ptr[i + r_idx];
             g = ptr[i + g_idx];


### PR DESCRIPTION
The C standard library offers much more robust `random` and `srandom`, which behave the same in different platforms — such as Linux and macOS.

With this change, the noise filter test stops failing on macOS.

I'm not so sure about non-POSIX counterparts, though.