### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,16 @@ name: build
 on:
   push:
   pull_request:
+
+permissions:
+  checks: write # to create new checks (coverallsapp/github-action)
+
 jobs:
   build:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      checks: write # to create new checks (coverallsapp/github-action)
+
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: lint/formatter
 on:
   push:
   pull_request:
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   black:
     runs-on: ubuntu-latest
@@ -11,6 +15,10 @@ jobs:
         with:
           options: "--check --verbose"
   flake8:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      checks: write # to update checks 
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.