### PR TITLE
docs(LICENSE) Update license year to present

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Globo.com
+Copyright (c) 2014-present Globo.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Two key reasons for this PR:
- Globo.com swag for hacktoberfest
- Updates the license year to "2018-present"