### PR TITLE
Updated the correct link on Readme.mkd

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -65,7 +65,7 @@ http://<thumbor-server>/300x200/smart/thumbor.readthedocs.io/en/latest/_images/l
 
 You should see an image of the thumbor logo in 300x200.
 
-Learn more about all you can do in [thumbor's documentation](http://thumbor.readthedocs.org/en/latest/index.html "thumbor docs").
+Learn more about all you can do in [thumbor's documentation](http://thumbor.readthedocs.io/en/latest/index.html "thumbor docs").
 
 ## ⚙️ Installation
 


### PR DESCRIPTION
I looked at the whole project and checked the broken links.

On line 68 Readme.mkd, found this link was not right though it has auto-redirection and the link takes to the right URL [thumbor's documentation](http://thumbor.readthedocs.org/en/latest/index.html "thumbor docs"). But, I worked on this to make sure the sanity checks are good enough for documentation.

https://thumbor.readthedocs.io/en/latest/index.html

Above mentioned is the correct URL.