### PR TITLE
Documention spell check

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -364,7 +364,7 @@ In the most of cases the image size will decrease.
 
 WARNING: Depending on case, this is not a good deal. This transformation
 maybe causes distortions or the size of image can increase.
-Images with texts, for example, the result image maybe will be distorced.
+Images with texts, for example, the result image maybe will be distorted.
 Dark images, for example, the size of result image maybe will be bigger.
 You have to evaluate the majority of your use cases to take a decision about the usage of this conf.
 
@@ -910,7 +910,7 @@ Example of Configuration File
    ## has no transparency (via alpha layer). WARNING: Depending on case, this is
    ## not a good deal. This transformation maybe causes distortions or the size
    ## of image can increase. Images with texts, for example, the result image
-   ## maybe will be distorced. Dark images, for example, the size of result image
+   ## maybe will be distorted. Dark images, for example, the size of result image
    ## maybe will be bigger. You have to evaluate the majority of your use cases
    ## to take a decision about the usage of this conf.
    ## Defaults to: False

--- a/docs/how_to_upload_images.rst
+++ b/docs/how_to_upload_images.rst
@@ -171,7 +171,7 @@ the HTTP **POST** request was send to the server :
     Content-Length: 822
     Slug : photo.jpg
 
-and the Thumbor server should return :
+and the Thumbor server should return:
 
 ::
 
@@ -208,7 +208,7 @@ the HTTP **POST** request was send to the server :
     Content-Type: multipart/form-data; boundary=----------------------------11df125d8b12
     Content-Length: 822
 
-and the Thumbor server should return :
+and the Thumbor server should return:
 
 ::
 
@@ -240,7 +240,7 @@ the HTTP **PUT** request was send to the server :
     Content-Length: 822
     Slug : modified_image.jpg
 
-and the Thumbor server should return :
+and the Thumbor server should return:
 
 ::
 
@@ -265,7 +265,7 @@ the HTTP **DELETE** request was send to the server :
 
     DELETE /image/05b2eda857314e559630c6f3334d818d/modified_image.jpg
 
-and the Thumbor server should return :
+and the Thumbor server should return:
 
 ::
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -87,7 +87,7 @@ https://launchpad.net/~thumbor/+archive/ppa.
 From the source of a stable release
 -----------------------------------
 
-Download the latest stable source-code version here on github or Pypi
+Download the latest stable source-code version here on GitHub or Pypi
 and decompress it.
 
 In the path you decompressed, execute ``pip install .`` or

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -87,7 +87,7 @@ https://launchpad.net/~thumbor/+archive/ppa.
 From the source of a stable release
 -----------------------------------
 
-Download the latest stable source-code version here on GitHub or Pypi
+Download the latest stable source-code version here on GitHub or PyPI
 and decompress it.
 
 In the path you decompressed, execute ``pip install .`` or

--- a/docs/proportion.rst
+++ b/docs/proportion.rst
@@ -6,7 +6,7 @@ Usage: `proportion(percentage)`
 Description
 -----------
 
-This filter applies the specified porportion to the image's height and width when cropping.
+This filter applies the specified proportion to the image's height and width when cropping.
 
 Arguments
 ---------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -44,7 +44,7 @@ If you need to specify the orientation from where to get the pixel
 color, just use ``/trim:top-left`` for the top-left pixel color or
 ``/trim:bottom-right`` for the bottom-right pixel color.
 
-Trim also supports color tolerance. The euclidian distance between the
+Trim also supports color tolerance. The euclidean distance between the
 colors of the reference pixel and the surrounding pixels is used. If the
 distance is within the tolerance they'll get trimmed. For a RGB image
 the tolerance would be within the range 0-442.

--- a/perf/thumbor.conf
+++ b/perf/thumbor.conf
@@ -97,7 +97,7 @@ AUTO_WEBP = True
 ## has no transparency (via alpha layer). WARNING: Depending on case, this is
 ## not a good deal. This transformation maybe causes distortions or the size
 ## of image can increase. Images with texts, for example, the result image
-## maybe will be distorced. Dark images, for example, the size of result image
+## maybe will be distorted. Dark images, for example, the size of result image
 ## maybe will be bigger. You have to evaluate the majority of your use cases
 ## to take a decision about the usage of this conf.
 ## Defaults to: False

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -185,7 +185,7 @@ Config.define(
     "no transparency (via alpha layer). "
     "WARNING: Depending on case, this is not a good deal. "
     "This transformation maybe causes distortions or the size of image can increase. "
-    "Images with texts, for example, the result image maybe will be distorced. "
+    "Images with texts, for example, the result image maybe will be distorted. "
     "Dark images, for example, the size of result image maybe will be bigger. "
     "You have to evaluate the majority of your use cases "
     "to take a decision about the usage of this conf.",

--- a/thumbor/ext/filters/_bounding_box.c
+++ b/thumbor/ext/filters/_bounding_box.c
@@ -96,6 +96,6 @@ _bounding_box_apply(PyObject *self, PyObject *args)
 FILTER_MODULE(_bounding_box,
     "apply(image_mode, width, height, reference_mode, tolerance, buffer) -> (left, top, right, bottom)\n"
     "Calculates the bounding box necessary to trim an image based on the color of "
-    "one of the corners and the euclidian distance between the colors within a "
+    "one of the corners and the euclidean distance between the colors within a "
     "specified tolerance."
 )

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -38,7 +38,7 @@ home = expanduser("~")
 ## Automatically converts PNG to JPG if PNG has no transparency.
 ## WARNING: Depending on case, this is not a good deal. This
 ## transformation maybe causes distortions or the size of image can increase.
-## Images with texts, for example, the result image maybe will be distorced.
+## Images with texts, for example, the result image maybe will be distorted.
 ## Dark images, for example, the size of result image maybe will be bigger.
 ## You have to evaluate the majority of your use cases to take a decision about
 ## this conf.


### PR DESCRIPTION
I made some spelling adjustments

- distorced -> distorted
- github -> GitHub
- porportion -> proportion 
- euclidian -> euclidean 
- Remove space before `:`