### PR TITLE
Add missing runtime dependencies to Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,6 @@ RUN apt-get update && \
         curl \
         gifsicle \
         libcairo2 \
-        libexiv2-27 \
         libjpeg-turbo-progs && \
 	apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,6 @@ FROM python:${PYTHON_VERSION}-slim-bullseye AS runner-image
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         curl \
-        ffmpeg \
         gifsicle \
         libcairo2 \
         libexiv2-27 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,8 +45,11 @@ FROM python:${PYTHON_VERSION}-slim-bullseye AS runner-image
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         curl \
+        ffmpeg \
         gifsicle \
-        libcairo2 && \
+        libcairo2 \
+        libexiv2-27 \
+        libjpeg-turbo-progs && \
 	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home thumbor


### PR DESCRIPTION
This adds dependencies highlighted by `thumbor-doctor` to the Docker image, which allows Thumbor to work better.

Note: There's still a problem reported by `thumbor-doctor` after this:

```
* pyexiv2
    Error Message:
        libboost_python39.so.1.74.0: cannot open shared object file: No such file or directory

    Error Description:
        If you do not need EXIF metadata, you can safely ignore this.
	For more information visit https://python3-exiv2.readthedocs.io/en/latest/.
```

This seems to stem from libboost-python being installed from the Debian archives which is built against Python 3.9 which Debian uses, so doesn't match the Python versions offered by the `python:*` Docker images.

To fix that, we would need to build libboost-python against the Python version in the Docker image at build time.

Also, if all the warnings were fixed, it would be ideal if `thumbor-doctor` was run at image build time so any new issues like these could be raised. That would, however, require `thumbor-doctor` to output a non-zero exit code in case errors were found. I don't assume that would be a very controversial change to make (it could potentially be put behind a flag).