### PR TITLE
Define image format by accept header

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -343,8 +343,15 @@ well as static gifs with the smallest possible size.**
 WARNING: When using gifsicle engine, filters will be skipped, except for `cover()` filter. thumbor
 will not do smart cropping as well.
 
+AUTO_*
+~~~~~~~~~~~~
+
+These configurations indicates that thumbor will try to automatically convert
+the image format to a lighter image format, following a better compression order
+`WEBP -> AVIF -> JPG -> HEIF`.
+
 AUTO\_WEBP
-~~~~~~~~~~
+^^^^^^^^^^
 
 This option indicates whether thumbor should send WebP images
 automatically if the request comes with an "Accept" header that
@@ -354,8 +361,19 @@ specifies that the browser supports "image/webp".
 
    AUTO_WEBP = True
 
+AUTO\_AVIF
+^^^^^^^^^^
+
+This option indicates whether thumbor should send Avif images
+automatically if the request comes with an "Accept" header that
+specifies that the browser supports "image/avif" and pillow-avif-plugin is enabled.
+
+.. code:: python
+
+   AUTO_AVIF = True
+
 AUTO\_PNG\_TO\_JPG
-~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^
 
 This option indicates whether thumbor should transform PNG images
 automatically to JPEG. If the image is a PNG without transparency and
@@ -371,6 +389,28 @@ You have to evaluate the majority of your use cases to take a decision about the
 .. code:: python
 
    AUTO_PNG_TO_JPG = True
+
+AUTO\_JPG
+^^^^^^^^^
+
+This option indicates whether thumbor should send JPG images
+automatically if the request comes with an "Accept" header that
+specifies that the browser supports "*/*", "image/jpg" or "image/jpeg".
+
+.. code:: python
+
+   AUTO_JPG = True
+
+AUTO\_HEIF
+^^^^^^^^^^
+
+This option indicates whether thumbor should send Heif images
+automatically if the request comes with an "Accept" header that
+specifies that the browser supports "image/heif" and pillow-heif is enabled.
+
+.. code:: python
+
+   AUTO_HEIF = True
 
 Queueing - Redis Single Node
 ----------------------------

--- a/tests/handlers/test_base_handler_with_auto_avif.py
+++ b/tests/handlers/test_base_handler_with_auto_avif.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2022 globo.com thumbor@googlegroups.com
+
+from shutil import which
+
+from preggy import expect
+from tornado.testing import gen_test
+
+from tests.handlers.test_base_handler import BaseImagingTestCase
+from thumbor.config import Config
+from thumbor.context import Context, ServerParameters
+from thumbor.importer import Importer
+
+# pylint: disable=broad-except,abstract-method,attribute-defined-outside-init,line-too-long,too-many-public-methods
+# pylint: disable=too-many-lines
+
+MIMETYPE = "image/avif"
+
+
+class ImageOperationsWithAutoAvifTestCase(BaseImagingTestCase):
+    def get_context(self):
+        cfg = Config(SECURITY_KEY="ACME-SEC")
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = self.loader_path
+        cfg.STORAGE = "thumbor.storages.no_storage"
+        cfg.AUTO_AVIF = True
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(
+            8889, "localhost", "thumbor.conf", None, "info", None
+        )
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, cfg, importer)
+        ctx.server.gifsicle_path = which("gifsicle")
+        return ctx
+
+    async def get_as_avif(self, url):
+        return await self.async_fetch(
+            url, headers={"Accept": f"{MIMETYPE},*/*;q=0.8"}
+        )
+
+    @gen_test
+    async def test_can_auto_convert_jpeg_to_avif(self):
+        response = await self.get_as_avif("/unsafe/image.jpg")
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_avif()
+
+    @gen_test
+    async def test_can_auto_convert_heic_to_avif(self):
+        response = await self.get_as_avif("/unsafe/image.heic")
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_avif()
+
+    @gen_test
+    async def test_should_not_convert_animated_gifs_to_avif(self):
+        response = await self.get_as_avif("/unsafe/animated.gif")
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_should_convert_image_with_small_width_and_no_height_to_avif(
+        self,
+    ):
+        response = await self.get_as_avif("/unsafe/0x0:1681x596/1x/image.jpg")
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_avif()
+
+    @gen_test
+    async def test_should_convert_monochromatic_jpeg_to_avif(self):
+        response = await self.get_as_avif("/unsafe/grayscale.jpg")
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_avif()
+
+    @gen_test
+    async def test_should_convert_cmyk_jpeg_to_avif(self):
+        response = await self.get_as_avif("/unsafe/cmyk.jpg")
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_avif()
+
+    @gen_test
+    async def test_shouldnt_convert_to_cmyk_to_avif_if_format_specified(self):
+        response = await self.get_as_avif(
+            "/unsafe/filters:format(png)/cmyk.jpg"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_png()
+
+    @gen_test
+    async def test_shouldnt_convert_cmyk_to_avif_if_gif(self):
+        response = await self.get_as_avif(
+            "/unsafe/filters:format(gif)/cmyk.jpg"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_shouldnt_convert_gif_to_avif_if_format_specified(self):
+        response = await self.get_as_avif(
+            "/unsafe/filters:format(gif)/image.jpg"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_should_convert_to_avif_if_format_invalid(self):
+        response = await self.get_as_avif(
+            "/unsafe/filters:format(asdf)/image.jpg"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_avif()

--- a/tests/handlers/test_base_handler_with_auto_heif.py
+++ b/tests/handlers/test_base_handler_with_auto_heif.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2022 globo.com thumbor@googlegroups.com
+
+from shutil import which
+
+from preggy import expect
+from tornado.testing import gen_test
+
+from tests.handlers.test_base_handler import BaseImagingTestCase
+from thumbor.config import Config
+from thumbor.context import Context, ServerParameters
+from thumbor.importer import Importer
+
+# pylint: disable=broad-except,abstract-method,attribute-defined-outside-init,line-too-long,too-many-public-methods
+# pylint: disable=too-many-lines
+
+MIMETYPE = "image/heif"
+
+
+class ImageOperationsWithAutoHeifTestCase(BaseImagingTestCase):
+    def get_context(self):
+        cfg = Config(SECURITY_KEY="ACME-SEC")
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = self.loader_path
+        cfg.STORAGE = "thumbor.storages.no_storage"
+        cfg.AUTO_HEIF = True
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(
+            8889, "localhost", "thumbor.conf", None, "info", None
+        )
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, cfg, importer)
+        ctx.server.gifsicle_path = which("gifsicle")
+        return ctx
+
+    async def get_as_heif(self, url):
+        return await self.async_fetch(
+            url, headers={"Accept": f"{MIMETYPE},*/*;q=0.8"}
+        )
+
+    @gen_test
+    async def test_can_auto_convert_jpeg_to_heif(self):
+        response = await self.get_as_heif("/unsafe/image.jpg")
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_heif()
+
+    @gen_test
+    async def test_can_auto_convert_avif_to_heif(self):
+        response = await self.get_as_heif("/unsafe/image.avif")
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_heif()
+
+    @gen_test
+    async def test_should_not_convert_animated_gifs_to_heif(self):
+        response = await self.get_as_heif("/unsafe/animated.gif")
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_should_convert_image_with_small_width_and_no_height_to_heif(
+        self,
+    ):
+        response = await self.get_as_heif("/unsafe/0x0:1681x596/1x/image.jpg")
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_heif()
+
+    @gen_test
+    async def test_should_convert_monochromatic_jpeg_to_heif(self):
+        response = await self.get_as_heif("/unsafe/grayscale.jpg")
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_heif()
+
+    @gen_test
+    async def test_should_convert_cmyk_jpeg_to_heif(self):
+        response = await self.get_as_heif("/unsafe/cmyk.jpg")
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_heif()
+
+    @gen_test
+    async def test_shouldnt_convert_to_cmyk_to_heif_if_format_specified(self):
+        response = await self.get_as_heif(
+            "/unsafe/filters:format(png)/cmyk.jpg"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_png()
+
+    @gen_test
+    async def test_shouldnt_convert_cmyk_to_heif_if_gif(self):
+        response = await self.get_as_heif(
+            "/unsafe/filters:format(gif)/cmyk.jpg"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_shouldnt_convert_gif_to_heif_if_format_specified(self):
+        response = await self.get_as_heif(
+            "/unsafe/filters:format(gif)/image.jpg"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_should_convert_to_heif_if_format_invalid(self):
+        response = await self.get_as_heif(
+            "/unsafe/filters:format(asdf)/image.jpg"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.body).to_be_heif()

--- a/tests/handlers/test_base_handler_with_auto_jpg.py
+++ b/tests/handlers/test_base_handler_with_auto_jpg.py
@@ -1,0 +1,328 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2022 globo.com thumbor@googlegroups.com
+
+from shutil import which
+
+from preggy import expect
+from tornado.testing import gen_test
+
+from tests.handlers.test_base_handler import BaseImagingTestCase
+from thumbor.config import Config
+from thumbor.context import Context, ServerParameters
+from thumbor.importer import Importer
+
+# pylint: disable=broad-except,abstract-method,attribute-defined-outside-init,line-too-long,too-many-public-methods
+# pylint: disable=too-many-lines
+
+MIMETYPE_ALL = "*/*"
+MIMETYPE_JPG = "image/jpg"
+MIMETYPE_JPEG = "image/jpeg"
+
+
+class ImageOperationsWithAutoJpgTestCase(BaseImagingTestCase):
+    def get_context(self):
+        cfg = Config(SECURITY_KEY="ACME-SEC")
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = self.loader_path
+        cfg.STORAGE = "thumbor.storages.no_storage"
+        cfg.AUTO_JPG = True
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(
+            8889, "localhost", "thumbor.conf", None, "info", None
+        )
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, cfg, importer)
+        ctx.server.gifsicle_path = which("gifsicle")
+        return ctx
+
+    async def get_as_jpg(self, url, mimetype):
+        return await self.async_fetch(
+            url, headers={"Accept": f"{mimetype};q=0.8"}
+        )
+
+    @gen_test
+    async def test_can_auto_convert_avif_to_jpg_with_accept_all(self):
+        response = await self.get_as_jpg("/unsafe/image.avif", MIMETYPE_ALL)
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_can_auto_convert_avif_to_jpg_with_accept_jpg(self):
+        response = await self.get_as_jpg("/unsafe/image.avif", MIMETYPE_JPG)
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_can_auto_convert_avif_to_jpg_with_accept_jpeg(self):
+        response = await self.get_as_jpg("/unsafe/image.avif", MIMETYPE_JPEG)
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_can_auto_convert_heic_to_jpg_with_accept_all(self):
+        response = await self.get_as_jpg("/unsafe/image.heic", MIMETYPE_ALL)
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_can_auto_convert_heic_to_jpg_with_accept_jpg(self):
+        response = await self.get_as_jpg("/unsafe/image.heic", MIMETYPE_JPG)
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_can_auto_convert_heic_to_jpg_with_accept_jpeg(self):
+        response = await self.get_as_jpg("/unsafe/image.heic", MIMETYPE_JPEG)
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_not_convert_animated_gifs_to_jpg_with_accept_all(
+        self,
+    ):
+        response = await self.get_as_jpg("/unsafe/animated.gif", MIMETYPE_ALL)
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_should_not_convert_animated_gifs_to_jpg_with_accept_jpg(
+        self,
+    ):
+        response = await self.get_as_jpg("/unsafe/animated.gif", MIMETYPE_JPG)
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_should_not_convert_animated_gifs_to_jpg_with_accept_jpeg(
+        self,
+    ):
+        response = await self.get_as_jpg("/unsafe/animated.gif", MIMETYPE_JPEG)
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_should_convert_image_with_small_width_and_no_height_to_jpg_with_accept_all(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/0x0:1681x596/1x/image.jpg", MIMETYPE_ALL
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_convert_image_with_small_width_and_no_height_to_jpg_with_accept_jpg(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/0x0:1681x596/1x/image.jpg", MIMETYPE_JPG
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_convert_image_with_small_width_and_no_height_to_jpg_with_accept_jpeg(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/0x0:1681x596/1x/image.jpg", MIMETYPE_JPEG
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_convert_monochromatic_jpeg_to_jpg_with_accept_all(
+        self,
+    ):
+        response = await self.get_as_jpg("/unsafe/grayscale.jpg", MIMETYPE_ALL)
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_convert_monochromatic_jpeg_to_jpg_with_accept_jpg(
+        self,
+    ):
+        response = await self.get_as_jpg("/unsafe/grayscale.jpg", MIMETYPE_JPG)
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_convert_monochromatic_jpeg_to_jpg_with_accept_jpeg(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/grayscale.jpg", MIMETYPE_JPEG
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_convert_cmyk_jpeg_to_jpg_with_accept_all(self):
+        response = await self.get_as_jpg("/unsafe/cmyk.jpg", MIMETYPE_ALL)
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_convert_cmyk_jpeg_to_jpg_with_accept_jpg(self):
+        response = await self.get_as_jpg("/unsafe/cmyk.jpg", MIMETYPE_JPG)
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_convert_cmyk_jpeg_to_jpg_with_accept_jpeg(self):
+        response = await self.get_as_jpg("/unsafe/cmyk.jpg", MIMETYPE_JPEG)
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_shouldnt_convert_to_cmyk_to_jpg_if_format_specified_with_accept_all(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(png)/cmyk.jpg", MIMETYPE_ALL
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_png()
+
+    @gen_test
+    async def test_shouldnt_convert_to_cmyk_to_jpg_if_format_specified_with_accept_jpg(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(png)/cmyk.jpg", MIMETYPE_JPG
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_png()
+
+    @gen_test
+    async def test_shouldnt_convert_to_cmyk_to_jpg_if_format_specified_with_accept_jpeg(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(png)/cmyk.jpg", MIMETYPE_JPEG
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_png()
+
+    @gen_test
+    async def test_shouldnt_convert_cmyk_to_jpg_if_gif_with_accept_all(self):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(gif)/cmyk.jpg", MIMETYPE_ALL
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_shouldnt_convert_cmyk_to_jpg_if_gif_with_accept_jpg(self):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(gif)/cmyk.jpg", MIMETYPE_JPG
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_shouldnt_convert_cmyk_to_jpg_if_gif_with_accept_jpeg(self):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(gif)/cmyk.jpg", MIMETYPE_JPEG
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_shouldnt_convert_gif_to_jpg_if_format_specified_with_accept_all(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(gif)/image.jpg", MIMETYPE_ALL
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_shouldnt_convert_gif_to_jpg_if_format_specified_with_accept_jpg(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(gif)/image.jpg", MIMETYPE_JPG
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_shouldnt_convert_gif_to_jpg_if_format_specified_with_accept_jpeg(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(gif)/image.jpg", MIMETYPE_JPEG
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_gif()
+
+    @gen_test
+    async def test_should_convert_to_jpg_if_format_invalid_with_accept_all(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(asdf)/image.jpg", MIMETYPE_ALL
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_convert_to_jpg_if_format_invalid_with_accept_jpg(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(asdf)/image.jpg", MIMETYPE_JPG
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_convert_to_jpg_if_format_invalid_with_accept_jpeg(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:format(asdf)/image.jpg", MIMETYPE_JPEG
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
+        expect(response.body).to_be_jpeg()

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -187,6 +187,27 @@ Config.define(
     "Imaging",
 )
 Config.define(
+    "AUTO_AVIF",
+    False,
+    "Specifies whether Avif format should be used automatically if the request accepts it "
+    "(via Accept header) and pillow-avif-plugin is enabled",
+    "Imaging",
+)
+Config.define(
+    "AUTO_JPG",
+    False,
+    "Specifies whether JPG format should be used automatically if the request accepts it "
+    "(via Accept header)",
+    "Imaging",
+)
+Config.define(
+    "AUTO_HEIF",
+    False,
+    "Specifies whether Heif format should be used automatically if the request accepts it "
+    "(via Accept header) and pillow-heif is enabled",
+    "Imaging",
+)
+Config.define(
     "AUTO_PNG_TO_JPG",
     False,
     "Specifies whether a PNG image should be used automatically if the png image has "

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -237,12 +237,15 @@ class RequestParameters:  # pylint: disable=too-few-public-methods,too-many-inst
         self.max_bytes = None
         self.max_age = max_age
         self.auto_png_to_jpg = auto_png_to_jpg
+        self.headers = None
 
         if request:
             self.url = request.path
             self.accepts_webp = "image/webp" in request.headers.get(
                 "Accept", ""
             )
+            if request.headers:
+                self.headers = request.headers
 
     @staticmethod
     def int_or_0(value):

--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -409,6 +409,12 @@ class BaseEngine:
     def has_transparency(self):
         raise NotImplementedError()
 
+    def avif_enabled(self):
+        raise NotImplementedError()
+
+    def heif_enabled(self):
+        raise NotImplementedError()
+
     def cleanup(self):
         pass
 
@@ -416,3 +422,9 @@ class BaseEngine:
         can_convert = self.extension == ".png" and not self.has_transparency()
 
         return can_convert
+
+    def can_auto_convert_to_avif(self):
+        return self.avif_enabled()
+
+    def can_auto_convert_to_heif(self):
+        return self.heif_enabled()

--- a/thumbor/engines/json_engine.py
+++ b/thumbor/engines/json_engine.py
@@ -123,6 +123,12 @@ class JSONEngine(BaseEngine):
     def has_transparency(self):
         return self.engine.has_transparency()
 
+    def avif_enabled(self):
+        return self.engine.avif_enabled()
+
+    def heif_enabled(self):
+        return self.engine.heif_enabled()
+
     def can_auto_convert_png_to_jpg(self):
         can_convert = super().can_auto_convert_png_to_jpg()
         if can_convert:

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -528,6 +528,12 @@ class Engine(BaseEngine):
 
         return has_transparency
 
+    def avif_enabled(self):
+        return HAVE_AVIF
+
+    def heif_enabled(self):
+        return HAVE_HEIF
+
     def paste(self, other_engine, pos, merge=True):
         if merge and not FILTERS_AVAILABLE:
             raise RuntimeError(

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -35,6 +35,17 @@ home = expanduser("~")
 ## Automatically converts images to WebP if Accepts header present
 # AUTO_WEBP = False
 
+## Automatically converts images to JPG if Accepts header present
+# AUTO_JPG = False
+
+## Automatically converts images to Avif if Accepts header present and
+## pillow-avif-plugin is enabled
+# AUTO_AVIF = False
+
+## Automatically converts images to Heif if Accepts header present and
+## pillow-heif is enabled
+# AUTO_HEIF = False
+
 ## Automatically converts PNG to JPG if PNG has no transparency.
 ## WARNING: Depending on case, this is not a good deal. This
 ## transformation maybe causes distortions or the size of image can increase.


### PR DESCRIPTION
## Motivation

Thumbor should consider the accept header to define image format, and sometimes the response should be “downgraded” to a supported image format.

## Solution

This PR adds three settings to define the image format based on the accept header.

- `AUTO_JPG`: Specifies whether JPG format should be used automatically if the request accepts it (via Accept header)

- `AUTO_AVIF`: Specifies whether Avif format should be used automatically if the request accepts it (via Accept header) and pillow-avif-plugin is enabled

- `AUTO_HEIF`: Specifies whether Heif format should be used automatically if the request accepts it (via Accept header) and pillow-heif is enabled.

closes https://github.com/thumbor/thumbor/issues/1504