### PR TITLE
Revert "fix(engines): Try to import piexif and use it when available …

### DIFF
--- a/tests/engines/test_base_engine.py
+++ b/tests/engines/test_base_engine.py
@@ -315,18 +315,3 @@ class BaseEngineTestCase(TestCase):
         expect(self.image).to_equal(((1, 2), (3, 4)))
 
         expect(self.engine.get_orientation()).to_equal(1)
-
-    @mock.patch("thumbor.engines.piexif")
-    def test_load_loads_exif_when_a_module_is_available(self, mock_piexif):
-        self.engine.create_image = mock.MagicMock()
-        self.engine.exif = "wow metadata"
-        self.engine.load(None, ".jpg")
-        expect(mock_piexif.load.called).to_be_true()
-
-    @mock.patch("thumbor.engines.piexif", new=None)
-    @mock.patch("thumbor.engines.logger.error")
-    def test_load_with_no_exif_module_should_not_err(self, mock_log_error):
-        self.engine.create_image = mock.MagicMock()
-        self.engine.exif = "wow metadata"
-        self.engine.load(None, ".jpg")
-        expect(mock_log_error.called).to_be_false()

--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -13,6 +13,7 @@
 
 import re
 from xml.etree.ElementTree import ParseError
+import piexif
 
 from thumbor.engines.extensions.exif_orientation_editor import (
     ExifOrientationEditor,
@@ -23,11 +24,6 @@ try:
     import cairosvg
 except ImportError:
     cairosvg = None
-
-try:
-    import piexif
-except ImportError:
-    piexif = None
 
 
 WEBP_SIDE_LIMIT = 16383
@@ -205,7 +201,7 @@ class BaseEngine:
             return
 
         try:
-            if piexif and getattr(self, "exif", None):
+            if getattr(self, "exif", None):
                 self.metadata = piexif.load(self.exif)
         except Exception as error:  # pylint: disable=broad-except
             logger.error("Error reading image metadata: %s", error)


### PR DESCRIPTION
As discussed in https://github.com/thumbor/thumbor/pull/1507 we reverted the #1524 commit, since the import of pyexif lib verification is no longer required. 