### PR TITLE
docs(thumbor): Link directly to 7.0.0 release notes for migration guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ more details)::
 .. warning::
     Release 7.0.0 introduces a major breaking change due to the migration to python 3
     and the modernization of our codebase. Please read the
-    `release notes <https://github.com/thumbor/thumbor/releases>`_
+    `release notes <https://github.com/thumbor/thumbor/releases/tag/7.0.0>`_
     for details on how to upgrade.
 
 Contents


### PR DESCRIPTION
The previous link is to the releases page, so requires a bit of hunting to find the actual migration guide. This PR links directly to the release (7.0.0) which lists the main breaking changes for Thumbor 7 and how to migrate.