### PR TITLE
fix: auto convert image with transparency

### DIFF
--- a/tests/handlers/test_base_handler_with_auto_jpg.py
+++ b/tests/handlers/test_base_handler_with_auto_jpg.py
@@ -326,3 +326,14 @@ class ImageOperationsWithAutoJpgTestCase(BaseImagingTestCase):
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
         expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_should_not_convert_to_jpg_if_image_has_transparency_with_accept_jpeg(
+        self,
+    ):
+        response = await self.get_as_jpg(
+            "/unsafe/paletted-transparent.png", MIMETYPE_JPEG
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers["Content-type"]).to_equal("image/png")
+        expect(response.body).to_be_png()

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -444,14 +444,17 @@ class BaseHandler(tornado.web.RequestHandler):
 
     def can_auto_convert_to_jpg(self):
         auto_jpg = self.context.config.AUTO_JPG
-        accepts_all = self.accepts_mime_type("*/*")
-        accepts_jpg = self.accepts_mime_type("image/jpg")
-        accepts_jpeg = self.accepts_mime_type("image/jpeg")
+        accepts_jpg = (
+            self.accepts_mime_type("*/*")
+            or self.accepts_mime_type("image/jpg")
+            or self.accepts_mime_type("image/jpeg")
+        )
 
         if (
             auto_jpg
-            and (accepts_all or accepts_jpg or accepts_jpeg)
+            and accepts_jpg
             and not self.context.request.engine.is_multiple()
+            and not self.context.request.engine.has_transparency()
         ):
             return True
 


### PR DESCRIPTION
# Motivation

Thumbor shouldn't convert images with transparency to jpeg format.

# Solution 

Was added a verification if image has transparency.

ps: Was tested with others formarts (`image/avif`, `image/heif` and `image/webp`) and this problem doesn't happened.

# Issue

closes https://github.com/thumbor/thumbor/issues/1540