### PR TITLE
Thumbor should send error to error handler

### DIFF
--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -642,6 +642,13 @@ class BaseHandler(tornado.web.RequestHandler):
             logger.exception("[BaseHander.finish_request] %s", error)
             self._error(500, f"Error while trying to fetch the image: {error}")
 
+            if self.context.config.USE_CUSTOM_ERROR_HANDLING:
+                self.context.modules.importer.error_handler.handle_error(
+                    context=self.context,
+                    handler=self.context.request_handler,
+                    exception=sys.exc_info(),
+                )
+
             return
 
         (results, content_type) = result


### PR DESCRIPTION
## Motivation

The loading results func is one of the most importants funcs in Thumbor, and we should handle errors that happens inside this func. Thumbor should send errors to error handler when loading results. 

## Problem

When Thumbor handle error with try/except, the error handler (sentry) can't capture event

## Solution

This PR sends error to custom error handler when is enabled

ps: was tested the first solution in issue, but will log the same exception 3 times, so because of that we choose the solution 2

closes https://github.com/thumbor/thumbor/issues/1543