### PR TITLE
Refactor code blocks for increased readability

### DIFF
--- a/tests/fixtures/transformer_test_data.py
+++ b/tests/fixtures/transformer_test_data.py
@@ -76,7 +76,7 @@ class MockSyncDetector(BaseDetector):
 
 class MockErrorSyncDetector(BaseDetector):
     async def detect(self):
-        raise Exception("x")  # pylint: disable=broad-exception-raised
+        raise IOError("some-io-error")
 
 
 # Test Data - pylint: disable=too-many-locals,too-many-instance-attributes

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -153,7 +153,7 @@ class TransformerTestCase(TestCase):
         )
         trans = Transformer(context)
 
-        with expect.error_to_happen(Exception, message="x"):
+        with expect.error_to_happen(IOError, message="some-io-error"):
             await trans.transform()
 
         expect(test_data.engine.calls["resize"]).to_length(0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,6 +112,15 @@ def test_get_color_space_handles_invalid_icc():
     assert result is None
 
 
+@mock.patch("thumbor.utils.ImageCms.ImageCmsProfile")
+def test_get_color_space_handles_null_xcolor_space(image_cms_profile_mock):
+    image_cms_profile_mock.return_value.profile.xcolor_space = None
+    img = Image.new("RGB", (50, 50), "white")
+    img.info["icc_profile"] = b"wow icc profile with null xcolor_space"
+    result = get_color_space(img)
+    assert result is None
+
+
 def test_get_color_space_missing_imagecms_returns_none():
     with mock.patch("thumbor.utils.ImageCms", new=None):
         img = Image.open("tests/fixtures/images/cmyk-icc.jpg")

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -944,13 +944,7 @@ def format_value(value):
     if isinstance(value, str):
         return f"'{value}'"
     if isinstance(value, (tuple, list, set)):
-        representation = "[\n"
-        for item in value:
-            representation += (  # pylint: disable=consider-using-join
-                f"#    {item}"
-            )
-        representation += "#]"
-        return representation
+        return "[\n" + "".join(f"#    {item}" for item in value) + "#]"
     return value
 
 


### PR DESCRIPTION
Refactor code blocks for increased readability

Cues from pylint. Issues solved are as follows:

```
************* Module thumbor.config
thumbor/config.py:914:12: R1713: Consider using str.join(sequence) for concatenating strings from an iterable (consider-using-join)
************* Module thumbor.utils
thumbor/utils.py:92:4: R1705: Unnecessary "else" after "return", remove the "else" and de-indent the code inside it (no-else-return)
************* Module tests.fixtures.transformer_test_data
tests/fixtures/transformer_test_data.py:79:8: W0719: Raising too general exception: Exception (broad-exception-raised)
```

This CL also fixes a code duplication issue in thumbor/utils.py