### PR TITLE
feature(engines): Pillow Preserve iptc info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,7 @@ def run_setup(extension_modules=None):
             "tornado==6.*,>=6.0.3",
             "thumbor-plugins-gifv==0.*,>=0.1.2",
             "webcolors==1.*,>=1.10.0",
+            "JpegIPTC>=1.4",
         ],
         extras_require={
             "all": ALL_REQUIREMENTS,

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -279,7 +279,7 @@ Config.define(
 Config.define(
     "PRESERVE_IPTC_INFO",
     False,
-    "Preserves Jpeg IPTC information in generated images. (fetch data from original file and add it back to thumbor output)",
+    "Preserves Jpeg IPTC information in generated images.",
     "Imaging",
 )
 

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -279,7 +279,7 @@ Config.define(
 Config.define(
     "PRESERVE_IPTC_INFO",
     False,
-    "Preserves Jpeg IPTC information in generated images.",
+    "Preserves Jpeg IPTC information in generated images. (fetch data from original file and add it back to thumbor output)",
     "Imaging",
 )
 

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -277,6 +277,13 @@ Config.define(
 )
 
 Config.define(
+    "PRESERVE_IPTC_INFO",
+    False,
+    "Preserves Jpeg IPTC information in generated images.",
+    "Imaging",
+)
+
+Config.define(
     "ALLOW_ANIMATED_GIFS",
     True,
     "Indicates whether thumbor should enable the EXPERIMENTAL support for animated gifs.",

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -21,6 +21,7 @@ from thumbor.engines import BaseEngine
 from thumbor.engines.extensions.pil import GifWriter
 from thumbor.filters.fill import Filter
 from thumbor.utils import deprecated, ensure_srgb, get_color_space, logger
+from JpegIPTC import JpegIPTC
 
 try:
     from thumbor.ext.filters import _composite
@@ -80,6 +81,7 @@ class Engine(BaseEngine):
         self.qtables = None
         self.original_mode = None
         self.exif = None
+        self.iptc = None
 
         try:
             if self.context.config.MAX_PIXELS is None or int(
@@ -112,6 +114,11 @@ class Engine(BaseEngine):
         self.icc_profile = img.info.get("icc_profile")
         self.exif = img.info.get("exif")
         self.original_mode = img.mode
+
+        if self.context.config.PRESERVE_IPTC_INFO:
+            jpegiptc_object = JpegIPTC()
+            jpegiptc_object.load_from_binarydata(buffer)
+            self.iptc = jpegiptc_object.get_raw_iptc()
 
         if hasattr(img, "layer"):
             self.subsampling = JpegImagePlugin.get_sampling(img)
@@ -433,6 +440,14 @@ class Engine(BaseEngine):
         results = img_buffer.getvalue()
         img_buffer.close()
         self.extension = ext
+
+        if self.context.config.PRESERVE_IPTC_INFO:
+            jpegiptc_object_d = JpegIPTC()
+            jpegiptc_object_d.load_from_binarydata(results)
+            jpegiptc_object_d.set_raw_iptc(self.iptc)
+            newresults = jpegiptc_object_d.dump()
+            if newresults is not None:
+                results = newresults
 
         return results
 

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -14,6 +14,7 @@ from subprocess import PIPE, Popen
 from tempfile import mkstemp
 
 import piexif
+from JpegIPTC import JpegIPTC
 from PIL import Image, ImageDraw, ImageFile, ImageSequence, JpegImagePlugin
 from PIL import features as pillow_features
 
@@ -21,7 +22,6 @@ from thumbor.engines import BaseEngine
 from thumbor.engines.extensions.pil import GifWriter
 from thumbor.filters.fill import Filter
 from thumbor.utils import deprecated, ensure_srgb, get_color_space, logger
-from JpegIPTC import JpegIPTC
 
 try:
     from thumbor.ext.filters import _composite


### PR DESCRIPTION
## Thumbor :
First, I want to thank everyone who works on this project: thumbor is a good software ! we love it !

## Context :
related with issue : https://github.com/thumbor/thumbor/issues/1301

In Europe, image copyright is protected by various laws and regulations, such as the Berne Convention for the Protection of Literary and Artistic Works and the Directive on the harmonization of certain aspects of copyright and related rights in the information society. These laws provide creators with exclusive rights over their works, including photographs and images, and require that any use of these works by others be authorized or licensed by the creator.

The use of JPEG IPTC tags can be particularly helpful in enforcing these copyright laws. **In fact, some countries in Europe, such as France and Germany, have enacted specific laws that require the use of IPTC tags on certain types of images, such as those used in advertising and editorial content**. These laws require that the copyright owner's name and contact information be included in the IPTC tags, making it easier for potential infringers to identify and contact the owner for permission to use the image.

## Solution :
I know that there is no pillow native solution to fetch iptc metadata.
I know that i can use thumbor_wand_engine to preserve those informations.
But, for some personal reasons, i need to stay on Pillow engine.

First, i try to add/write an "optimizer" to do the job but we can't access to the original image.
The best place for performance is to do the job inside the "thumbor pil engine" ( thumbor/engines/pil.py )
I tried a first proof of concept using iptcinfo3 : https://github.com/james-see/iptcinfo3
a simple patch into "create_image" function to save iptc data
another simple patch at the end of the "read" function to restore/rewrite saved iptc data
This solution works but :
- ipctinfo3 don't preserve all iptc records ( iptc envelop is lost )
- ipctinfo3 is "slow" : blindscan over all files (not jpeg only)
- iptcinfo3 read and decode iptc metada and save it to _dict object : need to be reencoded on write result.
- ipctinfo3 input/ouput is file or bytesio : that's not optimal for thumbor integration
- iptcinfo3 logging is "too much" verbose

conclusion, it was not "production" ready.

So, i write "JpegIPTC" : https://pypi.org/project/JpegIPTC : (based on iptcinfo3 but more simple : we work with raw data / not enable to decode/encode it)
it take an image on input : if file is a regular jpeg file, scan to find iptc segment data (raw) and save it. Then we can restore this raw segment to another jpeg file to create/overwrite iptc data.
JpegIPTC fetch record 1 & 2 from IPTC meta data.

## PR
	modified:   setup.py
	modified:   thumbor/config.py
	modified:   thumbor/engines/pil.py

new "require" @ setup.py
new config flag @ thumbor/config.py
patch @ thumbor/engines/pil.py

I can understand that you don't want to add a new "requirement" to thumbor : 
if this feature request should be rejected, i prepared a dedicated engine with this feature : [thumbor-piliptc-engine](https://github.com/gdegoulet/thumbor-piliptc-engine).

waiting for PR integration on the next release of thumbor ;)
Thanks for reading

## Example ( using libiptcdata-bin: /usr/bin/iptc )
```
rm -f test.jpg
wget -O test.jpg "http://localhost:8901/unsafe/filters:quality(60)/i.f1g.fr/media/cms/509x286_crop/2022/11/21/76bde3fc961f0fa8733756922d1e2ed06311d804ec38b89dc60d6ba36d30e046.jpg"

iptc test.jpg | head
test.jpg:
 Tag      Name                 Type      Size  Value
 -------- -------------------- --------- ----  -----
 1:000    Model Version        Short        2  2
 1:020    File Format          Short        2  1
 1:022    File Version         Short        2  2
 1:030    Service Identifier   String       9  AFP-PHOTO
 1:040    Envelope Number      NumString    8  12345678
 1:060    Envelope Priority    NumString    1  5
 1:070    Date Sent            Date         8  20221120
```

