### PR TITLE
Replace CurlError with HTTPClientError

### DIFF
--- a/tests/loaders/test_http_loader.py
+++ b/tests/loaders/test_http_loader.py
@@ -206,6 +206,19 @@ class HttpLoaderTestCase(DummyAsyncHttpClientTestCase):
         expect(result.successful).to_be_true()
 
     @gen_test
+    async def test_load_not_found(self):
+        url = self.get_url("/not-found.jpg")
+        config = Config()
+        config.HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT = False
+        ctx = Context(None, config, None)
+
+        result = await loader.load(ctx, url)
+        expect(result).to_be_instance_of(LoaderResult)
+        expect(result.buffer).to_be_null()
+        expect(result.successful).to_be_false()
+        expect(result.error).to_equal(LoaderResult.ERROR_NOT_FOUND)
+
+    @gen_test
     async def test_load_with_utf8_url(self):
         url = self.get_url(quote("/maracujá.jpg".encode("utf-8")))
         config = Config()
@@ -336,6 +349,27 @@ class HttpLoaderWithUserAgentForwardingTestCase(DummyAsyncHttpClientTestCase):
         result = await loader.load(ctx, url)
         expect(result).to_be_instance_of(LoaderResult)
         expect(result.buffer).to_equal("DEFAULT_USER_AGENT")
+
+
+class HttpCurlNotFoundLoaderTestCase(DummyAsyncHttpClientTestCase):
+    def get_app(self):
+        application = tornado.web.Application([(r"/", TimeoutHandler)])
+
+        return application
+
+    @gen_test
+    async def test_load_not_found(self):
+        url = self.get_url("/not-found.jpg")
+        config = Config()
+        config.HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT = True
+        config.HTTP_LOADER_REQUEST_TIMEOUT = 1
+        ctx = Context(None, config, None)
+
+        result = await loader.load(ctx, url)
+        expect(result).to_be_instance_of(LoaderResult)
+        expect(result.buffer).to_be_null()
+        expect(result.successful).to_be_false()
+        expect(result.error).to_equal(LoaderResult.ERROR_NOT_FOUND)
 
 
 class HttpCurlTimeoutLoaderTestCase(DummyAsyncHttpClientTestCase):

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -143,11 +143,9 @@ async def load(
             "tornado.curl_httpclient.CurlAsyncHTTPClient"
         )
         prepare_curl_callback = _get_prepare_curl_callback(context.config)
-        exc_type = tornado.curl_httpclient.CurlError
     else:
         http_client_implementation = None  # default
         prepare_curl_callback = None
-        exc_type = tornado.httpclient.HTTPClientError
 
     tornado.httpclient.AsyncHTTPClient.configure(
         http_client_implementation,
@@ -200,7 +198,7 @@ async def load(
     start = datetime.datetime.now()
     try:
         response = await client.fetch(req, raise_error=True)
-    except exc_type as err:
+    except tornado.httpclient.HTTPClientError as err:
         response = tornado.httpclient.HTTPResponse(
             req, err.code, reason=err.message, start_time=start
         )


### PR DESCRIPTION
The following error:

```python
2023-06-19 19:27:42 thumbor:ERROR ERROR: Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/thumbor/handlers/__init__.py", line 212, in get_image
    result = await self._fetch(self.context.request.image_url)
  File "/usr/local/lib/python3.9/dist-packages/thumbor/handlers/__init__.py", line 884, in _fetch
    loader_result = await self.context.modules.loader.load(
  File "/usr/local/lib/python3.9/dist-packages/thumbor/loaders/http_loader.py", line 202, in load
    response = await client.fetch(req, raise_error=True)
tornado.httpclient.HTTPClientError: HTTP 404: Not Found
```

Happens because `HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT` is `True` and the upstream host returned a 404 status error.

The type of `exc_type` is `tornado.httpclient.HTTPClientError` and not the expected `tornado.curl_httpclient.CurlError`. (`CurlError` is an [extension](https://github.com/tornadoweb/tornado/blob/v6.3.2/tornado/curl_httpclient.py#L576) of `HTTPError`)

