### PR TITLE
docs: Add a v2 .readthedocs.yaml config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build docs in PDF and ePub formats
+formats:
+  - pdf
+  - epub
+
+# Specify Python requirements
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
Read the Docs will start requiring a .readthedocs.yaml configuration file for all projects in order to build documentation successfully.

For more information, read the blog post available at https://blog.readthedocs.com/migrate-configuration-v2/