### PR TITLE
Drop python 3.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,45 +6,11 @@ orbs:
 workflows:
   ci:
       jobs:
-        - build-and-test-python37
         - build-and-test-python38
         - build-and-test-python39
         - build-and-test-python310
 
 jobs:
-  build-and-test-python37:
-    working_directory: /app
-    docker:
-      - image: thumbororg/thumbor-test:37
-    steps:
-      - checkout
-      - run:
-          name: Update dependencies
-          command: make setup
-      - run:
-          name: Compile Extensions
-          command: make compile_ext
-      - run:
-          name: Redis
-          command: make redis
-      - run:
-          name: Run Unit Tests
-          command: make sequential-unit
-      - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
-          path: test-results
-      - store_artifacts: # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
-          path: test-results
-          destination: tr1
-      - run:
-          name: Run Integration Tests
-          command: env ASYNC_TEST_TIMEOUT=30 make integration_run
-      - run:
-          name: Lint
-          command: make flake pylint
-      - run:
-          name: Coverage
-          command: env COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN coveralls
-
   build-and-test-python38:
     working_directory: /app
     docker:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         image-tag:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Other than that, we seriously advise you to use
 your environment clean of thumbor's dependencies and you can choose when
 to "turn them on".
 
-The project requires Python 3.7+, and in this version virtualenv is already installed by default, to create a virtual environment follow the next steps:
+The project requires Python 3.8+, and in this version virtualenv is already installed by default, to create a virtual environment follow the next steps:
 
 
 1. Create a virtual environment, in the folder .venv, located in the user's home folder

--- a/Makefile
+++ b/Makefile
@@ -165,16 +165,6 @@ test-docker-run: test-docker-37-run test-docker-38-run test-docker-39-run test-d
 
 test-docker-publish: test-docker-37-publish test-docker-38-publish test-docker-39-publish test-docker-310-publish
 
-test-docker-37-build:
-	@docker build -f TestDockerfile --build-arg PYTHON_VERSION=3.7 -t thumbor-test-37 .
-
-test-docker-37-run:
-	@docker run -v "$$(pwd):/app" thumbororg/thumbor-test:37 make compile_ext redis sequential-unit integration flake
-
-test-docker-37-publish:
-	@docker image tag thumbor-test-37:latest thumbororg/thumbor-test:37
-	@docker push thumbororg/thumbor-test:37
-
 test-docker-38-build:
 	@docker build -f TestDockerfile --build-arg PYTHON_VERSION=3.8 -t thumbor-test-38 .
 

--- a/docs/hacking_on_thumbor.rst
+++ b/docs/hacking_on_thumbor.rst
@@ -17,7 +17,7 @@ We seriously advise you to use
 keep your environment clean of thumbor's dependencies and you can choose
 when to "turn them on".
 
-You'll also need python >= 3.7 and `python poetry <https://python-poetry.org/>`_.
+You'll also need python >= 3.8 and `python poetry <https://python-poetry.org/>`_.
 
 Installing poetry should be as easy as ``pip install poetry``, but you can find more about it in their website.
 

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,6 @@ def run_setup(extension_modules=None):
             "Operating System :: MacOS",
             "Operating System :: POSIX :: Linux",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
O suporte ao python 3.7 foi encerrado em `27 Jun 2023`
https://endoflife.date/python