### PR TITLE
Fix - add section license in README.mkd file

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -151,6 +151,10 @@ If you use thumbor, please take 1 minute and answer [this survey](http://t.co/qP
 
 Join the chat at https://gitter.im/thumbor/thumbor
 
+## License
+
+Thumbor is licensed under the [MIT license](LICENSE).
+
 ## 👀 Demo
 
 You can see thumbor in action at http://thumborize.me/


### PR DESCRIPTION
The README.mkd file doesn't have the section of MIT license. I added the section in this project, in addition to the others.