### PR TITLE
Improve docs of auto mime-type config

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -347,8 +347,8 @@ AUTO_*
 ~~~~~~~~~~~~
 
 These configurations indicates that thumbor will try to automatically convert
-the image format to a lighter image format, following a better compression order
-`WEBP -> AVIF -> JPG -> HEIF`.
+the image format to a lighter image format, according to this compression order:
+`WEBP, AVIF, JPG, HEIF` — from highest (`WEBP`) to lowest (`HEIF`) priority.
 
 AUTO\_WEBP
 ^^^^^^^^^^


### PR DESCRIPTION
# Motivation

Clarify documentation on precedence for auto conversion of mime types

# Problem

Documentation can be confusing, allowing for misinterpretations. Related on https://github.com/thumbor/thumbor/issues/1584

# Testing

- Setup docs:
```sh
$ make setup_docs
```

- Build docs:
```sh
$ make build_docs
```

- Generated html in 
```sh
$ thumbor-github/docs/_build/html/configuration.html
```

<img width="1086" alt="image" src="https://github.com/thumbor/thumbor/assets/62268905/80f3d36a-486d-4e03-b674-8ebd7a5ec8f8">

 
cc/ thanks for the support @scorphus @rhurling
