### PR TITLE
Drop Python3.7 from wheel build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ if wheel is not None:
             python, abi, plat = super().get_tag()
 
             if python.startswith("cp"):
-                return "cp37", "abi3", plat
+                return "cp38", "abi3", plat
             return python, abi, plat
 
     kwargs["cmdclass"] = {"bdist_wheel": bdist_wheel_abi3}


### PR DESCRIPTION
Since support for Python 3.7 was dropped, there's no need to build wheels with 3.7 support.