### PR TITLE
Run tests on Python3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = "cp3[89]* cp31[01]*"
+build = "cp3[89]* cp31[012]*"
 
 [tool.cibuildwheel.macos]
 archs = "x86_64 arm64 universal2"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ TESTS_REQUIREMENTS = [
     "isort==4.*,>=4.3.21",
     "pre-commit==2.*,>=2.17.0",
     "preggy==1.*,>=1.4.4",
-    "pylint==2.*,>=2.4.4",
+    "pylint==3.*",
     "pyssim==0.*,>=0.4.0",
     "pytest>=6.2.5",
     "pytest-asyncio==0.*,>=0.10.0",
@@ -52,7 +52,7 @@ TESTS_REQUIREMENTS = [
 
 OPENCV_REQUIREMENTS = [
     "opencv-python-headless==4.*,>=4.2.0",
-    "numpy==1.*,<1.24.0",
+    "numpy==1.*,<1.27.0",
 ]
 
 EXTRA_LIBS_REQUIREMENTS = [
@@ -92,7 +92,7 @@ def filter_extension_module(name, lib_objs, lib_headers):
             "-Wno-unused-parameter",
         ],
         py_limited_api=True,
-        define_macros=[("Py_LIMITED_API", "0x03070000")],
+        define_macros=[("Py_LIMITED_API", "0x03080000")],
     )
 
 
@@ -138,6 +138,7 @@ def run_setup(extension_modules=None):
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
             "Programming Language :: Python :: 3 :: Only",
             "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
             "Topic :: Multimedia :: Graphics :: Presentation",
@@ -151,7 +152,8 @@ def run_setup(extension_modules=None):
             "derpconf==0.*,>=0.8.3",
             "libthumbor==2.*,>=2.0.2",
             "piexif==1.*,>=1.1.3",
-            "Pillow==10.*, >=10.0.1",
+            # TODO: Pillow version 10.1.0 is raising a PIL.Image.DecompressionBombError on tests
+            "Pillow==10.*, <10.1.0",
             "pytz>=2019.3.0",
             "statsd==3.*,>=3.3.0",
             "tornado==6.*,>=6.0.3",

--- a/thumbor/doctor.py
+++ b/thumbor/doctor.py
@@ -253,7 +253,7 @@ def format_error(dependency, err, msg):
         {err}
 
     Error Description:
-        { formatted_msg }
+        {formatted_msg}
     """
     return result.strip()
 


### PR DESCRIPTION
Pillow had to be pinned to a version lower than 10.1.0.0. The property `MAX_IMAGE_PIXELS` is being ignored, causing tests to fail with `PIL.Image.DecompressionBombError: Image size (10364948220 pixels) exceeds limit of 150000000.0 pixels, could be decompression bomb DOS attack.`

```
==============================================================================
ERROR: tests/handlers/test_base_handler_with_auto_avif.py::ImageOperationsWithAutoAvifTestCase::test_should_not_convert_animated_gifs_to_avif
------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/local/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/usr/local/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/tornado/testing.py", line 102, in __call__
    result = self.orig_method(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/tornado/testing.py", line 620, in post_coroutine
    return self.io_loop.run_sync(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/tornado/ioloop.py", line 527, in run_sync
    return future_cell[0].result()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/tests/handlers/test_base_handler_with_auto_avif.py", line 71, in test_should_not_convert_animated_gifs_to_avif
    expect(response.body).to_be_gif()
  File "/usr/local/lib/python3.12/site-packages/preggy/core.py", line 285, in _assert_topic
    return _registered_assertions[method_name](self.topic, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/preggy/core.py", line 58, in wrapper
    func(*args, **kw)
  File "/usr/local/lib/python3.12/site-packages/preggy/core.py", line 123, in test_assertion
    if not func(*args):
           ^^^^^^^^^^^
  File "/app/tests/base.py", line 136, in to_be_gif
    image = Image.open(BytesIO(topic))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/PIL/Image.py", line 3284, in open
    im = _open_core(fp, filename, prefix, formats)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/PIL/Image.py", line 3270, in _open_core
    im = factory(fp, filename)
         ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/PIL/ImageFile.py", line 117, in __init__
    self._open()
  File "/usr/local/lib/python3.12/site-packages/PIL/GifImagePlugin.py", line 108, in _open
    self._seek(0)  # get ready to read first frame
    ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/PIL/GifImagePlugin.py", line 265, in _seek
    Image._decompression_bomb_check(self._size)
  File "/usr/local/lib/python3.12/site-packages/PIL/Image.py", line 3179, in _decompression_bomb_check
    raise DecompressionBombError(msg)
PIL.Image.DecompressionBombError: Image size (10364948220 pixels) exceeds limit of 150000000.0 pixels, could be decompression bomb DOS attack.
```