### PR TITLE
Should have vary header with auto heif and avif

### DIFF
--- a/tests/handlers/test_base_handler_with_auto_avif.py
+++ b/tests/handlers/test_base_handler_with_auto_avif.py
@@ -53,6 +53,7 @@ class ImageOperationsWithAutoAvifTestCase(BaseImagingTestCase):
 
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_avif()
 
     @gen_test
@@ -61,6 +62,7 @@ class ImageOperationsWithAutoAvifTestCase(BaseImagingTestCase):
 
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_avif()
 
     @gen_test
@@ -68,6 +70,7 @@ class ImageOperationsWithAutoAvifTestCase(BaseImagingTestCase):
         response = await self.get_as_avif("/unsafe/animated.gif")
 
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_gif()
 
     @gen_test
@@ -78,6 +81,7 @@ class ImageOperationsWithAutoAvifTestCase(BaseImagingTestCase):
 
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_avif()
 
     @gen_test
@@ -85,6 +89,7 @@ class ImageOperationsWithAutoAvifTestCase(BaseImagingTestCase):
         response = await self.get_as_avif("/unsafe/grayscale.jpg")
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_avif()
 
     @gen_test
@@ -92,6 +97,7 @@ class ImageOperationsWithAutoAvifTestCase(BaseImagingTestCase):
         response = await self.get_as_avif("/unsafe/cmyk.jpg")
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_avif()
 
     @gen_test
@@ -100,6 +106,7 @@ class ImageOperationsWithAutoAvifTestCase(BaseImagingTestCase):
             "/unsafe/filters:format(png)/cmyk.jpg"
         )
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_png()
 
     @gen_test
@@ -108,6 +115,7 @@ class ImageOperationsWithAutoAvifTestCase(BaseImagingTestCase):
             "/unsafe/filters:format(gif)/cmyk.jpg"
         )
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_gif()
 
     @gen_test
@@ -116,6 +124,7 @@ class ImageOperationsWithAutoAvifTestCase(BaseImagingTestCase):
             "/unsafe/filters:format(gif)/image.jpg"
         )
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_gif()
 
     @gen_test
@@ -125,4 +134,5 @@ class ImageOperationsWithAutoAvifTestCase(BaseImagingTestCase):
         )
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_avif()

--- a/tests/handlers/test_base_handler_with_auto_heif.py
+++ b/tests/handlers/test_base_handler_with_auto_heif.py
@@ -53,6 +53,7 @@ class ImageOperationsWithAutoHeifTestCase(BaseImagingTestCase):
 
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_heif()
 
     @gen_test
@@ -61,6 +62,7 @@ class ImageOperationsWithAutoHeifTestCase(BaseImagingTestCase):
 
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_heif()
 
     @gen_test
@@ -68,6 +70,7 @@ class ImageOperationsWithAutoHeifTestCase(BaseImagingTestCase):
         response = await self.get_as_heif("/unsafe/animated.gif")
 
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_gif()
 
     @gen_test
@@ -78,6 +81,7 @@ class ImageOperationsWithAutoHeifTestCase(BaseImagingTestCase):
 
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_heif()
 
     @gen_test
@@ -85,6 +89,7 @@ class ImageOperationsWithAutoHeifTestCase(BaseImagingTestCase):
         response = await self.get_as_heif("/unsafe/grayscale.jpg")
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_heif()
 
     @gen_test
@@ -92,6 +97,7 @@ class ImageOperationsWithAutoHeifTestCase(BaseImagingTestCase):
         response = await self.get_as_heif("/unsafe/cmyk.jpg")
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_heif()
 
     @gen_test
@@ -100,6 +106,7 @@ class ImageOperationsWithAutoHeifTestCase(BaseImagingTestCase):
             "/unsafe/filters:format(png)/cmyk.jpg"
         )
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_png()
 
     @gen_test
@@ -108,6 +115,7 @@ class ImageOperationsWithAutoHeifTestCase(BaseImagingTestCase):
             "/unsafe/filters:format(gif)/cmyk.jpg"
         )
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_gif()
 
     @gen_test
@@ -116,6 +124,7 @@ class ImageOperationsWithAutoHeifTestCase(BaseImagingTestCase):
             "/unsafe/filters:format(gif)/image.jpg"
         )
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_gif()
 
     @gen_test
@@ -125,4 +134,5 @@ class ImageOperationsWithAutoHeifTestCase(BaseImagingTestCase):
         )
         expect(response.code).to_equal(200)
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
+        expect(response.headers).to_include("Vary")
         expect(response.body).to_be_heif()

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -721,7 +721,11 @@ class BaseHandler(tornado.web.RequestHandler):
             buffer = results
 
         # auto-convert configured?
-        should_vary = self.context.config.AUTO_WEBP
+        should_vary = (
+            self.context.config.AUTO_WEBP
+            or self.context.config.AUTO_AVIF
+            or self.context.config.AUTO_HEIF
+        )
         # we have image (not video)
         should_vary = should_vary and content_type.startswith("image/")
         # output format is not requested via format filter


### PR DESCRIPTION
This PR aims to add `Vary` header in Thumbor response to avoid problems with downstream caches.

Closes https://github.com/thumbor/thumbor/issues/1563
thanks @mpdude 