### PR TITLE
bump dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         image-tag:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
   packages: write
 
 env:
+  CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
   python-version: "3.10"
 
 jobs:
@@ -90,7 +91,6 @@ jobs:
     strategy:
       matrix:
         python_version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Other than that, we seriously advise you to use
 your environment clean of thumbor's dependencies and you can choose when
 to "turn them on".
 
-The project requires Python 3.8+, and in this version virtualenv is already installed by default, to create a virtual environment follow the next steps:
+The project requires Python 3.9+, and in this version virtualenv is already installed by default, to create a virtual environment follow the next steps:
 
 
 1. Create a virtual environment, in the folder .venv, located in the user's home folder

--- a/Makefile
+++ b/Makefile
@@ -159,21 +159,11 @@ sample_images:
 	# the watermark filter's logic is too complicated to reproduce with IM, the watermark test images can't be generated here
 	# similarly, the noise, colorize, redeye and fill filters generate output too unique to be reproduce with IM and can't be generated here
 
-test-docker-build: test-docker-37-build test-docker-38-build test-docker-39-build test-docker310-build
+test-docker-build: test-docker-39-build test-docker310-build test-docker311-build test-docker312-build
 
-test-docker-run: test-docker-37-run test-docker-38-run test-docker-39-run test-docker-310-run
+test-docker-run: test-docker-39-run test-docker-310-run test-docker311-build test-docker312-build
 
-test-docker-publish: test-docker-37-publish test-docker-38-publish test-docker-39-publish test-docker-310-publish
-
-test-docker-38-build:
-	@docker build -f TestDockerfile --build-arg PYTHON_VERSION=3.8 -t thumbor-test-38 .
-
-test-docker-38-run:
-	@docker run -v "$$(pwd):/app" thumbororg/thumbor-test:38 make compile_ext redis sequential-unit integration flake
-
-test-docker-38-publish:
-	@docker image tag thumbor-test-38:latest thumbororg/thumbor-test:38
-	@docker push thumbororg/thumbor-test:38
+test-docker-publish: test-docker-39-publish test-docker-310-publish test-docker311-build test-docker312-build
 
 test-docker-39-build:
 	@docker build -f TestDockerfile --build-arg PYTHON_VERSION=3.9 -t thumbor-test-39 .
@@ -194,6 +184,26 @@ test-docker-310-run:
 test-docker-310-publish:
 	@docker image tag thumbor-test-310:latest thumbororg/thumbor-test:310
 	@docker push thumbororg/thumbor-test:310
+
+test-docker-311-build:
+	@docker build -f TestDockerfile --build-arg PYTHON_VERSION=3.11 -t thumbor-test-311 .
+
+test-docker-311-run:
+	@docker run -v "$$(pwd):/app" thumbororg/thumbor-test:311 make compile_ext redis sequential-unit integration flake
+
+test-docker-311-publish:
+	@docker image tag thumbor-test-311:latest thumbororg/thumbor-test:311
+	@docker push thumbororg/thumbor-test:311
+
+test-docker-312-build:
+	@docker build -f TestDockerfile --build-arg PYTHON_VERSION=3.12 -t thumbor-test-312 .
+
+test-docker-312-run:
+	@docker run -v "$$(pwd):/app" thumbororg/thumbor-test:312 make compile_ext redis sequential-unit integration flake
+
+test-docker-312-publish:
+	@docker image tag thumbor-test-312:latest thumbororg/thumbor-test:312
+	@docker push thumbororg/thumbor-test:312
 
 publish:
 	@python setup.py sdist

--- a/docs/hacking_on_thumbor.rst
+++ b/docs/hacking_on_thumbor.rst
@@ -17,7 +17,7 @@ We seriously advise you to use
 keep your environment clean of thumbor's dependencies and you can choose
 when to "turn them on".
 
-You'll also need python >= 3.8 and `python poetry <https://python-poetry.org/>`_.
+You'll also need python >= 3.9 and `python poetry <https://python-poetry.org/>`_.
 
 Installing poetry should be as easy as ``pip install poetry``, but you can find more about it in their website.
 
@@ -82,7 +82,7 @@ If there was anything to merge, just run your tests again. If they pass,
 Introducing a new Dependency
 ----------------------------
 
-If we introduce a new dependency, the testing docker images need to be updated. 
+If we introduce a new dependency, the testing docker images need to be updated.
 
 If the new dependency requires changes to the docker image, make sure to update the TestDockerfile36, TestDockerfile37, TestDockerfile38 and TestDockerfile39 files.
 

--- a/setup.py
+++ b/setup.py
@@ -32,35 +32,34 @@ with open("thumbor/__init__.py") as f:
 kwargs = {}
 
 TESTS_REQUIREMENTS = [
-    "coverage==6.*,>=6.3.2",
-    "flake8==3.*,>=3.7.9",
-    "isort==4.*,>=4.3.21",
-    "pre-commit==2.*,>=2.17.0",
+    "coverage==7.*,>=7.4.0",
+    "flake8==7.*,>=7.0.0",
+    "isort==5.*,>=5.13.2",
+    "pre-commit==3.*,>=3.6.0",
     "preggy==1.*,>=1.4.4",
-    "pylint==3.*",
-    "pyssim==0.*,>=0.4.0",
-    "pytest>=6.2.5",
-    "pytest-asyncio==0.*,>=0.10.0",
-    "pytest-cov==3.*,>=3.0.0",
-    "pytest-tldr==0.*,>=0.2.1",
-    "pytest-xdist==2.*,>=2.4.0",
+    "pylint==3.*,>=3.0.3",
+    "pyssim==0.*,>=0.7",
+    "pytest==7.*,>=7.4.4",
+    "pytest-asyncio==0.*,>=0.23.3",
+    "pytest-cov==4.*,>=4.1.0",
+    "pytest-tldr==0.*,>=0.2.5",
+    "pytest-xdist==3.*,>=3.5.0",
     "redis==5.*,>=5.0.1",
-    "remotecv>=2.3.0",
-    "sentry-sdk==0.*,>=0.14.1",
+    "remotecv==5.*,>=5.1.8",
+    "sentry-sdk==1.*,>=1.39.1",
     "yanc==0.*,>=0.3.3",
 ]
 
 OPENCV_REQUIREMENTS = [
-    "opencv-python-headless==4.*,>=4.2.0",
-    "numpy==1.*,<1.27.0",
+    "opencv-python-headless==4.*,>=4.9.0.80",
+    "numpy==1.*,>=1.26.3",
 ]
 
 EXTRA_LIBS_REQUIREMENTS = [
-    # Going to update in a proper commit
-    "cairosvg>=2.5.2",
-    "pycurl==7.*,>=7.43.0",
-    "pillow-avif-plugin==1.*,>=1.2.2",
-    "pillow-heif>=0.7.0",
+    "cairosvg==2.*,>=2.7.1",
+    "pycurl==7.*,>=7.45.2",
+    "pillow-avif-plugin==1.*,>=1.4.1",
+    "pillow-heif==0.*,>=0.14.0",
 ]
 
 ALL_REQUIREMENTS = OPENCV_REQUIREMENTS + EXTRA_LIBS_REQUIREMENTS
@@ -72,7 +71,7 @@ if wheel is not None:
             python, abi, plat = super().get_tag()
 
             if python.startswith("cp"):
-                return "cp38", "abi3", plat
+                return "cp39", "abi3", plat
             return python, abi, plat
 
     kwargs["cmdclass"] = {"bdist_wheel": bdist_wheel_abi3}
@@ -125,7 +124,7 @@ def run_setup(extension_modules=None):
         author_email="thumbor@googlegroups.com",
         url="https://github.com/thumbor/thumbor/wiki",
         license="MIT",
-        python_requires=">=3.8",
+        python_requires=">=3.9",
         classifiers=[
             "Development Status :: 4 - Beta",
             "Intended Audience :: Developers",
@@ -134,7 +133,6 @@ def run_setup(extension_modules=None):
             "Operating System :: MacOS",
             "Operating System :: POSIX :: Linux",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
@@ -148,18 +146,18 @@ def run_setup(extension_modules=None):
         include_package_data=True,
         package_data={"": ["*.xml"]},
         install_requires=[
-            "colorama==0.*,>=0.4.3",
-            "derpconf==0.*,>=0.8.3",
+            "colorama==0.*,>=0.4.6",
+            "derpconf==0.*,>=0.8.4",
             "libthumbor==2.*,>=2.0.2",
             "piexif==1.*,>=1.1.3",
             # TODO: Pillow version 10.1.0 is raising a PIL.Image.DecompressionBombError on tests
-            "Pillow==10.*, <10.1.0",
-            "pytz>=2019.3.0",
-            "statsd==3.*,>=3.3.0",
-            "tornado==6.*,>=6.0.3",
-            "thumbor-plugins-gifv==0.*,>=0.1.2",
-            "webcolors==1.*,>=1.10.0",
-            "JpegIPTC>=1.4",
+            "Pillow==10.*,<10.1.0",
+            "pytz==2023.*,>=2023.3.post1",
+            "statsd==4.*,>=4.0.1",
+            "tornado==6.*,>=6.4",
+            "thumbor-plugins-gifv==0.*,>=0.1.5",
+            "webcolors==1.*,>=1.13.0",
+            "JpegIPTC==1.*,>=1.5",
         ],
         extras_require={
             "all": ALL_REQUIREMENTS,

--- a/tests/error_handlers/test_sentry.py
+++ b/tests/error_handlers/test_sentry.py
@@ -141,9 +141,7 @@ class SentryTestCase(TestCase):
         expect(request["headers"]).to_length(2)
 
         expect(request["headers"]).to_include("Cookie")
-        expect(request["headers"]["Cookie"]).to_equal(
-            "cookie1=value; cookie2=value2;"
-        )
+        expect(request["headers"]["Cookie"]).to_equal("[Filtered]")
         expect(request["headers"]["header1"]).to_equal("value1")
 
         expect(request["query_string"]).to_equal("a=1&b=2")


### PR DESCRIPTION
# Motivation
This PR aims to upgrade dependencies.

ps: python 3.8 will no longer be supported, same https://github.com/thumbor-community/redis/pull/16 and https://github.com/thumbor/remotecv/pull/86

# Depends
https://github.com/thumbor/thumbor-plugins/pull/90 ✅ 