### PR TITLE
chore: Reformat files according to new Black Code Style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - id: end-of-file-fixer
   - id: check-yaml
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 24.1.0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/flake8

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -341,9 +341,9 @@ class Engine(BaseEngine):
             ext == ".png"
             and self.context.config.PNG_COMPRESSION_LEVEL is not None
         ):
-            options[
-                "compress_level"
-            ] = self.context.config.PNG_COMPRESSION_LEVEL
+            options["compress_level"] = (
+                self.context.config.PNG_COMPRESSION_LEVEL
+            )
 
         if options["quality"] is None:
             options["quality"] = self.context.config.QUALITY

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -298,9 +298,9 @@ class BaseHandler(tornado.web.RequestHandler):
         self.normalize_crops(normalized, req, engine)
 
         if req.meta:
-            self.context.transformer.engine = (
-                self.context.request.engine
-            ) = JSONEngine(engine, req.image_url, req.meta_callback)
+            self.context.transformer.engine = self.context.request.engine = (
+                JSONEngine(engine, req.image_url, req.meta_callback)
+            )
 
         await self.context.transformer.transform()
         await self.after_transform()

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -168,9 +168,9 @@ async def load(
                 header_key
             ) in context.config.HTTP_LOADER_FORWARD_HEADERS_WHITELIST:
                 if header_key in context.request_handler.request.headers:
-                    headers[
-                        header_key
-                    ] = context.request_handler.request.headers[header_key]
+                    headers[header_key] = (
+                        context.request_handler.request.headers[header_key]
+                    )
 
     if user_agent is None and "User-Agent" not in headers:
         user_agent = context.config.HTTP_LOADER_DEFAULT_USER_AGENT

--- a/thumbor/storages/mixed_storage.py
+++ b/thumbor/storages/mixed_storage.py
@@ -34,9 +34,9 @@ class Storage(BaseStorage):
                 item_value=self.context.config.MIXED_STORAGE_FILE_STORAGE,
                 class_name="Storage",
             )
-            self.file_storage = (
-                self.context.modules.file_storage
-            ) = self.context.modules.importer.file_storage(self.context)
+            self.file_storage = self.context.modules.file_storage = (
+                self.context.modules.importer.file_storage(self.context)
+            )
 
     def _init_crypto_storage(self):
         if self.crypto_storage is None:
@@ -45,9 +45,9 @@ class Storage(BaseStorage):
                 item_value=self.context.config.MIXED_STORAGE_CRYPTO_STORAGE,
                 class_name="Storage",
             )
-            self.crypto_storage = (
-                self.context.modules.crypto_storage
-            ) = self.context.modules.importer.crypto_storage(self.context)
+            self.crypto_storage = self.context.modules.crypto_storage = (
+                self.context.modules.importer.crypto_storage(self.context)
+            )
 
     def _init_detector_storage(self):
         if self.detector_storage is None:
@@ -56,9 +56,9 @@ class Storage(BaseStorage):
                 item_value=self.context.config.MIXED_STORAGE_DETECTOR_STORAGE,
                 class_name="Storage",
             )
-            self.detector_storage = (
-                self.context.modules.detector_storage
-            ) = self.context.modules.importer.detector_storage(self.context)
+            self.detector_storage = self.context.modules.detector_storage = (
+                self.context.modules.importer.detector_storage(self.context)
+            )
 
     async def put(self, path, file_bytes):
         self._init_file_storage()


### PR DESCRIPTION
Every new year, the first new version of Black may introduce formatting changes, which is the case of version 24.1.0. Please, check Black's Stability Policy for reference:

https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy