### PR TITLE
Change OS library to async aiofiles & reduce some IO

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,7 @@ def run_setup(extension_modules=None):
         include_package_data=True,
         package_data={"": ["*.xml"]},
         install_requires=[
+            "aiofiles==23.*,>=23.2.1",
             "colorama==0.*,>=0.4.6",
             "derpconf==0.*,>=0.8.4",
             "libthumbor==2.*,>=2.0.2",

--- a/thumbor/result_storages/__init__.py
+++ b/thumbor/result_storages/__init__.py
@@ -8,8 +8,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
-import os
-from os.path import exists
+import aiofiles.os
 
 from thumbor.engines import BaseEngine
 from thumbor.loaders import LoaderResult
@@ -57,10 +56,10 @@ class BaseStorage:
     def last_updated(self):
         raise NotImplementedError()
 
-    def ensure_dir(self, path):
-        if not exists(path):
+    async def ensure_dir(self, path):
+        if not await aiofiles.os.path.exists(path):
             try:
-                os.makedirs(path)
+                await aiofiles.os.makedirs(path)
             except OSError as err:
                 # FILE ALREADY EXISTS = 17
                 if err.errno != 17:

--- a/thumbor/storages/__init__.py
+++ b/thumbor/storages/__init__.py
@@ -8,8 +8,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
-import os
-from os.path import exists
+import aiofiles.os
 
 
 class BaseStorage:
@@ -52,10 +51,10 @@ class BaseStorage:
     async def remove(self, path):
         raise NotImplementedError()
 
-    def ensure_dir(self, path):
-        if not exists(path):
+    async def ensure_dir(self, path):
+        if not await aiofiles.os.path.exists(path):
             try:
-                os.makedirs(path)
+                await aiofiles.os.makedirs(path)
             except OSError as err:
                 # FILE ALREADY EXISTS = 17
                 if err.errno != 17:


### PR DESCRIPTION
This PR replaces the OS blocking library with [aiofiles](https://github.com/Tinche/aiofiles), which wraps the OS and makes it an async variant.

(Unfortunately I was not able to run the tests using make test (the same tests wrapped by docker) however I tested the functions manually.)

https://github.com/thumbor/thumbor/issues/1650