### PR TITLE
Fix lint warnings

### DIFF
--- a/thumbor/filters/watermark.py
+++ b/thumbor/filters/watermark.py
@@ -82,6 +82,10 @@ class Filter(BaseFilter):
         mos_y = self.y == "repeat"
         center_x = self.x == "center"
         center_y = self.y == "center"
+
+        inv_x = False
+        inv_y = False
+
         if not center_x and not mos_x:
             inv_x = self.x[0] == "-"
             x = int(self.x)


### PR DESCRIPTION
```
Run docker exec thumbor_test make pylint
************* Module thumbor.filters.watermark
thumbor/filters/watermark.py:96:17: E0606: Possibly using variable 'inv_x' before assignment (possibly-used-before-assignment)
thumbor/filters/watermark.py:110:17: E0606: Possibly using variable 'inv_y' before assignment (possibly-used-before-assignment)

-----------------------------------
Your code has been rated at 9.99/10

make: *** [Makefile:6[4](https://github.com/thumbor/thumbor/actions/runs/9341143670/job/25707564632#step:11:5): pylint] Error 2
```