### PR TITLE
Change document default port to 80

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -22,7 +22,7 @@ to *0.0.0.0* (listening on localhost and current IP).
 ~~~~~~~~~~~~
 
 The port that Tornado will listen for incoming request. It defaults to
-*8888*.
+*80*.
 
 -c or --conf
 ~~~~~~~~~~~~


### PR DESCRIPTION
Based on [this doc](https://thumbor.readthedocs.io/en/latest/hosting.html#running-with-docker), the port default value must be changed to 80 from 8888.