### PR TITLE
WIP: Fix intermittent watermark test

### DIFF
--- a/tests/filters/test_watermark.py
+++ b/tests/filters/test_watermark.py
@@ -95,7 +95,7 @@ class WatermarkFilterTestCase(FilterTestCase):
         image = await self.get_filtered(
             "source.jpg",
             "thumbor.filters.watermark",
-            "watermark(watermark,30,-50,60)",
+            "watermark(watermark.png,30,-50,60)",
         )
         expected = self.get_fixture("watermarkSimple.jpg")
         ssim = self.get_ssim(image, expected)


### PR DESCRIPTION
Python 3.13
Pillow 11

Maybe there's a problem with the symlink? 0e546476b9bb40dfc80e2ca7ce6303d9fea05c8f

Sometimes, when running locally or in the Debian CI, the `test_watermark_filter_detect_extension_simple` 
test fails with the following error. 

```bash
____ WatermarkFilterTestCase.test_watermark_filter_detect_extension_simple _____
self = <tests.filters.test_watermark.WatermarkFilterTestCase testMethod=test_watermark_filter_detect_extension_simple>
    @gen_test
    async def test_watermark_filter_detect_extension_simple(self):
>       image = await self.get_filtered(
            "source.jpg",
            "thumbor.filters.watermark",
            "watermark(watermark,30,-50,60)",
        )
tests/filters/test_watermark.py:95: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
thumbor/testing.py:241: in get_filtered
    await fltr.run()
thumbor/filters/__init__.py:217: in run
    results.append(await self.runnable_method(*self.params))
thumbor/filters/__init__.py:55: in wrapper
    return await filtered_function(self, *args2)
thumbor/filters/watermark.py:215: in watermark
    raise error
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <thumbor.filters.watermark.Filter object at 0x7fa93941df40>
url = 'watermark', x = '30', y = '-50', alpha = 60, w_ratio = False
h_ratio = False
    @filter_method(
        BaseFilter.String,
        r"(?:-?\d+p?)|center|repeat",
        r"(?:-?\d+p?)|center|repeat",
        BaseFilter.PositiveNumber,
        r"(?:-?\d+)|none",
        r"(?:-?\d+)|none",
    )
    async def watermark(
        self, url, x, y, alpha, w_ratio=False, h_ratio=False
    ):  # pylint: disable=too-many-positional-arguments
        self.url = url
        self.x = x
        self.y = y
        self.alpha = alpha
        self.w_ratio = (
            float(w_ratio) / 100.0 if w_ratio and w_ratio != "none" else False
        )
        self.h_ratio = (
            float(h_ratio) / 100.0 if h_ratio and h_ratio != "none" else False
        )
        self.watermark_engine = self.context.modules.engine.__class__(
            self.context
        )
        self.storage = self.context.modules.storage
    
        try:
            buffer = await self.storage.get(self.url)
            if buffer is not None:
                return self.on_image_ready(buffer)
    
            if not self.validate(self.url):
                raise tornado.web.HTTPError(400)
    
            result = await self.context.modules.loader.load(
                self.context, self.url
            )
    
            if isinstance(result, LoaderResult) and not result.successful:
                logger.warning(
                    "bad watermark result error=%s metadata=%s",
                    result.error,
                    result.metadata,
                )
>               raise tornado.web.HTTPError(400)
E               tornado.web.HTTPError: HTTP 400: Bad Request
thumbor/filters/watermark.py:202: HTTPError
```
Setting a file extension seems to resolve the issue

```diff
-            "watermark(watermark,30,-50,60)",
+            "watermark(watermark.png,30,-50,60)",
```