### PR TITLE
Bump setuptools to >=78.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ def run_setup(extension_modules=None):
             "piexif==1.*,>=1.1.3",
             "Pillow>=10.4.0,<11.0.0",
             "pytz==2023.*,>=2023.3.post1",
-            "setuptools==75.*,>=75.2.0",
+            "setuptools==78.*,>=78.1.1",
             "statsd==4.*,>=4.0.1",
             "thumbor-plugins-gifv==0.*,>=0.1.5",
             "tornado==6.*,>=6.4",


### PR DESCRIPTION
setuptools has a path traversal vulnerability in PackageIndex.download that leads to Arbitrary File Write