### PR TITLE
Remove deprecated license classifier in favor of SPDX expression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,6 @@ def run_setup(extension_modules=None):
         classifiers=[
             "Development Status :: 4 - Beta",
             "Intended Audience :: Developers",
-            "License :: OSI Approved :: MIT License",
             "Natural Language :: English",
             "Operating System :: MacOS",
             "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
Replaces deprecated license classifier with SPDX-style license field ("MIT"). Recommended by setuptools and Python packaging standards.