### PR TITLE
Fix SyntaxWarning for invalid escape sequence in byte regex

### DIFF
--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -27,10 +27,7 @@ except ImportError:
 
 WEBP_SIDE_LIMIT = 16383
 
-SVG_RE = re.compile(
-    b"<svg\s[^>]*([\"'])http[^\"']*svg[^\"']*",  # pylint: disable=anomalous-backslash-in-string
-    re.I,
-)
+SVG_RE = re.compile(rb"<svg\b[^>]*?>", re.I)
 
 
 class EngineResult:


### PR DESCRIPTION
Replaced a regular byte string with a raw byte string (rb"...") to fix a SyntaxWarning caused by an invalid escape sequence (\s) in the SVG_RE regex pattern.

```
# aptitude reinstall thumbor
The following packages will be REINSTALLED:
  thumbor 
0 packages upgraded, 0 newly installed, 1 reinstalled, 0 to remove and 0 not upgraded.
Need to get 0 B/881 kB of archives. After unpacking 0 B will be used.
(Reading database ... 490910 files and directories currently installed.)
Preparing to unpack .../thumbor_7.7.7-2_amd64.deb ...
Unpacking thumbor (7.7.7-2) over (7.7.7-2) ...
Setting up thumbor (7.7.7-2) ...
/usr/lib/python3/dist-packages/thumbor/engines/__init__.py:31: SyntaxWarning: invalid escape sequence '\s'
  b"<svg\s[^>]*([\"'])http[^\"']*svg[^\"']*",  # pylint: disable=anomalous-backslash-in-string
Processing triggers for man-db (2.13.1-1) ...
Scanning processes...                                                                                                                                                              
Scanning processor microcode...                                                                                                                                                    
Scanning linux images... 
```