### PR TITLE
Add support for AUTO_IMAGE_FORMAT_PREFERENCE configuration

### DIFF
--- a/docs/autojpg.rst
+++ b/docs/autojpg.rst
@@ -6,12 +6,15 @@ Usage: `autojpg(enabled)`
 Description
 -----------
 
-This filter overrides ``AUTO_PNG_TO_JPG`` config variable.
+This filter overrides only the ``AUTO_PNG_TO_JPG`` fallback for the current
+request. It does not enable or disable a ``jpg`` entry explicitly configured
+in ``AUTO_IMAGE_FORMAT_PREFERENCE``.
 
 Arguments
 ---------
 
--  enabled - Passing ``True``, which is the default value, you will override the ``AUTO_PNG_TO_JPG`` config variable and False to keep the default behavior of thus config.
+- ``enabled`` - ``True`` enables PNG-to-JPEG fallback and ``False`` disables
+  it for this request. The default is ``True``.
 
 Example
 -------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -397,6 +397,12 @@ Images with texts, for example, the result image maybe will be distorted.
 Dark images, for example, the size of result image maybe will be bigger.
 You have to evaluate the majority of your use cases to take a decision about the usage of this conf.
 
+This conversion remains independent of ``AUTO_IMAGE_FORMAT_PREFERENCE``.
+When a preference list is configured and none of its entries can be used,
+thumbor still applies ``AUTO_PNG_TO_JPG`` as a fallback. The ``autojpg()``
+filter enables or disables this fallback for an individual request; it does
+not enable or disable a ``jpg`` entry in the preference list.
+
 .. code:: python
 
    AUTO_PNG_TO_JPG = True
@@ -433,6 +439,71 @@ specifies that the browser supports "image/heif" and pillow-heif is enabled.
 .. code:: python
 
    AUTO_HEIF = True
+
+AUTO\_IMAGE\_FORMAT\_PREFERENCE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This option defines the order in which thumbor attempts automatic output
+formats. The valid tokens are ``webp``, ``avif``, ``jpg``, ``heif`` and
+``png``. Values are stripped of surrounding whitespace and converted to
+lowercase. Duplicate values after the first occurrence, non-string values
+and unknown tokens are ignored.
+
+For each entry, thumbor checks the request's ``Accept`` header and the
+current engine's capabilities, then selects the first eligible format. AVIF
+and HEIF therefore require their respective engine support, JPEG is not
+selected for an image with transparency, and preference entries are not
+selected for multi-image input. Media types are matched case-insensitively,
+and an entry with an explicit quality value of ``q=0`` is not eligible.
+``image/*`` applies to all supported image formats, while the less specific
+``*/*`` retains the legacy behavior of enabling JPEG only. If no entry is
+eligible, thumbor preserves the engine's output format, except for the
+independent ``AUTO_PNG_TO_JPG`` fallback described above.
+
+A preference list containing at least one valid entry overrides
+``AUTO_WEBP``, ``AUTO_AVIF``, ``AUTO_JPG``, ``AUTO_PNG`` and ``AUTO_HEIF``.
+If any entries are invalid, thumbor logs one warning listing the ignored
+values. If every entry is invalid, thumbor treats the preference as empty.
+An empty preference uses the individual settings in their legacy order:
+``webp``, ``avif``, ``jpg``, ``heif``, then ``png``.
+
+.. code:: python
+
+   # Prioritize AVIF over WebP.
+   AUTO_IMAGE_FORMAT_PREFERENCE = ["avif", "webp", "jpg", "png", "heif"]
+
+   # Or prioritize JPEG for workloads where that is preferable.
+   AUTO_IMAGE_FORMAT_PREFERENCE = ["jpg", "webp", "avif", "png", "heif"]
+
+The result-storage cache key must vary with the active formats accepted by
+the request. The built-in file result storage does this automatically and
+uses an isolated namespace whenever a preference, ``AUTO_AVIF``,
+``AUTO_JPG``, ``AUTO_HEIF``, ``AUTO_PNG`` or ``AUTO_PNG_TO_JPG`` is active.
+It migrates legacy entries only for configurations where the old ``default``
+or WebP namespace is unambiguous. Custom result storages must use
+``thumbor.auto_image_format.get_auto_image_format_cache_key`` as described
+in :doc:`custom_result_storages`. When enabling or reordering this setting,
+do not migrate a legacy cached object into a new format namespace unless its
+content type is verified; a cache purge is the safest upgrade path for
+storages that cannot isolate the old entries.
+
+This namespace change also applies on upgrade when the preference remains
+empty but ``AUTO_AVIF``, ``AUTO_JPG``, ``AUTO_HEIF``, ``AUTO_PNG`` or
+``AUTO_PNG_TO_JPG`` is already enabled. Existing generated images in the
+legacy ``default`` namespace are deliberately treated as cache misses and
+regenerated. Plan for a temporarily cold cache, pre-warm it or use a gradual
+rollout if the additional origin and processing load would be significant.
+Legacy files are not removed automatically, so account for their disk usage
+until they are cleaned up separately. An ``AUTO_WEBP``-only configuration
+keeps its existing cache namespace.
+
+The default is an empty list, which retains the individual ``AUTO_*``
+settings.
+
+.. code:: python
+
+   # Use individual AUTO_* settings (default behavior).
+   AUTO_IMAGE_FORMAT_PREFERENCE = []
 
 Queueing - Redis Single Node
 ----------------------------
@@ -979,6 +1050,12 @@ Example of Configuration File
    ## to take a decision about the usage of this conf.
    ## Defaults to: False
    #AUTO_PNG_TO_JPG = False
+
+   ## Ordered list of preferred automatic output formats. Valid formats are
+   ## webp, avif, jpg, heif and png. A non-empty normalized list overrides the
+   ## individual AUTO_* settings. AUTO_PNG_TO_JPG remains independent.
+   ## Defaults to: []
+   #AUTO_IMAGE_FORMAT_PREFERENCE = []
 
    ## Specify the ratio between 1in and 1px for SVG images. This is only used
    ## whenrasterizing SVG images having their size units in cm or inches.

--- a/docs/custom_result_storages.rst
+++ b/docs/custom_result_storages.rst
@@ -7,3 +7,50 @@ Storage <https://github.com/thumbor/thumbor/blob/master/thumbor/result_storages/
 
 The required methods are ``put``, ``get``, ``validate_path`` and
 ``normalize_path``.
+
+Automatic image formats and cache keys
+--------------------------------------
+
+A result storage must keep responses for different automatic image-format
+capabilities in separate cache namespaces. This is required both for the
+individual ``AUTO_*`` options and for ``AUTO_IMAGE_FORMAT_PREFERENCE``.
+Otherwise, clients requesting the same thumbor URL but advertising different
+formats can receive an incompatible cached image.
+
+Use thumbor's cache-key helper when building the normalized path or key:
+
+.. code:: python
+
+   from thumbor.auto_image_format import get_auto_image_format_cache_key
+
+   format_key = get_auto_image_format_cache_key(
+       self.context.config,
+       self.context.request,
+   )
+   cache_namespace = format_key or "default"
+
+Treat the returned value as an opaque discriminator. It represents the
+active automatic formats accepted by the request and can contain more than
+one format. For configurations that require isolation from legacy cache
+entries, it also contains an internal namespace version. In that mode the
+helper returns a discriminator even when no configured format was accepted.
+Include it in both read and write keys before any cache lookup.
+
+If a custom handler overrides ``BaseHandler.accepts_mime_type`` while
+``AUTO_AVIF``, ``AUTO_HEIF``, ``AUTO_JPG``, ``AUTO_PNG`` or a preference
+containing one of those formats is active, thumbor bypasses result storage for
+that request. The override may depend on the image engine, filters or other
+state that does not exist during the pre-load cache lookup, so no safe cache
+discriminator can be calculated at that point. The override continues to run
+during output-format selection, at the same stage as before.
+``AUTO_WEBP``-only and ``AUTO_PNG_TO_JPG``-only configurations are unaffected
+because this hook has never controlled those conversions.
+
+When enabling or reordering ``AUTO_IMAGE_FORMAT_PREFERENCE``, an entry from
+an older ``default`` or ``auto_webp`` namespace is not necessarily valid for
+the new namespace. Treat such an entry as a cache miss and regenerate it.
+Do not copy or move legacy objects into a new format namespace unless their
+actual content type has been verified. Existing custom storages that do not
+use the helper must adopt it before enabling these automatic formats. Purge
+their generated-image cache once during that rollout; purging without first
+isolating the new keys does not prevent future format collisions.

--- a/tests/handlers/test_base_handler_compatibility.py
+++ b/tests/handlers/test_base_handler_compatibility.py
@@ -1,0 +1,490 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2026 globo.com thumbor@googlegroups.com
+
+import datetime
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from preggy import expect
+
+from thumbor.auto_image_format import get_auto_image_format_cache_key
+from thumbor.config import Config
+from thumbor.context import RequestParameters
+from thumbor.handlers import BaseHandler
+
+
+def make_context(auto_webp=True, accepts_webp=True, headers=None):
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.can_convert_to_webp.return_value = True
+    request = SimpleNamespace(
+        accepts_webp=accepts_webp,
+        engine=engine,
+        headers=headers,
+    )
+
+    return SimpleNamespace(
+        config=SimpleNamespace(AUTO_WEBP=auto_webp),
+        request=request,
+    )
+
+
+def make_handler(context, handler_class=BaseHandler):
+    handler = object.__new__(handler_class)
+    handler.context = context
+    return handler
+
+
+def test_is_webp_keeps_legacy_behavior():
+    context = make_context()
+    handler = make_handler(context)
+
+    expect(handler.is_webp(context)).to_be_true()
+
+    context.config.AUTO_WEBP = False
+    expect(handler.is_webp(context)).to_be_false()
+
+
+def test_can_auto_convert_to_webp_keeps_is_webp_extension_point():
+    class CustomHandler(BaseHandler):
+        def is_webp(self, context):
+            return True
+
+    context = make_context(auto_webp=False)
+    handler = make_handler(context, CustomHandler)
+
+    expect(handler.can_auto_convert_to_webp()).to_be_true()
+
+
+def test_accepts_mime_type_keeps_legacy_header_lookup():
+    context = make_context(
+        headers={"Accept": "image/avif,image/webp,*/*;q=0.8"}
+    )
+    handler = make_handler(context)
+
+    expect(handler.accepts_mime_type("image/webp")).to_be_true()
+    expect(handler.accepts_mime_type("image/png")).to_be_false()
+
+
+def test_accepts_mime_type_without_headers_returns_false():
+    context = make_context(headers=None)
+    handler = make_handler(context)
+
+    expect(handler.accepts_mime_type("image/webp")).to_be_false()
+
+
+def test_accepts_mime_type_preserves_literal_wildcard_semantics():
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/jpeg"},
+    )
+    request = RequestParameters(request=tornado_request)
+    context = SimpleNamespace(request=request)
+    handler = make_handler(context)
+
+    expect(handler.accepts_mime_type("image/jpeg")).to_be_true()
+    expect(handler.accepts_mime_type("*/*")).to_be_false()
+
+
+@pytest.mark.parametrize(
+    "conversion_method,accepted_mimetype",
+    [
+        ("can_auto_convert_to_avif", "image/avif"),
+        ("can_auto_convert_to_heif", "image/heif"),
+        ("can_auto_convert_to_jpg", "image/jpeg"),
+        ("can_auto_convert_to_png", "image/png"),
+    ],
+)
+def test_accepts_mime_type_remains_an_extension_point(
+    conversion_method, accepted_mimetype
+):
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            return mimetype == accepted_mimetype
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.has_transparency.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    engine.can_auto_convert_to_heif.return_value = True
+    request = SimpleNamespace(
+        accepts_avif=False,
+        accepts_heif=False,
+        accepts_jpeg=False,
+        accepts_png=False,
+        engine=engine,
+        headers=None,
+    )
+    context = SimpleNamespace(
+        config=SimpleNamespace(
+            AUTO_AVIF=True,
+            AUTO_HEIF=True,
+            AUTO_JPG=True,
+            AUTO_PNG=True,
+        ),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    expect(getattr(handler, conversion_method)()).to_be_true()
+
+
+def test_accepts_mime_type_override_can_reject_a_parsed_format():
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            return False
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    request = SimpleNamespace(
+        accepts_avif=True,
+        engine=engine,
+        headers={"Accept": "image/avif"},
+    )
+    context = SimpleNamespace(
+        config=SimpleNamespace(AUTO_AVIF=True),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    expect(handler.can_auto_convert_to_avif()).to_be_false()
+
+
+def test_accepts_mime_type_super_call_uses_parsed_quality():
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(  # pylint: disable=useless-parent-delegation
+            self, mimetype=""
+        ):
+            return super().accepts_mime_type(mimetype)
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/avif;q=0,image/*;q=0.8"},
+    )
+    request = RequestParameters(request=tornado_request)
+    request.engine = engine
+    context = SimpleNamespace(
+        config=Config(AUTO_AVIF=True),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    expect(handler.accepts_mime_type("image/avif")).to_be_false()
+    expect(handler.can_auto_convert_to_avif()).to_be_false()
+
+
+def test_accepts_mime_type_super_call_honors_image_wildcard():
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(  # pylint: disable=useless-parent-delegation
+            self, mimetype=""
+        ):
+            return super().accepts_mime_type(mimetype)
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/*;q=0.8"},
+    )
+    request = RequestParameters(request=tornado_request)
+    request.engine = engine
+    context = SimpleNamespace(
+        config=Config(AUTO_AVIF=True),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    expect(handler.accepts_mime_type("image/avif")).to_be_true()
+    expect(handler.accepts_mime_type("application/json")).to_be_false()
+    expect(handler.accepts_mime_type("*/*")).to_be_false()
+    expect(handler.can_auto_convert_to_avif()).to_be_true()
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+    expect(get_auto_image_format_cache_key(context.config, request)).to_equal(
+        "auto_format_v1_flags_preserve_avif"
+    )
+
+
+@pytest.mark.parametrize(
+    "accept_header",
+    [
+        "image/jpeg;q=0,*/*;q=0.8",
+        "image/jpg;q=0,*/*;q=0.8",
+        "image/*;q=0,*/*;q=0.8",
+        "image/jpeg;q=0,image/jpg;q=0.8",
+    ],
+)
+def test_custom_accepts_mime_type_honors_explicit_jpeg_rejection(
+    accept_header,
+):
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(  # pylint: disable=useless-parent-delegation
+            self, mimetype=""
+        ):
+            return super().accepts_mime_type(mimetype)
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.has_transparency.return_value = False
+    tornado_request = mock.Mock(
+        path="/image.png",
+        headers={"Accept": accept_header},
+    )
+    request = RequestParameters(request=tornado_request)
+    request.engine = engine
+    config = Config(AUTO_JPG=True)
+    context = SimpleNamespace(config=config, request=request)
+    handler = make_handler(context, CustomHandler)
+
+    expect(request.accepts_jpeg).to_be_false()
+    expect(handler.can_auto_convert_to_jpg()).to_be_false()
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+    expect(get_auto_image_format_cache_key(config, request)).to_equal(
+        "auto_format_v1_flags_preserve_default"
+    )
+
+
+@pytest.mark.parametrize(
+    "accept_header",
+    [
+        "*/*;q=0.8",
+        "image/jpeg;q=0.8,image/*;q=0",
+    ],
+)
+def test_custom_accepts_mime_type_keeps_valid_jpeg_fallback(accept_header):
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(  # pylint: disable=useless-parent-delegation
+            self, mimetype=""
+        ):
+            return super().accepts_mime_type(mimetype)
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.has_transparency.return_value = False
+    tornado_request = mock.Mock(
+        path="/image.png",
+        headers={"Accept": accept_header},
+    )
+    request = RequestParameters(request=tornado_request)
+    request.engine = engine
+    config = Config(AUTO_JPG=True)
+    context = SimpleNamespace(config=config, request=request)
+    handler = make_handler(context, CustomHandler)
+
+    expect(handler.can_auto_convert_to_jpg()).to_be_true()
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+    expect(get_auto_image_format_cache_key(config, request)).to_equal(
+        "auto_format_v1_flags_preserve_jpg"
+    )
+
+
+def test_custom_accepts_mime_type_bypasses_result_storage_without_calling_it():
+    calls = []
+
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            calls.append(mimetype)
+            return "*/*" in self.context.request.headers.get("Accept", "")
+
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "*/*"},
+    )
+    request = RequestParameters(request=tornado_request)
+    config = Config(AUTO_AVIF=True)
+    context = SimpleNamespace(config=config, request=request)
+    handler = make_handler(context, CustomHandler)
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+
+    request.headers = {"Accept": ""}
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+    expect(calls).to_be_empty()
+
+
+def test_custom_accepts_mime_type_runs_after_engine_is_available():
+    calls = []
+
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            calls.append(mimetype)
+            return self.context.request.engine.accepts_mime_type(mimetype)
+
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/avif"},
+    )
+    request = RequestParameters(request=tornado_request)
+    context = SimpleNamespace(
+        config=Config(AUTO_AVIF=True),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+
+    expect(calls).to_be_empty()
+
+    engine = mock.Mock()
+    engine.accepts_mime_type.return_value = True
+    engine.is_multiple.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    request.engine = engine
+
+    expect(handler.can_auto_convert_to_avif()).to_be_true()
+    expect(calls).to_equal(["image/avif"])
+
+
+@pytest.mark.parametrize(
+    "config_overrides",
+    [
+        {"AUTO_AVIF": True},
+        {"AUTO_HEIF": True},
+        {"AUTO_JPG": True},
+        {"AUTO_PNG": True},
+        {"AUTO_IMAGE_FORMAT_PREFERENCE": ["webp", "jpg"]},
+    ],
+)
+def test_custom_accepts_mime_type_bypasses_extended_format_cache(
+    config_overrides,
+):
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            return True
+
+    context = SimpleNamespace(
+        config=Config(**config_overrides),
+        request=RequestParameters(),
+    )
+    handler = make_handler(context, CustomHandler)
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+
+
+@pytest.mark.parametrize(
+    "config_overrides,expected_cache_key",
+    [
+        ({"AUTO_WEBP": True}, "auto_webp"),
+        (
+            {"AUTO_IMAGE_FORMAT_PREFERENCE": ["webp"]},
+            "auto_format_v1_preference_preserve_webp",
+        ),
+        (
+            {"AUTO_PNG_TO_JPG": True},
+            "auto_format_v1_flags_png_to_jpg_default",
+        ),
+    ],
+)
+def test_custom_accepts_mime_type_keeps_webp_cache(
+    config_overrides,
+    expected_cache_key,
+):
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            return True
+
+    request = RequestParameters(accepts_webp=True)
+    context = SimpleNamespace(
+        config=Config(**config_overrides),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+    handler.accepts_mime_type = mock.Mock(return_value=True)
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_true()
+
+    handler.accepts_mime_type.assert_not_called()
+    expect(get_auto_image_format_cache_key(context.config, request)).to_equal(
+        expected_cache_key
+    )
+
+
+@pytest.mark.asyncio
+async def test_custom_accepts_mime_type_bypasses_result_storage_read_and_write():
+    calls = []
+
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            calls.append(mimetype)
+            return self.context.request.engine.accepts_mime_type(mimetype)
+
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/avif"},
+    )
+    request = RequestParameters(request=tornado_request)
+    result_storage = mock.AsyncMock()
+    result_storage.get.return_value = None
+    filters_runner = SimpleNamespace(apply_filters=mock.AsyncMock())
+    filters_factory = mock.Mock()
+    filters_factory.create_instances.return_value = filters_runner
+    thread_pool = SimpleNamespace(
+        queue=mock.AsyncMock(return_value=(b"image", "image/jpeg"))
+    )
+    context = SimpleNamespace(
+        config=Config(AUTO_AVIF=True),
+        request=request,
+        modules=SimpleNamespace(result_storage=result_storage),
+        metrics=mock.Mock(),
+        filters_factory=filters_factory,
+        thread_pool=thread_pool,
+    )
+    handler = make_handler(context, CustomHandler)
+    handler._response_start = (  # pylint: disable=protected-access
+        datetime.datetime.now()
+    )
+    handler.request = SimpleNamespace(arguments={})
+    handler.get_image = mock.AsyncMock()
+
+    await handler.execute_image_operations()
+
+    result_storage.get.assert_not_awaited()
+    handler.get_image.assert_awaited_once_with()
+    expect(calls).to_be_empty()
+
+    handler._write_results_to_client = (  # pylint: disable=protected-access
+        mock.AsyncMock()
+    )
+    handler._cleanup = mock.Mock()  # pylint: disable=protected-access
+
+    await handler.finish_request()
+
+    result_storage.put.assert_not_awaited()
+    expect(request.prevent_result_storage).to_be_false()

--- a/tests/handlers/test_base_handler_with_auto_image_format_preference.py
+++ b/tests/handlers/test_base_handler_with_auto_image_format_preference.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2025 globo.com thumbor@googlegroups.com
+
+from shutil import which
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from preggy import expect
+from tornado.testing import gen_test
+
+from tests.handlers.test_base_handler import BaseImagingTestCase
+from thumbor.config import Config
+from thumbor.context import Context, ServerParameters
+from thumbor.handlers import BaseHandler
+from thumbor.importer import Importer
+
+
+def resolve_preferred_extension(
+    preference, accepted_formats=None, multiple=False, transparent=False
+):
+    accepted_formats = accepted_formats or set(preference)
+    engine = mock.Mock(extension=".gif")
+    engine.is_multiple.return_value = multiple
+    engine.has_transparency.return_value = transparent
+    engine.can_convert_to_webp.return_value = "webp" in accepted_formats
+    engine.can_auto_convert_to_avif.return_value = "avif" in accepted_formats
+    engine.can_auto_convert_to_heif.return_value = "heif" in accepted_formats
+    engine.can_auto_convert_png_to_jpg.return_value = False
+    request = SimpleNamespace(
+        accepts_webp="webp" in accepted_formats,
+        accepts_avif="avif" in accepted_formats,
+        accepts_heif="heif" in accepted_formats,
+        accepts_jpeg="jpg" in accepted_formats,
+        accepts_png="png" in accepted_formats,
+        auto_png_to_jpg=None,
+        engine=engine,
+    )
+    context = SimpleNamespace(
+        config=Config(AUTO_IMAGE_FORMAT_PREFERENCE=preference),
+        request=request,
+    )
+    handler = object.__new__(BaseHandler)
+    handler.context = context
+
+    # pylint: disable=protected-access
+    return handler._resolve_auto_image_extension(context)
+
+
+@pytest.mark.parametrize(
+    "image_format", ["webp", "avif", "jpg", "heif", "png"]
+)
+def test_resolves_every_supported_preferred_format(image_format):
+    expect(resolve_preferred_extension([image_format])).to_equal(
+        f".{image_format}"
+    )
+
+
+def test_skips_unsupported_preferred_format():
+    expect(
+        resolve_preferred_extension(
+            ["avif", "webp"], accepted_formats={"webp"}
+        )
+    ).to_equal(".webp")
+
+
+def test_skips_jpg_for_transparent_image():
+    expect(resolve_preferred_extension(["jpg"], transparent=True)).to_equal(
+        ".gif"
+    )
+
+
+def test_skips_preferred_formats_for_multiple_images():
+    expect(
+        resolve_preferred_extension(["webp", "png"], multiple=True)
+    ).to_equal(".gif")
+
+
+class ImageOperationsWithAutoImageFormatPreferenceTestCase(
+    BaseImagingTestCase
+):
+    def get_context(self):
+        cfg = Config(SECURITY_KEY="ACME-SEC")
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = self.loader_path
+        cfg.STORAGE = "thumbor.storages.no_storage"
+        cfg.AUTO_WEBP = True
+        cfg.AUTO_AVIF = True
+        cfg.AUTO_IMAGE_FORMAT_PREFERENCE = ["avif", "webp", "jpg", "png"]
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(
+            8889, "localhost", "thumbor.conf", None, "info", None
+        )
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, cfg, importer)
+        ctx.server.gifsicle_path = which("gifsicle")
+        return ctx
+
+    async def get_as_webp_first(self, url):
+        return await self.async_fetch(
+            url, headers={"Accept": "image/webp,image/avif,*/*;q=0.8"}
+        )
+
+    @gen_test
+    async def test_can_auto_convert_to_avif(self):
+        response = await self.get_as_webp_first("/unsafe/image.jpg")
+        expect(response.code).to_equal(200)
+        expect(response.headers).to_include("Vary")
+        expect(response.headers["Vary"]).to_include("Accept")
+
+        expect(response.body).to_be_avif()
+
+    @gen_test
+    async def test_skips_preferred_format_rejected_with_quality_zero(self):
+        response = await self.async_fetch(
+            "/unsafe/image.jpg",
+            headers={"Accept": "image/avif;q=0,image/webp;q=0.8"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Vary"]).to_include("Accept")
+        expect(response.body).to_be_webp()
+
+    @gen_test
+    async def test_falls_back_to_engine_extension_when_no_match_exists(self):
+        response = await self.async_fetch(
+            "/unsafe/image.jpg", headers={"Accept": "image/tiff"}
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers).to_include("Vary")
+        expect(response.headers["Vary"]).to_include("Accept")
+
+        expect(response.body).to_be_jpeg()
+
+
+class ImageOperationsWithoutAutoImageFormatPreferenceTestCase(
+    BaseImagingTestCase
+):
+    def get_context(self):
+        cfg = Config(SECURITY_KEY="ACME-SEC")
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = self.loader_path
+        cfg.STORAGE = "thumbor.storages.no_storage"
+        cfg.AUTO_WEBP = True
+        cfg.AUTO_AVIF = True
+        cfg.AUTO_IMAGE_FORMAT_PREFERENCE = []
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(
+            8889, "localhost", "thumbor.conf", None, "info", None
+        )
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, cfg, importer)
+        ctx.server.gifsicle_path = which("gifsicle")
+        return ctx
+
+    async def get_as_webp_first(self, url):
+        return await self.async_fetch(
+            url, headers={"Accept": "image/webp,image/avif,*/*;q=0.8"}
+        )
+
+    @gen_test
+    async def test_can_auto_convert_to_webp(self):
+        response = await self.get_as_webp_first("/unsafe/image.jpg")
+        expect(response.code).to_equal(200)
+        expect(response.headers).to_include("Vary")
+        expect(response.headers["Vary"]).to_include("Accept")
+
+        expect(response.body).to_be_webp()
+
+
+class ImageOperationsWithAutoImageFormatPreferenceOverrideTestCase(
+    BaseImagingTestCase
+):
+    def get_context(self):
+        cfg = Config(SECURITY_KEY="ACME-SEC")
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = self.loader_path
+        cfg.STORAGE = "thumbor.storages.no_storage"
+        cfg.AUTO_WEBP = False
+        cfg.AUTO_AVIF = False
+        cfg.AUTO_JPG = False
+        cfg.AUTO_PNG = False
+        cfg.AUTO_HEIF = False
+        cfg.AUTO_IMAGE_FORMAT_PREFERENCE = [" invalid ", " WebP ", "webp"]
+        cfg.FILTERS = [*cfg.FILTERS, "thumbor.filters.autojpg"]
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(
+            8889, "localhost", "thumbor.conf", None, "info", None
+        )
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, cfg, importer)
+        ctx.server.gifsicle_path = which("gifsicle")
+        return ctx
+
+    @gen_test
+    async def test_preference_overrides_auto_flags(self):
+        response = await self.async_fetch(
+            "/unsafe/image.jpg", headers={"Accept": "image/webp,*/*;q=0.8"}
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers).to_include("Vary")
+        expect(response.headers["Vary"]).to_include("Accept")
+
+        expect(response.body).to_be_webp()
+
+    @gen_test
+    async def test_autojpg_false_does_not_override_explicit_jpg_preference(
+        self,
+    ):
+        self.context.config.AUTO_IMAGE_FORMAT_PREFERENCE = ["jpg"]
+
+        response = await self.async_fetch(
+            "/unsafe/filters:autojpg(false)/"
+            "Giunchedi%2C_Filippo_January_2015_01.png",
+            headers={"Accept": "image/jpeg"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_jpeg()
+
+
+class ImageOperationsWithPreferenceAndAutoPngToJpgTestCase(
+    BaseImagingTestCase
+):
+    def get_context(self):
+        cfg = Config(SECURITY_KEY="ACME-SEC")
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = self.loader_path
+        cfg.STORAGE = "thumbor.storages.no_storage"
+        cfg.AUTO_PNG_TO_JPG = True
+        cfg.AUTO_IMAGE_FORMAT_PREFERENCE = ["webp"]
+        cfg.FILTERS = [*cfg.FILTERS, "thumbor.filters.autojpg"]
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(
+            8889, "localhost", "thumbor.conf", None, "info", None
+        )
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, cfg, importer)
+        ctx.server.gifsicle_path = which("gifsicle")
+        return ctx
+
+    @gen_test
+    async def test_preferred_format_wins_over_auto_png_to_jpg(self):
+        response = await self.async_fetch(
+            "/unsafe/Giunchedi%2C_Filippo_January_2015_01.png",
+            headers={"Accept": "image/webp"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_webp()
+
+    @gen_test
+    async def test_auto_png_to_jpg_is_fallback_after_preference(self):
+        response = await self.async_fetch(
+            "/unsafe/Giunchedi%2C_Filippo_January_2015_01.png",
+            headers={"Accept": "image/png"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_autojpg_false_disables_only_png_to_jpg_fallback(self):
+        response = await self.async_fetch(
+            "/unsafe/filters:autojpg(false)/"
+            "Giunchedi%2C_Filippo_January_2015_01.png",
+            headers={"Accept": "image/png"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_png()
+
+    @gen_test
+    async def test_autojpg_true_keeps_png_to_jpg_fallback_enabled(self):
+        response = await self.async_fetch(
+            "/unsafe/filters:autojpg(true)/"
+            "Giunchedi%2C_Filippo_January_2015_01.png",
+            headers={"Accept": "image/png"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_jpeg()

--- a/tests/handlers/test_base_handler_with_auto_jpg.py
+++ b/tests/handlers/test_base_handler_with_auto_jpg.py
@@ -32,6 +32,7 @@ class ImageOperationsWithAutoJpgTestCase(BaseImagingTestCase):
         cfg.FILE_LOADER_ROOT_PATH = self.loader_path
         cfg.STORAGE = "thumbor.storages.no_storage"
         cfg.AUTO_JPG = True
+        cfg.FILTERS = [*cfg.FILTERS, "thumbor.filters.autojpg"]
 
         importer = Importer(cfg)
         importer.import_modules()
@@ -47,6 +48,18 @@ class ImageOperationsWithAutoJpgTestCase(BaseImagingTestCase):
         return await self.async_fetch(
             url, headers={"Accept": f"{mimetype};q=0.8"}
         )
+
+    @gen_test
+    async def test_autojpg_false_does_not_disable_auto_jpg(self):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:autojpg(false)/"
+            "Giunchedi%2C_Filippo_January_2015_01.png",
+            MIMETYPE_JPEG,
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Vary"]).to_include("Accept")
+        expect(response.body).to_be_jpeg()
 
     @gen_test
     async def test_can_auto_convert_avif_to_jpg_with_accept_all(self):
@@ -103,6 +116,7 @@ class ImageOperationsWithAutoJpgTestCase(BaseImagingTestCase):
         response = await self.get_as_jpg("/unsafe/animated.gif", MIMETYPE_ALL)
 
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_gif()
 
     @gen_test

--- a/tests/handlers/test_base_handler_with_auto_png.py
+++ b/tests/handlers/test_base_handler_with_auto_png.py
@@ -51,6 +51,7 @@ class ImageOperationsWithAutoPngTestCase(BaseImagingTestCase):
         response = await self.get_as_png("/unsafe/image.jpg")
 
         expect(response.code).to_equal(200)
+        expect(response.headers["Vary"]).to_include("Accept")
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
         expect(response.body).to_be_png()
 
@@ -67,6 +68,7 @@ class ImageOperationsWithAutoPngTestCase(BaseImagingTestCase):
         response = await self.get_as_png("/unsafe/animated.gif")
 
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_gif()
 
     @gen_test

--- a/tests/result_storages/test_file_storage.py
+++ b/tests/result_storages/test_file_storage.py
@@ -7,14 +7,22 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
+import asyncio
+import hashlib
 import tempfile
 from datetime import datetime
-from os.path import abspath, dirname, join
+from os.path import abspath, dirname, exists, join
 from unittest import mock
+from urllib.parse import unquote
 
 from preggy import expect
 from tornado.testing import gen_test
 
+from thumbor.auto_image_format import (
+    get_active_auto_image_formats,
+    get_auto_image_format_cache_key,
+    get_normalized_auto_image_format_preference,
+)
 from thumbor.config import Config
 from thumbor.context import RequestParameters
 from thumbor.result_storages import ResultStorageResult
@@ -50,6 +58,14 @@ class BaseFileStorageTestCase(TestCase):
     def get_fixture_path():
         return abspath(join(dirname(__file__), "../fixtures/result_storages"))
 
+    @staticmethod
+    def get_image_fixture_path(filename):
+        return abspath(join(dirname(__file__), "../fixtures/images", filename))
+
+    def read_image_fixture(self, filename):
+        with open(self.get_image_fixture_path(filename), "rb") as image_file:
+            return image_file.read()
+
     def get_context(self):
         ctx = super().get_context()
         cfg = self.get_config()
@@ -63,8 +79,60 @@ class BaseFileStorageTestCase(TestCase):
     def get_http_path():
         return "http://example.com/path/to/a.jpg"
 
+    def put_legacy_fixture(self, filename):
+        legacy_path = self.file_storage.normalize_path_legacy(
+            self.context.request.url
+        )
+        self.file_storage.ensure_dir(dirname(legacy_path))
+
+        image_bytes = self.read_image_fixture(filename)
+
+        with open(legacy_path, "wb") as legacy_file:
+            legacy_file.write(image_bytes)
+
+        return legacy_path, image_bytes
+
+    def put_previous_hashed_fixture(self, prefix, filename):
+        path = self.context.request.url
+        # This reproduces the legacy cache layout; SHA-1 is not used for
+        # security or integrity checks.
+        digest = hashlib.sha1(
+            unquote(path).encode("utf-8"), usedforsecurity=False
+        ).hexdigest()
+        previous_path = join(
+            self.storage_path.name,
+            prefix,
+            digest[:2],
+            digest[2:4],
+            digest[4:],
+        )
+        self.file_storage.ensure_dir(dirname(previous_path))
+
+        image_bytes = self.read_image_fixture(filename)
+
+        with open(previous_path, "wb") as previous_file:
+            previous_file.write(image_bytes)
+
+        return previous_path, image_bytes
+
 
 class FileStorageTestCase(BaseFileStorageTestCase):
+    def test_is_not_legacy_auto_webp(self):
+        expect(self.file_storage.is_auto_webp).to_be_false()
+
+    def test_is_auto_webp_override_controls_legacy_cache_key(self):
+        class CustomFileStorage(FileStorage):
+            @property
+            def is_auto_webp(self):
+                return True
+
+        custom_storage = CustomFileStorage(self.context)
+
+        expect(custom_storage.normalize_path(self.get_http_path())).to_equal(
+            f"{self.storage_path.name}/auto_webp/b6/be/"
+            "a3e916129541a9e7146f69a15eb4d7c77c98"
+        )
+
     @gen_test
     async def test_normalized_path(self):
         expect(self.file_storage).not_to_be_null()
@@ -74,6 +142,32 @@ class FileStorageTestCase(BaseFileStorageTestCase):
             f"{self.storage_path.name}/default/b6/be/"
             "a3e916129541a9e7146f69a15eb4d7c77c98"
         )
+
+    @gen_test
+    async def test_normalized_path_without_request(self):
+        del self.context.request
+
+        expect(self.file_storage).not_to_be_null()
+        expect(
+            self.file_storage.normalize_path(self.get_http_path())
+        ).to_equal(
+            f"{self.storage_path.name}/default/b6/be/"
+            "a3e916129541a9e7146f69a15eb4d7c77c98"
+        )
+
+    @gen_test
+    async def test_migrates_legacy_default_cache(self):
+        self.context.request.url = self.get_http_path()
+        legacy_path, image_bytes = self.put_legacy_fixture("image.jpg")
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result.buffer).to_equal(image_bytes)
+        expect(exists(legacy_path)).to_be_false()
+        expect(exists(current_path)).to_be_true()
 
 
 class WebPFileStorageTestCase(BaseFileStorageTestCase):
@@ -93,6 +187,22 @@ class WebPFileStorageTestCase(BaseFileStorageTestCase):
     def get_request(self):  # pylint: disable=arguments-differ
         return RequestParameters(accepts_webp=True)
 
+    def test_preserves_legacy_is_auto_webp_property(self):
+        expect(self.file_storage.is_auto_webp).to_be_true()
+
+    def test_is_auto_webp_override_can_disable_legacy_cache_key(self):
+        class CustomFileStorage(FileStorage):
+            @property
+            def is_auto_webp(self):
+                return False
+
+        custom_storage = CustomFileStorage(self.context)
+
+        expect(custom_storage.normalize_path(self.get_http_path())).to_equal(
+            f"{self.storage_path.name}/default/b6/be/"
+            "a3e916129541a9e7146f69a15eb4d7c77c98"
+        )
+
     @gen_test
     async def test_normalized_path_with_auto_webp_path(self):
         expect(self.file_storage).not_to_be_null()
@@ -102,6 +212,336 @@ class WebPFileStorageTestCase(BaseFileStorageTestCase):
             f"{self.storage_path.name}/auto_webp/b6/be/"
             "a3e916129541a9e7146f69a15eb4d7c77c98"
         )
+
+    @gen_test
+    async def test_migrates_legacy_auto_webp_cache(self):
+        self.context.request.url = self.get_http_path()
+        legacy_path, image_bytes = self.put_legacy_fixture("image.webp")
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result.buffer).to_equal(image_bytes)
+        expect(exists(legacy_path)).to_be_false()
+        expect(exists(current_path)).to_be_true()
+
+
+class PreferredFormatsFileStorageTestCase(BaseFileStorageTestCase):
+    def get_config(self):
+        self.storage_path = (
+            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        )
+        return Config(
+            AUTO_IMAGE_FORMAT_PREFERENCE=[" avif ", "webp", "invalid"],
+            RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=self.storage_path.name,
+        )
+
+    def get_request(self):  # pylint: disable=arguments-differ
+        return RequestParameters(accepts_webp=True, accepts_avif=True)
+
+    @gen_test
+    async def test_normalized_path_with_preferred_formats_path(self):
+        expect(self.file_storage).not_to_be_null()
+        expect(
+            self.file_storage.normalize_path(self.get_http_path())
+        ).to_equal(
+            f"{self.storage_path.name}/"
+            "auto_format_v1_preference_preserve_avif-webp/b6/be/"
+            "a3e916129541a9e7146f69a15eb4d7c77c98"
+        )
+
+    @gen_test
+    async def test_put_and_get_keep_accept_variants_separate(self):
+        self.context.request.url = self.get_http_path()
+        avif_bytes = await asyncio.to_thread(
+            self.read_image_fixture, "image.avif"
+        )
+
+        await self.file_storage.put(avif_bytes)
+        avif_webp_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        self.context.request = RequestParameters(
+            url=self.get_http_path(), accepts_webp=True
+        )
+        webp_bytes = await asyncio.to_thread(
+            self.read_image_fixture, "image.webp"
+        )
+
+        await self.file_storage.put(webp_bytes)
+        webp_path = self.file_storage.normalize_path(self.context.request.url)
+
+        expect(avif_webp_path).not_to_equal(webp_path)
+        expect((await self.file_storage.get()).buffer).to_equal(webp_bytes)
+
+        self.context.request = RequestParameters(
+            url=self.get_http_path(), accepts_webp=True, accepts_avif=True
+        )
+        expect((await self.file_storage.get()).buffer).to_equal(avif_bytes)
+
+
+class PreferredWebPFileStorageTestCase(BaseFileStorageTestCase):
+    def get_config(self):
+        self.storage_path = (
+            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        )
+        return Config(
+            AUTO_WEBP=False,
+            AUTO_IMAGE_FORMAT_PREFERENCE=["webp"],
+            RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=self.storage_path.name,
+        )
+
+    def get_request(self):  # pylint: disable=arguments-differ
+        return RequestParameters(url=self.get_http_path(), accepts_webp=True)
+
+    @gen_test
+    async def test_does_not_migrate_legacy_default_into_auto_webp(self):
+        legacy_path, _ = self.put_legacy_fixture("image.jpg")
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(legacy_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+    @gen_test
+    async def test_does_not_read_previous_auto_webp_namespace(self):
+        previous_path, _ = self.put_previous_hashed_fixture(
+            "auto_webp", "image.avif"
+        )
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(previous_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+    @gen_test
+    async def test_does_not_read_previous_default_namespace(self):
+        self.context.request = RequestParameters(
+            url=self.get_http_path(), accepts_webp=False
+        )
+        previous_path, _ = self.put_previous_hashed_fixture(
+            "default", "image.avif"
+        )
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(previous_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+
+class AutoAvifFileStorageTestCase(BaseFileStorageTestCase):
+    def get_config(self):
+        self.storage_path = (
+            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        )
+        return Config(
+            AUTO_AVIF=True,
+            RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=self.storage_path.name,
+        )
+
+    def get_request(self):  # pylint: disable=arguments-differ
+        return RequestParameters(url=self.get_http_path())
+
+    @gen_test
+    async def test_does_not_migrate_unsafe_legacy_default_cache(self):
+        legacy_path, _ = self.put_legacy_fixture("image.jpg")
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(legacy_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+    def test_uses_isolated_default_namespace(self):
+        expect(
+            self.file_storage.normalize_path(self.context.request.url)
+        ).to_equal(
+            f"{self.storage_path.name}/"
+            "auto_format_v1_flags_preserve_default/b6/be/"
+            "a3e916129541a9e7146f69a15eb4d7c77c98"
+        )
+
+
+class AutoPngToJpgFileStorageTestCase(BaseFileStorageTestCase):
+    def get_config(self):
+        self.storage_path = (
+            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        )
+        return Config(
+            AUTO_PNG_TO_JPG=True,
+            RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=self.storage_path.name,
+        )
+
+    def get_request(self):  # pylint: disable=arguments-differ
+        return RequestParameters(url=self.get_http_path())
+
+    @gen_test
+    async def test_does_not_read_previous_default_cache(self):
+        previous_path, _ = self.put_previous_hashed_fixture(
+            "default", "1x1.png"
+        )
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(previous_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+
+class AutoWebPAndAvifFileStorageTestCase(BaseFileStorageTestCase):
+    def get_config(self):
+        self.storage_path = (
+            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        )
+        return Config(
+            AUTO_WEBP=True,
+            AUTO_AVIF=True,
+            RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=self.storage_path.name,
+        )
+
+    def get_request(self):  # pylint: disable=arguments-differ
+        return RequestParameters(url=self.get_http_path(), accepts_webp=True)
+
+    @gen_test
+    async def test_does_not_migrate_contaminated_legacy_webp_cache(self):
+        legacy_path, _ = self.put_legacy_fixture("image.avif")
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(legacy_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+
+class AutoImageFormatCacheKeyTestCase(TestCase):
+    def test_extended_formats_use_isolated_cache_keys(self):
+        config = Config(AUTO_AVIF=True)
+
+        expect(
+            get_auto_image_format_cache_key(
+                config, RequestParameters(accepts_avif=True)
+            )
+        ).to_equal("auto_format_v1_flags_preserve_avif")
+        expect(
+            get_auto_image_format_cache_key(config, RequestParameters())
+        ).to_equal("auto_format_v1_flags_preserve_default")
+
+    def test_cache_key_separates_policies_and_png_to_jpg_fallback(self):
+        request = RequestParameters(accepts_heif=True)
+        flags_without_fallback = Config(AUTO_HEIF=True, AUTO_PNG_TO_JPG=False)
+        flags_with_fallback = Config(AUTO_HEIF=True, AUTO_PNG_TO_JPG=True)
+        preference_with_fallback = Config(
+            AUTO_IMAGE_FORMAT_PREFERENCE=["heif"],
+            AUTO_PNG_TO_JPG=True,
+        )
+
+        cache_keys = {
+            get_auto_image_format_cache_key(flags_without_fallback, request),
+            get_auto_image_format_cache_key(flags_with_fallback, request),
+            get_auto_image_format_cache_key(preference_with_fallback, request),
+        }
+
+        expect(len(cache_keys)).to_equal(3)
+
+    def test_png_to_jpg_only_uses_isolated_cache_key(self):
+        expect(
+            get_auto_image_format_cache_key(
+                Config(AUTO_PNG_TO_JPG=True), RequestParameters()
+            )
+        ).to_equal("auto_format_v1_flags_png_to_jpg_default")
+
+    def test_quality_zero_does_not_enter_legacy_webp_cache(self):
+        request = mock.Mock(
+            path="http://example.com/path/to/a.jpg",
+            headers={"Accept": "image/webp;q=0"},
+        )
+
+        expect(
+            get_auto_image_format_cache_key(
+                Config(AUTO_WEBP=True),
+                RequestParameters(request=request),
+            )
+        ).to_be_null()
+
+    @mock.patch("thumbor.auto_image_format.logger.warning")
+    def test_invalid_preference_warns_once_and_uses_legacy_flags(
+        self, warning
+    ):
+        config = Config(
+            AUTO_WEBP=True,
+            AUTO_IMAGE_FORMAT_PREFERENCE=["invalid", 1, "INVALID"],
+        )
+        request = RequestParameters(accepts_webp=True)
+
+        expect(get_normalized_auto_image_format_preference(config)).to_equal(
+            ()
+        )
+        expect(get_active_auto_image_formats(config)).to_equal(("webp",))
+        expect(get_auto_image_format_cache_key(config, request)).to_equal(
+            "auto_webp"
+        )
+        get_normalized_auto_image_format_preference(config)
+
+        warning.assert_called_once_with(
+            "Ignoring invalid AUTO_IMAGE_FORMAT_PREFERENCE values: %r. "
+            "Valid formats are: %s.",
+            ["invalid", 1, "INVALID"],
+            "webp, avif, jpg, heif, png",
+        )
+
+    def test_normalized_preference_cache_is_published_atomically(self):
+        class ReentrantConfig:
+            def __init__(self):
+                self.AUTO_IMAGE_FORMAT_PREFERENCE = [  # pylint: disable=invalid-name
+                    "avif"
+                ]
+                self.observed_preferences = []
+                self.inspecting_cache_write = False
+
+            def __setattr__(self, name, value):
+                object.__setattr__(self, name, value)
+
+                if not name.startswith(
+                    "_AUTO_IMAGE_FORMAT_PREFERENCE_"
+                ) or object.__getattribute__(self, "inspecting_cache_write"):
+                    return
+
+                object.__setattr__(self, "inspecting_cache_write", True)
+                self.observed_preferences.append(
+                    get_normalized_auto_image_format_preference(self)
+                )
+                object.__setattr__(self, "inspecting_cache_write", False)
+
+        config = ReentrantConfig()
+
+        expect(get_normalized_auto_image_format_preference(config)).to_equal(
+            ("avif",)
+        )
+        expect(config.observed_preferences).to_equal([("avif",)])
 
 
 class ResultStorageResultTestCase(BaseFileStorageTestCase):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -227,6 +227,10 @@ class RequestParametersTestCase(TestCase):
         expect(params.unsafe).to_be_false()
         expect(params.format).to_be_null()
         expect(params.accepts_webp).to_be_false()
+        expect(params.accepts_avif).to_be_false()
+        expect(params.accepts_heif).to_be_false()
+        expect(params.accepts_png).to_be_false()
+        expect(params.accepts_jpeg).to_be_false()
         expect(params.max_bytes).to_be_null()
         expect(params.max_age).to_be_null()
 
@@ -285,10 +289,137 @@ class RequestParametersTestCase(TestCase):
 
     @staticmethod
     def test_can_get_params_from_request():
-        request = mock.Mock(path="/test.jpg", headers={"Accept": "image/webp"})
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={
+                "Accept": "image/webp,image/avif,image/heif,image/png,image/jpeg"
+            },
+        )
         params = RequestParameters(request=request, image="/test.jpg")
         expect(params.accepts_webp).to_be_true()
+        expect(params.accepts_avif).to_be_true()
+        expect(params.accepts_heif).to_be_true()
+        expect(params.accepts_png).to_be_true()
+        expect(params.accepts_jpeg).to_be_true()
         expect(params.image_url).to_equal("/test.jpg")
+
+    @staticmethod
+    def test_accept_header_respects_quality_and_is_case_insensitive():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={
+                "Accept": "IMAGE/AVIF;Q=0, IMAGE/WEBP;Q=0.8, image/png;q=0"
+            },
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_avif).to_be_false()
+        expect(params.accepts_webp).to_be_true()
+        expect(params.accepts_png).to_be_false()
+
+    @staticmethod
+    def test_explicit_jpeg_rejection_overrides_accept_any():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "image/jpeg;q=0,*/*;q=0.8"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_jpeg).to_be_false()
+
+    @staticmethod
+    def test_accept_any_keeps_legacy_jpeg_support():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "*/*;q=0.8"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_jpeg).to_be_true()
+        expect(params.accepts_webp).to_be_false()
+
+    @staticmethod
+    def test_image_wildcard_accepts_image_formats():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "image/*;q=0.8"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_webp).to_be_true()
+        expect(params.accepts_avif).to_be_true()
+        expect(params.accepts_heif).to_be_true()
+        expect(params.accepts_png).to_be_true()
+        expect(params.accepts_jpeg).to_be_true()
+
+    @staticmethod
+    def test_image_wildcard_rejection_overrides_accept_any():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "image/*;q=0,*/*;q=0.8"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_webp).to_be_false()
+        expect(params.accepts_avif).to_be_false()
+        expect(params.accepts_heif).to_be_false()
+        expect(params.accepts_png).to_be_false()
+        expect(params.accepts_jpeg).to_be_false()
+
+    @staticmethod
+    def test_accept_header_parses_quoted_delimiters_before_quality():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": 'image/webp;profile="a,b;c";q=0,image/jpeg'},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_webp).to_be_false()
+        expect(params.accepts_jpeg).to_be_true()
+
+    @staticmethod
+    def test_unparameterized_media_range_controls_default_representation():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "image/webp;profile=foo;q=1,image/webp;q=0"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_webp).to_be_false()
+
+    @staticmethod
+    def test_canonical_jpeg_rejection_takes_precedence_over_jpg_alias():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "image/jpeg;q=0,image/jpg;q=1"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_jpeg).to_be_false()
+
+    @staticmethod
+    def test_preserves_legacy_positional_arguments():
+        request = mock.Mock(
+            path="/legacy.jpg",
+            headers={"Accept": "image/webp"},
+        )
+        legacy_positional_arguments = [None] * 32
+        legacy_positional_arguments[28:] = [True, request, 3600, False]
+
+        params = RequestParameters(*legacy_positional_arguments)
+
+        expect(params.url).to_equal("/legacy.jpg")
+        expect(params.accepts_webp).to_be_true()
+        expect(params.max_age).to_equal(3600)
+        expect(params.auto_png_to_jpg).to_be_false()
 
 
 class ContextImporterTestCase(TestCase):

--- a/thumbor/auto_image_format.py
+++ b/thumbor/auto_image_format.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2025 globo.com thumbor@googlegroups.com
+
+from thumbor.utils import logger
+
+DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE = ("webp", "avif", "jpg", "heif", "png")
+VALID_AUTO_IMAGE_FORMATS = frozenset(DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE)
+AUTO_IMAGE_FORMAT_CACHE_KEY_PREFIX = "auto_format_v1"
+
+AUTO_IMAGE_FORMAT_CONFIG_FLAGS = {
+    "webp": "AUTO_WEBP",
+    "avif": "AUTO_AVIF",
+    "jpg": "AUTO_JPG",
+    "heif": "AUTO_HEIF",
+    "png": "AUTO_PNG",
+}
+
+AUTO_IMAGE_FORMAT_ACCEPT_ATTRS = {
+    "webp": "accepts_webp",
+    "avif": "accepts_avif",
+    "jpg": "accepts_jpeg",
+    "heif": "accepts_heif",
+    "png": "accepts_png",
+}
+
+
+def _get_raw_auto_image_format_preference(config):
+    return tuple(getattr(config, "AUTO_IMAGE_FORMAT_PREFERENCE", ()) or ())
+
+
+def has_auto_image_format_preference(config):
+    return bool(get_normalized_auto_image_format_preference(config))
+
+
+def get_normalized_auto_image_format_preference(config):
+    raw_preference = _get_raw_auto_image_format_preference(config)
+    cached_preference = getattr(
+        config,
+        "_AUTO_IMAGE_FORMAT_PREFERENCE_CACHE",
+        None,
+    )
+
+    if cached_preference is None or cached_preference[0] != raw_preference:
+        normalized_preference = []
+        invalid_formats = []
+        seen_formats = set()
+
+        for image_format in raw_preference:
+            if not isinstance(image_format, str):
+                invalid_formats.append(image_format)
+                continue
+
+            normalized_format = image_format.strip().lower()
+
+            if normalized_format not in VALID_AUTO_IMAGE_FORMATS:
+                invalid_formats.append(image_format)
+                continue
+
+            if normalized_format in seen_formats:
+                continue
+
+            seen_formats.add(normalized_format)
+            normalized_preference.append(normalized_format)
+
+        if invalid_formats:
+            logger.warning(
+                "Ignoring invalid AUTO_IMAGE_FORMAT_PREFERENCE values: %r. "
+                "Valid formats are: %s.",
+                invalid_formats,
+                ", ".join(DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE),
+            )
+
+        cached_preference = (
+            raw_preference,
+            tuple(normalized_preference),
+        )
+        setattr(
+            config,
+            "_AUTO_IMAGE_FORMAT_PREFERENCE_CACHE",
+            cached_preference,
+        )
+
+    return cached_preference[1]
+
+
+def get_active_auto_image_formats(config):
+    if has_auto_image_format_preference(config):
+        return get_normalized_auto_image_format_preference(config)
+
+    active_formats = []
+
+    for image_format in DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE:
+        config_flag = AUTO_IMAGE_FORMAT_CONFIG_FLAGS[image_format]
+
+        if getattr(config, config_flag, False):
+            active_formats.append(image_format)
+
+    return tuple(active_formats)
+
+
+def requires_auto_image_format_cache_isolation(config):
+    """Return whether legacy ``default``/``auto_webp`` keys are unsafe."""
+    if has_auto_image_format_preference(config):
+        return True
+
+    return getattr(config, "AUTO_PNG_TO_JPG", False) or any(
+        getattr(config, AUTO_IMAGE_FORMAT_CONFIG_FLAGS[image_format], False)
+        for image_format in DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE
+        if image_format != "webp"
+    )
+
+
+def get_auto_image_format_cache_key(config, request):
+    """Return the cache variant for an auto-format request.
+
+    Result storage implementations can use this helper to keep responses for
+    different ``Accept`` capabilities in separate cache namespaces.
+    """
+    preference_enabled = has_auto_image_format_preference(config)
+    active_formats = get_active_auto_image_formats(config)
+    cache_isolation_required = requires_auto_image_format_cache_isolation(
+        config
+    )
+
+    if not active_formats and not cache_isolation_required:
+        return None
+
+    accepted_formats = []
+
+    for image_format in active_formats:
+        accept_attr = AUTO_IMAGE_FORMAT_ACCEPT_ATTRS[image_format]
+
+        if getattr(request, accept_attr, False):
+            accepted_formats.append(image_format)
+
+    if cache_isolation_required:
+        policy = "preference" if preference_enabled else "flags"
+        fallback = (
+            "png_to_jpg"
+            if getattr(config, "AUTO_PNG_TO_JPG", False)
+            else "preserve"
+        )
+        variant = "-".join(accepted_formats) or "default"
+        return (
+            f"{AUTO_IMAGE_FORMAT_CACHE_KEY_PREFIX}_{policy}_"
+            f"{fallback}_{variant}"
+        )
+
+    if not accepted_formats:
+        return None
+
+    return "auto_" + "-".join(accepted_formats)
+
+
+def get_legacy_auto_image_format_cache_key(config, request):
+    """Return the cache variant used by the legacy ``v2`` file layout."""
+    if getattr(config, "AUTO_WEBP", False) and getattr(
+        request, "accepts_webp", False
+    ):
+        return "auto_webp"
+
+    return None

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -236,6 +236,15 @@ Config.define(
     "Imaging",
 )
 Config.define(
+    "AUTO_IMAGE_FORMAT_PREFERENCE",
+    [],
+    "Ordered list of preferred formats to be used automatically. "
+    "Valid formats are webp, avif, jpg, heif and png. A list containing at "
+    "least one valid format overrides all individual AUTO_* format settings, "
+    "but AUTO_PNG_TO_JPG remains an independent fallback.",
+    "Imaging",
+)
+Config.define(
     "SVG_DPI",
     150,
     "Specify the ratio between 1in and 1px for SVG images. This is only used when "

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -14,6 +14,95 @@ from thumbor.metrics.logger_metrics import Metrics
 from thumbor.threadpool import ThreadPool
 
 
+def _split_http_header(value, delimiter):
+    parts = []
+    current_part = []
+    quoted = False
+    escaped = False
+
+    for character in value:
+        if escaped:
+            current_part.append(character)
+            escaped = False
+            continue
+
+        if quoted and character == "\\":
+            current_part.append(character)
+            escaped = True
+            continue
+
+        if character == '"':
+            quoted = not quoted
+        elif character == delimiter and not quoted:
+            parts.append("".join(current_part))
+            current_part = []
+            continue
+
+        current_part.append(character)
+
+    parts.append("".join(current_part))
+    return parts
+
+
+def _parse_accept_quality(value):
+    try:
+        quality = float(value.strip())
+    except ValueError:
+        return 0.0
+
+    return quality if 0 <= quality <= 1 else 0.0
+
+
+def _parse_accept_media_range(media_range):
+    parts = [part.strip() for part in _split_http_header(media_range, ";")]
+    media_type = parts[0].lower()
+
+    if not media_type:
+        return None
+
+    for parameter in parts[1:]:
+        name, separator, value = parameter.partition("=")
+        if not separator:
+            continue
+
+        if name.strip().lower() == "q":
+            return media_type, _parse_accept_quality(value)
+
+        # Parameters before q apply to the media type itself. Since thumbor
+        # cannot match those variants, the media range is not applicable.
+        return None
+
+    return media_type, 1.0
+
+
+def _parse_accept_header(accept_header):
+    accepted_media_types = {}
+
+    for media_range in _split_http_header(accept_header or "", ","):
+        parsed_media_range = _parse_accept_media_range(media_range)
+        if parsed_media_range is None:
+            continue
+
+        media_type, quality = parsed_media_range
+        accepted_media_types[media_type] = max(
+            quality,
+            accepted_media_types.get(media_type, 0.0),
+        )
+
+    return accepted_media_types
+
+
+def _accepts_media_type(accepted_media_types, *media_types, allow_any=False):
+    for media_type in media_types:
+        if media_type in accepted_media_types:
+            return accepted_media_types[media_type] > 0
+
+    if "image/*" in accepted_media_types:
+        return accepted_media_types["image/*"] > 0
+
+    return allow_any and accepted_media_types.get("*/*", 0) > 0
+
+
 # Same logic as Importer. This class is very useful and will remain like so for now
 class Context:  # pylint: disable=too-many-instance-attributes
     """
@@ -170,6 +259,10 @@ class RequestParameters:  # pylint: disable=too-few-public-methods,too-many-inst
         request=None,
         max_age=None,
         auto_png_to_jpg=None,
+        accepts_avif=False,
+        accepts_heif=False,
+        accepts_png=False,
+        accepts_jpeg=False,
     ):
         self.debug = bool(debug)
         self.meta = bool(meta)
@@ -232,19 +325,59 @@ class RequestParameters:  # pylint: disable=too-few-public-methods,too-many-inst
         self.prevent_result_storage = False
         self.unsafe = unsafe == "unsafe" or unsafe is True
         self.format = None
-        self.accepts_webp = accepts_webp
+        self._set_accepted_image_formats(
+            (
+                accepts_webp,
+                accepts_avif,
+                accepts_heif,
+                accepts_png,
+                accepts_jpeg,
+            )
+        )
         self.max_bytes = None
         self.max_age = max_age
         self.auto_png_to_jpg = auto_png_to_jpg
         self.headers = None
+        self._accepted_media_types = {}
 
         if request:
-            self.url = request.path
-            self.accepts_webp = "image/webp" in request.headers.get(
-                "Accept", ""
+            self._set_request_headers(request)
+
+    def _set_request_headers(self, request):
+        accept_header = ""
+        self.url = request.path
+        if request.headers:
+            self.headers = request.headers
+            accept_header = request.headers.get("Accept", "")
+
+        self._set_accepted_image_formats_from_header(accept_header)
+
+    def _set_accepted_image_formats_from_header(self, accept_header):
+        accepted_media_types = _parse_accept_header(accept_header)
+        self._accepted_media_types = accepted_media_types
+        self._set_accepted_image_formats(
+            (
+                _accepts_media_type(accepted_media_types, "image/webp"),
+                _accepts_media_type(accepted_media_types, "image/avif"),
+                _accepts_media_type(accepted_media_types, "image/heif"),
+                _accepts_media_type(accepted_media_types, "image/png"),
+                _accepts_media_type(
+                    accepted_media_types,
+                    "image/jpeg",
+                    "image/jpg",
+                    allow_any=True,
+                ),
             )
-            if request.headers:
-                self.headers = request.headers
+        )
+
+    def _set_accepted_image_formats(self, accepted_formats):
+        (
+            self.accepts_webp,
+            self.accepts_avif,
+            self.accepts_heif,
+            self.accepts_png,
+            self.accepts_jpeg,
+        ) = accepted_formats
 
     @staticmethod
     def int_or_0(value):

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -19,6 +19,12 @@ from tornado.locks import Condition
 
 import thumbor.filters
 from thumbor import __version__
+from thumbor.auto_image_format import (
+    DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE,
+    get_active_auto_image_formats,
+    get_normalized_auto_image_format_preference,
+    has_auto_image_format_preference,
+)
 from thumbor.context import Context, RequestParameters
 from thumbor.engines import BaseEngine, EngineResult
 from thumbor.engines.json_engine import JSONEngine
@@ -30,6 +36,30 @@ from thumbor.transformer import Transformer
 from thumbor.utils import CONTENT_TYPE, EXTENSION, logger
 
 HTTP_DATE_FMT = "%a, %d %b %Y %H:%M:%S GMT"
+
+PREFERENCE_AUTO_IMAGE_FORMAT_METHODS = {
+    "webp": "_supports_webp",
+    "avif": "_supports_avif",
+    "jpg": "_supports_jpg",
+    "heif": "_supports_heif",
+    "png": "_supports_png",
+}
+
+LEGACY_AUTO_IMAGE_FORMAT_METHODS = {
+    "webp": "can_auto_convert_to_webp",
+    "avif": "can_auto_convert_to_avif",
+    "jpg": "_can_auto_convert_to_jpg_in_legacy_mode",
+    "heif": "can_auto_convert_to_heif",
+    "png": "can_auto_convert_to_png",
+}
+
+LEGACY_AUTO_IMAGE_FORMAT_LOG_MESSAGES = {
+    "webp": "Image format set by AUTO_WEBP as %s.",
+    "avif": "Image format set by AUTO_AVIF as %s.",
+    "jpg": "Image format set by AUTO_PNG_TO_JPG or AUTO_JPG as %s.",
+    "heif": "Image format set by AUTO_HEIF as %s.",
+    "png": "Image format set by AUTO_PNG as %s.",
+}
 
 # Handlers should not override __init__ pylint: disable=attribute-defined-outside-init,arguments-differ
 # pylint: disable=broad-except,abstract-method,too-many-branches,too-many-return-statements,too-many-statements,too-many-lines
@@ -138,7 +168,11 @@ class BaseHandler(tornado.web.RequestHandler):
             or not self.context.request.unsafe
         )
 
-        if self.context.modules.result_storage and should_store:
+        if (
+            self.context.modules.result_storage
+            and should_store
+            and self._can_use_result_storage_with_auto_image_formats()
+        ):
             start = datetime.datetime.now()
 
             try:
@@ -349,13 +383,23 @@ class BaseHandler(tornado.web.RequestHandler):
 
         await self.finish_request()
 
-    def is_webp(self, context):
+    def _supports_webp(self, context=None):
+        if context is None:
+            context = self.context
+
+        request = context.request
+
         return (
-            context.config.AUTO_WEBP
-            and context.request.accepts_webp
-            and not context.request.engine.is_multiple()
-            and context.request.engine.can_convert_to_webp()
+            request.accepts_webp
+            and not request.engine.is_multiple()
+            and request.engine.can_convert_to_webp()
         )
+
+    def is_webp(self, context):
+        return context.config.AUTO_WEBP and self._supports_webp(context)
+
+    def can_auto_convert_to_webp(self):
+        return self.is_webp(self.context)
 
     def is_animated_gif(self, data):
         if data[:6] not in [b"GIF87a", b"GIF89a"]:
@@ -404,8 +448,8 @@ class BaseHandler(tornado.web.RequestHandler):
         config = self.context.config
 
         enabled = (
-            request_override is None
-            if config.AUTO_PNG_TO_JPG
+            config.AUTO_PNG_TO_JPG
+            if request_override is None
             else request_override
         )
 
@@ -415,67 +459,190 @@ class BaseHandler(tornado.web.RequestHandler):
         return False
 
     def accepts_mime_type(self, mimetype=""):
-        if self.context.request and self.context.request.headers:
-            return mimetype in self.context.request.headers.get("Accept", "")
+        request = self.context.request
+        if request and request.headers:
+            accepted_media_types = getattr(
+                request, "_accepted_media_types", None
+            )
+            if accepted_media_types is not None:
+                normalized_mimetype = mimetype.strip().lower()
+
+                if normalized_mimetype in accepted_media_types:
+                    return accepted_media_types[normalized_mimetype] > 0
+
+                return (
+                    normalized_mimetype.startswith("image/")
+                    and normalized_mimetype != "image/*"
+                    and accepted_media_types.get("image/*", 0) > 0
+                )
+
+            return mimetype in request.headers.get("Accept", "")
 
         return False
 
-    def can_auto_convert_to_avif(self):
-        auto_avif = self.context.config.AUTO_AVIF
-        accepts_avif = self.accepts_mime_type("image/avif")
+    def _custom_accepts_jpeg(self, accepts_mime_type_method):
+        accepted_media_types = getattr(
+            self.context.request,
+            "_accepted_media_types",
+            None,
+        )
+        if accepted_media_types is not None:
+            for mimetype in (
+                "image/jpeg",
+                "image/jpg",
+                "image/*",
+                "*/*",
+            ):
+                if mimetype in accepted_media_types:
+                    if accepted_media_types[mimetype] <= 0:
+                        return False
+                    break
 
-        if (
-            auto_avif is True
-            and accepts_avif is True
-            and not self.context.request.engine.is_multiple()
-        ):
-            return self.context.request.engine.can_auto_convert_to_avif()
-
-        return False
-
-    def can_auto_convert_to_heif(self):
-        auto_heif = self.context.config.AUTO_HEIF
-        accepts_heif = self.accepts_mime_type("image/heif")
-
-        if (
-            auto_heif
-            and accepts_heif
-            and not self.context.request.engine.is_multiple()
-        ):
-            return self.context.request.engine.can_auto_convert_to_heif()
-
-        return False
-
-    def can_auto_convert_to_jpg(self):
-        auto_jpg = self.context.config.AUTO_JPG
-        accepts_jpg = (
-            self.accepts_mime_type("*/*")
-            or self.accepts_mime_type("image/jpg")
-            or self.accepts_mime_type("image/jpeg")
+        return any(
+            accepts_mime_type_method(mimetype)
+            for mimetype in ("*/*", "image/jpg", "image/jpeg")
         )
 
-        if (
-            auto_jpg
-            and accepts_jpg
-            and not self.context.request.engine.is_multiple()
-            and not self.context.request.engine.has_transparency()
-        ):
-            return True
+    def _has_custom_accepts_mime_type(self):
+        accepts_mime_type_method = self.accepts_mime_type
+        return (
+            getattr(accepts_mime_type_method, "__func__", None)
+            is not BaseHandler.accepts_mime_type
+        )
 
-        return False
+    def _can_use_result_storage_with_auto_image_formats(self):
+        active_formats = get_active_auto_image_formats(self.context.config)
+        has_extended_format = any(
+            image_format != "webp" for image_format in active_formats
+        )
+
+        return not (
+            has_extended_format and self._has_custom_accepts_mime_type()
+        )
+
+    def _accepts_parsed_mime_type(self, accept_attr, *mimetypes):
+        accepts_mime_type_method = self.accepts_mime_type
+        if self._has_custom_accepts_mime_type():
+            if accept_attr == "accepts_jpeg":
+                return self._custom_accepts_jpeg(accepts_mime_type_method)
+
+            return any(
+                accepts_mime_type_method(mimetype) for mimetype in mimetypes
+            )
+
+        return bool(getattr(self.context.request, accept_attr, False))
+
+    def _supports_avif(self):
+        request = self.context.request
+
+        return (
+            self._accepts_parsed_mime_type("accepts_avif", "image/avif")
+            and not request.engine.is_multiple()
+            and request.engine.can_auto_convert_to_avif()
+        )
+
+    def can_auto_convert_to_avif(self):
+        return self.context.config.AUTO_AVIF and self._supports_avif()
+
+    def _supports_heif(self):
+        request = self.context.request
+
+        return (
+            self._accepts_parsed_mime_type("accepts_heif", "image/heif")
+            and not request.engine.is_multiple()
+            and request.engine.can_auto_convert_to_heif()
+        )
+
+    def can_auto_convert_to_heif(self):
+        return self.context.config.AUTO_HEIF and self._supports_heif()
+
+    def _supports_jpg(self):
+        request = self.context.request
+        accepts_jpg = self._accepts_parsed_mime_type(
+            "accepts_jpeg", "*/*", "image/jpg", "image/jpeg"
+        )
+
+        return (
+            accepts_jpg
+            and not request.engine.is_multiple()
+            and not request.engine.has_transparency()
+        )
+
+    def can_auto_convert_to_jpg(self):
+        return self.context.config.AUTO_JPG and self._supports_jpg()
+
+    def _can_auto_convert_to_jpg_in_legacy_mode(self):
+        return (
+            self.can_auto_convert_png_to_jpg()
+            or self.can_auto_convert_to_jpg()
+        )
+
+    def _supports_png(self):
+        request = self.context.request
+
+        return (
+            self._accepts_parsed_mime_type("accepts_png", "image/png")
+            and not request.engine.is_multiple()
+        )
 
     def can_auto_convert_to_png(self):
-        auto_png = self.context.config.AUTO_PNG
-        accepts_png = self.accepts_mime_type("image/png")
+        return self.context.config.AUTO_PNG and self._supports_png()
 
-        if (
-            auto_png
-            and accepts_png
-            and not self.context.request.engine.is_multiple()
-        ):
-            return True
+    def _resolve_auto_image_extension(self, context):
+        if has_auto_image_format_preference(context.config):
+            for image_format in get_normalized_auto_image_format_preference(
+                context.config
+            ):
+                method_name = PREFERENCE_AUTO_IMAGE_FORMAT_METHODS[
+                    image_format
+                ]
 
-        return False
+                if getattr(self, method_name)():
+                    image_extension = f".{image_format}"
+                    logger.debug(
+                        "Image format set by AUTO_IMAGE_FORMAT_PREFERENCE as %s.",
+                        image_extension,
+                    )
+
+                    return image_extension
+
+            if self.can_auto_convert_png_to_jpg():
+                image_extension = ".jpg"
+                logger.debug(
+                    "Image format set by AUTO_PNG_TO_JPG as %s.",
+                    image_extension,
+                )
+
+                return image_extension
+
+            image_extension = context.request.engine.extension
+            logger.debug(
+                "No preferred image format matched. Retrieving from engine "
+                "extension: %s.",
+                image_extension,
+            )
+
+            return image_extension
+
+        for image_format in DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE:
+            method_name = LEGACY_AUTO_IMAGE_FORMAT_METHODS[image_format]
+
+            if getattr(self, method_name)():
+                image_extension = f".{image_format}"
+                logger.debug(
+                    LEGACY_AUTO_IMAGE_FORMAT_LOG_MESSAGES[image_format],
+                    image_extension,
+                )
+
+                return image_extension
+
+        image_extension = context.request.engine.extension
+        logger.debug(
+            "No image format specified. Retrieving from engine extension: %s.",
+            image_extension,
+        )
+
+        return image_extension
 
     def define_image_type(self, context, result):
         if result is not None:
@@ -483,6 +650,7 @@ class BaseHandler(tornado.web.RequestHandler):
                 buffer = result.buffer
             else:
                 buffer = result
+
             image_extension = EXTENSION.get(
                 BaseEngine.get_mimetype(buffer), ".jpg"
             )
@@ -497,42 +665,9 @@ class BaseHandler(tornado.web.RequestHandler):
         if image_extension is not None:
             image_extension = f".{image_extension}"
             logger.debug("Image format specified as %s.", image_extension)
-        elif self.is_webp(context):
-            image_extension = ".webp"
-            logger.debug(
-                "Image format set by AUTO_WEBP as %s.", image_extension
-            )
-        elif self.can_auto_convert_to_avif():
-            image_extension = ".avif"
-            logger.debug(
-                "Image format set by AUTO_AVIF as %s.", image_extension
-            )
-        elif (
-            self.can_auto_convert_png_to_jpg()
-            or self.can_auto_convert_to_jpg()
-        ):
-            image_extension = ".jpg"
-            logger.debug(
-                "Image format set by AUTO_PNG_TO_JPG or AUTO_JPG as %s.",
-                image_extension,
-            )
-        elif self.can_auto_convert_to_heif():
-            image_extension = ".heif"
-            logger.debug(
-                "Image format set by AUTO_HEIF as %s.", image_extension
-            )
-        elif self.can_auto_convert_to_png():
-            image_extension = ".png"
-            logger.debug(
-                "Image format set by AUTO_PNG as %s.", image_extension
-            )
+
         else:
-            image_extension = context.request.engine.extension
-            logger.debug(
-                "No image format specified. Retrieving "
-                "from the image extension: %s.",
-                image_extension,
-            )
+            image_extension = self._resolve_auto_image_extension(context)
 
         content_type = CONTENT_TYPE.get(image_extension, CONTENT_TYPE[".jpg"])
 
@@ -650,6 +785,7 @@ class BaseHandler(tornado.web.RequestHandler):
         should_store = (
             result_storage
             and not context.request.prevent_result_storage
+            and self._can_use_result_storage_with_auto_image_formats()
             and (
                 context.config.RESULT_STORAGE_STORES_UNSAFE
                 or not context.request.unsafe
@@ -738,11 +874,7 @@ class BaseHandler(tornado.web.RequestHandler):
             buffer = results
 
         # auto-convert configured?
-        should_vary = (
-            self.context.config.AUTO_WEBP
-            or self.context.config.AUTO_AVIF
-            or self.context.config.AUTO_HEIF
-        )
+        should_vary = bool(get_active_auto_image_formats(self.context.config))
         # we have image (not video)
         should_vary = should_vary and content_type.startswith("image/")
         # output format is not requested via format filter

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -16,6 +16,11 @@ from uuid import uuid4
 
 import pytz
 
+from thumbor.auto_image_format import (
+    get_auto_image_format_cache_key,
+    get_legacy_auto_image_format_cache_key,
+    requires_auto_image_format_cache_isolation,
+)
 from thumbor.engines import BaseEngine
 from thumbor.result_storages import BaseStorage, ResultStorageResult
 from thumbor.utils import deprecated, logger
@@ -26,8 +31,14 @@ class Storage(BaseStorage):
 
     @property
     def is_auto_webp(self):
+        """Whether the request used the WebP variant in the legacy layout."""
+        request = getattr(self.context, "request", None)
+
         return (
-            self.context.config.AUTO_WEBP and self.context.request.accepts_webp
+            get_legacy_auto_image_format_cache_key(
+                self.context.config, request
+            )
+            == "auto_webp"
         )
 
     async def put(self, image_bytes):
@@ -75,7 +86,7 @@ class Storage(BaseStorage):
 
         if not exists(file_abspath):
             legacy_path = self.normalize_path_legacy(path)
-            if isfile(legacy_path):
+            if self.can_migrate_legacy_path() and isfile(legacy_path):
                 logger.debug(
                     "[RESULT_STORAGE] migrating image from old location at %s",
                     legacy_path,
@@ -120,9 +131,35 @@ class Storage(BaseStorage):
                 "/"
             )
         )
-        prefix = "auto_webp" if self.is_auto_webp else "default"
+        prefix = self.get_auto_image_format_cache_key() or "default"
 
         return f"{root_path}/{prefix}/{digest[:2]}/{digest[2:4]}/{digest[4:]}"
+
+    def get_auto_image_format_cache_key(self):
+        request = getattr(self.context, "request", None)
+
+        if request is None:
+            return None
+
+        if (
+            not requires_auto_image_format_cache_isolation(self.context.config)
+            and type(self).is_auto_webp is not Storage.is_auto_webp
+        ):
+            return "auto_webp" if self.is_auto_webp else None
+
+        return get_auto_image_format_cache_key(self.context.config, request)
+
+    def can_migrate_legacy_path(self):
+        request = getattr(self.context, "request", None)
+
+        if request is None:
+            return False
+
+        if requires_auto_image_format_cache_isolation(self.context.config):
+            return False
+
+        legacy_cache_key = "auto_webp" if self.is_auto_webp else None
+        return self.get_auto_image_format_cache_key() == legacy_cache_key
 
     def normalize_path_legacy(self, path):
         path = unquote(path)

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -49,6 +49,12 @@ home = expanduser("~")
 ## pillow-heif is enabled
 # AUTO_HEIF = False
 
+## Preferred order for automatic output formats. Valid values are webp, avif,
+## jpg, heif and png. Invalid values are ignored with a warning. A list with at
+## least one valid value overrides all individual AUTO_* options above; an empty
+## list or one with no valid values keeps legacy behavior.
+# AUTO_IMAGE_FORMAT_PREFERENCE = []
+
 ## Automatically converts PNG to JPG if PNG has no transparency.
 ## WARNING: Depending on case, this is not a good deal. This
 ## transformation maybe causes distortions or the size of image can increase.


### PR DESCRIPTION
Ordered list of preferred formats to be used automatically.

Example: `['webp', 'avif', 'jpg', 'png', 'heif']`

If set, this overrides the individual AUTO_* format settings.