### PR TITLE
Remove run-time dependency on setuptools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ setup:
 	@echo  "\n\nYou are strongly recommended to run 'pre-commit install'\n"
 
 compile_ext build:
+	@$(PYTHON) -m pip install setuptools
 	@$(PYTHON) setup.py build_ext -i
 
 test: build redis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
   "piexif>=1.1.3,<2.0.0",
   "Pillow>=10.4.0,<13.0.0",
   "pytz>=2023.3.post1,<2027.0.0",
-  "setuptools>=78.1.1,<79.0.0",
   "statsd>=4.0.1,<5.0.0",
   "thumbor-plugins-gifv>=0.1.5,<1.0.0",
   "tornado>=6.4,<7.0.0",


### PR DESCRIPTION
https://github.com/thumbor/thumbor/pull/1699 added a run-time dependency on `setuptools` with the rationale that Python 3.12 removed it from the default dependencies.  That would make sense if thumbor needed `setuptools` at run-time.  However, thumbor doesn't use `setuptools` at run-time (or anything else shipped with it, such as `distutils` or `pkg_resources`).

Of course `setuptools` is needed to run `setup.py` itself, but a dependency expressed in `install_requires` has never done anything to achieve that because `setuptools` has to be present in order to process that dependency.  `pyproject.toml` already has `build-system.requires`, which is the correct way to express the build-time dependency.

It therefore seems to make most sense to simply drop this run-time dependency.

A better workaround for the original problem is to explicitly install `setuptools` before explicitly running `setup.py`.

Closes: #1692