### PR TITLE
Add metrics for filters

### DIFF
--- a/docs/custom_filters.rst
+++ b/docs/custom_filters.rst
@@ -34,6 +34,13 @@ Let's analyse it:
 - The filter method should be named according to how you want it to be invoked by thumbor (a.k.a the URL part). In our example, our filter will be invoked with ``quality(99)``;
 - The filter method is just an async function that you can do whatever you need with the image.
 
+When a metrics backend is enabled, each filter execution emits a
+``filter.<filter_name>.time`` timing. Successful executions also emit
+``filter.<filter_name>.count``, while failed executions emit
+``filter.<filter_name>.error``. The ``<filter_name>`` portion comes from the
+decorated method name, so it should stay stable if you rely on dashboards or
+alerts.
+
 And that's it, we got our filter. In order to use it, we need to put it in our ``thumbor.conf``:
 
 .. code:: python

--- a/tests/filters/test_base_filter.py
+++ b/tests/filters/test_base_filter.py
@@ -8,7 +8,7 @@
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from preggy import expect
@@ -446,3 +446,142 @@ class WithPreLoadFilterTestCase(BaseFilterTestCase):
             thumbor.filters.PHASE_PRE_LOAD
         ]
         expect(instances[0].params).to_equal(["aaaa"])
+
+
+class FilterMethodMetricsTestCase(TestCase):
+
+    def _make_context(self, multiple=False, frame_count=3):
+        cfg = Config()
+        importer = Importer(cfg)
+        importer.import_modules()
+        context = Context(config=cfg, importer=importer)
+        context.metrics = MagicMock()
+
+        if multiple:
+            context.modules.engine.is_multiple = lambda: True
+            context.modules.engine.frame_engines = lambda: [
+                MagicMock() for _ in range(frame_count)
+            ]
+        else:
+            context.modules.engine.is_multiple = lambda: False
+
+        return context
+
+    def _make_success_filter(self, context):
+        class _SuccessFilter(BaseFilter):
+            @filter_method(BaseFilter.Number)
+            async def success_filter(self, value):
+                return value
+
+        _SuccessFilter.__module__ = "thumbor.filters.success_filter"
+        _SuccessFilter.pre_compile()
+        return _SuccessFilter("success_filter(42)", context)
+
+    def _make_error_filter(self, context):
+        class _ErrorFilter(BaseFilter):
+            @filter_method(BaseFilter.Number)
+            async def error_filter(self, value):
+                raise ValueError("boom")
+
+        _ErrorFilter.__module__ = "thumbor.filters.error_filter"
+        _ErrorFilter.pre_compile()
+        return _ErrorFilter("error_filter(1)", context)
+
+    @gen_test
+    async def test_emits_count_and_timing_on_success(self):
+        context = self._make_context()
+        instance = self._make_success_filter(context)
+        await instance.run()
+
+        context.metrics.incr.assert_called_once_with(
+            "filter.success_filter.count"
+        )
+        context.metrics.timing.assert_called_once()
+        expect(context.metrics.timing.call_args[0][0]).to_equal(
+            "filter.success_filter.time"
+        )
+
+    @gen_test
+    async def test_emits_metrics_once_for_multiple_engines(self):
+        context = self._make_context(multiple=True)
+        instance = self._make_success_filter(context)
+        result = await instance.run()
+
+        expect(result).to_equal([42, 42, 42])
+        context.metrics.incr.assert_called_once_with(
+            "filter.success_filter.count"
+        )
+        context.metrics.timing.assert_called_once()
+        expect(context.metrics.timing.call_args[0][0]).to_equal(
+            "filter.success_filter.time"
+        )
+
+    @gen_test
+    async def test_uses_filter_name_instead_of_module_name_in_metrics(self):
+        context = self._make_context()
+
+        class _AliasedFilter(BaseFilter):
+            @filter_method(BaseFilter.Number)
+            async def public_name(self, value):
+                return value
+
+        _AliasedFilter.__module__ = "thumbor.filters.internal_module_name"
+        factory = FiltersFactory([_AliasedFilter])
+        runner = factory.create_instances(context, "public_name(42)")
+        filters = runner.filter_instances[thumbor.filters.PHASE_POST_TRANSFORM]
+
+        await filters[0].run()
+
+        incr_calls = [c[0][0] for c in context.metrics.incr.call_args_list]
+        timing_calls = [c[0][0] for c in context.metrics.timing.call_args_list]
+
+        expect(incr_calls).to_include("filter.public_name.count")
+        expect(timing_calls).to_include("filter.public_name.time")
+        expect(incr_calls).Not.to_include("filter.internal_module_name.count")
+        expect(timing_calls).Not.to_include("filter.internal_module_name.time")
+
+    @gen_test
+    async def test_timing_value_is_non_negative_integer(self):
+        context = self._make_context()
+        instance = self._make_success_filter(context)
+        await instance.run()
+
+        _, elapsed = context.metrics.timing.call_args[0]
+
+        expect(elapsed).to_be_instance_of(int)
+        expect(elapsed).to_be_greater_or_equal_to(0)
+        expect(elapsed).to_be_lesser_than(5000)
+
+    @gen_test
+    async def test_emits_error_and_timing_on_exception(self):
+        context = self._make_context()
+        instance = self._make_error_filter(context)
+
+        with expect.error_to_happen(ValueError, message="boom"):
+            await instance.run()
+
+        context.metrics.incr.assert_called_once_with(
+            "filter.error_filter.error"
+        )
+        context.metrics.timing.assert_called_once()
+        expect(context.metrics.timing.call_args[0][0]).to_equal(
+            "filter.error_filter.time"
+        )
+
+    @gen_test
+    async def test_does_not_fail_when_metrics_is_none(self):
+        context = self._make_context()
+        context.metrics = None
+
+        class _SafeFilter(BaseFilter):
+            @filter_method(BaseFilter.Number)
+            async def safe_filter(self, value):
+                return value
+
+        _SafeFilter.__module__ = "thumbor.filters.safe_filter"
+        _SafeFilter.pre_compile()
+
+        instance = _SafeFilter("safe_filter(7)", context)
+
+        with expect.error_not_to_happen(Exception):
+            await instance.run()

--- a/thumbor/filters/__init__.py
+++ b/thumbor/filters/__init__.py
@@ -8,7 +8,9 @@
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
 import collections
+import functools
 import re
+import time
 
 BUILTIN_FILTERS = [
     "thumbor.filters.brightness",
@@ -51,6 +53,7 @@ PHASE_AFTER_LOAD = "after-load"
 
 def filter_method(*args):
     def _filter_deco(filtered_function):
+        @functools.wraps(filtered_function)
         async def wrapper(self, *args2):
             return await filtered_function(self, *args2)
 
@@ -61,11 +64,15 @@ def filter_method(*args):
             )
             defaults = default_padding + list(filtered_function.__defaults__)
 
-        wrapper.filter_data = {
-            "name": filtered_function.__name__,
-            "params": args,
-            "defaults": defaults,
-        }
+        setattr(
+            wrapper,
+            "filter_data",
+            {
+                "name": filtered_function.__name__,
+                "params": args,
+                "defaults": defaults,
+            },
+        )
         return wrapper
 
     return _filter_deco
@@ -203,6 +210,10 @@ class BaseFilter:
         if self.params is None:
             return
 
+        metrics = self.context.metrics if self.context else None
+        filter_name = self.runnable_method.filter_data["name"]
+        start = time.perf_counter()
+
         if self.engine:
             if self.engine.is_multiple():
                 engines_to_run = self.engine.frame_engines()
@@ -212,8 +223,18 @@ class BaseFilter:
             engines_to_run = [None]
 
         results = []
-        for engine in engines_to_run:
-            self.engine = engine
-            results.append(await self.runnable_method(*self.params))
-
-        return results
+        try:
+            for engine in engines_to_run:
+                self.engine = engine
+                results.append(await self.runnable_method(*self.params))
+            if metrics:
+                metrics.incr(f"filter.{filter_name}.count")
+            return results
+        except Exception:
+            if metrics:
+                metrics.incr(f"filter.{filter_name}.error")
+            raise
+        finally:
+            if metrics:
+                elapsed = int(round((time.perf_counter() - start) * 1000))
+                metrics.timing(f"filter.{filter_name}.time", elapsed)


### PR DESCRIPTION
Introduce success, error, and timing metrics for filters at the filter execution level, including multi-frame images. Use time.perf_counter() for timing, add coverage for multi-frame engines, and document the metric behavior.



When a metrics backend is enabled, each filter execution emits a ``filter.<filter_name>.time`` timing. Successful executions also emit ``filter.<filter_name>.count``, while failed executions emit ``filter.<filter_name>.error``. The ``<filter_name>`` portion comes from the decorated method name, so it should stay stable if you rely on dashboards or alerts.