### PR TITLE
Respect ALLOWED_SOURCES in the frame filter

### DIFF
--- a/tests/filters/test_frame.py
+++ b/tests/filters/test_frame.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from preggy import expect
+from tornado.testing import gen_test
+
+from thumbor.config import Config
+from thumbor.context import Context
+from thumbor.filters import frame
+from thumbor.importer import Importer
+from thumbor.testing import FilterTestCase
+
+
+class FrameFilterTestCase(FilterTestCase):
+    @gen_test
+    async def test_frame_validate_allowed_source(self):
+        config = Config(
+            ALLOWED_SOURCES=[
+                "s.glbimg.com",
+            ],
+            LOADER="thumbor.loaders.http_loader",
+        )
+        importer = Importer(config)
+        importer.import_modules()
+
+        context = Context(config=config, importer=importer)
+        filter_instance = frame.Filter("", context)
+
+        expect(
+            filter_instance.validate("https://s2.glbimg.com/logo.jpg")
+        ).to_be_false()
+        expect(
+            filter_instance.validate("https://s.glbimg.com/logo.jpg")
+        ).to_be_true()

--- a/thumbor/filters/frame.py
+++ b/thumbor/filters/frame.py
@@ -7,9 +7,12 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
+import tornado.web
+
 from thumbor.ext.filters import _nine_patch
 from thumbor.filters import BaseFilter, filter_method
 from thumbor.loaders import LoaderResult
+from thumbor.utils import logger
 
 
 class Filter(BaseFilter):
@@ -105,5 +108,17 @@ class Filter(BaseFilter):
         if buffer is not None:
             return await self.on_image_ready(buffer)
 
+        if not self.validate(self.url):
+            raise tornado.web.HTTPError(400)
+
         result = await self.context.modules.loader.load(self.context, self.url)
         await self.on_fetch_done(result)
+
+    def validate(self, url):
+        if not hasattr(self.context.modules.loader, "validate"):
+            return True
+
+        if not self.context.modules.loader.validate(self.context, url):
+            logger.warning('frame source not allowed: "%s"', url)
+            return False
+        return True


### PR DESCRIPTION
Add the same loader validation used by the watermark filter before loading frame assets, so disallowed external frame URLs are rejected with HTTP 400.