### PR TITLE
Remove unused webcolors direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
   "statsd>=4.0.1,<5.0.0",
   "thumbor-plugins-gifv>=0.1.5,<1.0.0",
   "tornado>=6.4,<7.0.0",
-  "webcolors>=1.13.0,<2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
webcolors is no longer imported by thumbor's own code. The GIFV plugin still declares webcolors as its own dependency, so installations that include thumbor-plugins-gifv continue to receive it transitively.

Closes: #1808