### PR TITLE
Replace this alternation with a character class.

### DIFF
--- a/thumbor/loaders/__init__.py
+++ b/thumbor/loaders/__init__.py
@@ -12,9 +12,7 @@ from typing import Dict, Pattern
 
 from thumbor.utils import logger
 
-LEGACY_ALLOWED_SOURCE_REGEX_MARKERS = re.compile(
-    r"(\\|[\^\$\*\+\?\{\}\[\]\(\)\|])"
-)
+LEGACY_ALLOWED_SOURCE_REGEX_MARKERS = re.compile(r"[\\^$*+?{}\[\]()|]")
 WARNED_LEGACY_ALLOWED_SOURCE_REGEXES = set()
 
 


### PR DESCRIPTION
Sonar rule python:S6035: Single-character alternations in regular expressions should be replaced with character classes.