### PR TITLE
Use concise character class syntax '\d' instead of '[0-9]'.

### DIFF
--- a/tests/loaders/test_http_loader.py
+++ b/tests/loaders/test_http_loader.py
@@ -193,7 +193,7 @@ class ValidateUrlTestCase(TestCase):
         """Compiled patterns should work as real regexes."""
         config = Config()
         config.ALLOWED_SOURCES = [
-            re.compile(r"https?://cdn[0-9]+\.example\.com/.*")
+            re.compile(r"https?://cdn\d+\.example\.com/.*")
         ]
         ctx = Context(None, config, None)
         expect(


### PR DESCRIPTION
Sonar rule python:S6353: Regular expression quantifiers and character classes should be used concisely.