### PR TITLE
ci: add build provenance attestations and fix GHCR manifest race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,7 +335,7 @@ jobs:
             echo "Digest not yet visible on GHCR, retrying in $((attempt * 10))s..."
             sleep $((attempt * 10))
           done
-          echo "digest=$(jq -r '.["manifest.digest"]' /tmp/ghcr-metadata.json)" >> "$GITHUB_OUTPUT"
+echo "digest=$(jq -er '.["containerimage.manifest.digest"]' /tmp/ghcr-metadata.json)" >> "$GITHUB_OUTPUT"
 
       - name: Attest GHCR image
         uses: actions/attest@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 env:
   CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
@@ -83,8 +86,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         if: github.event_name != 'pull_request'
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: true
           skip-existing: true
 
   docker-build:
@@ -314,22 +316,73 @@ jobs:
             type=sha
 
       - name: Create and push GHCR manifest
+        id: ghcr-manifest
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("ghcr.io/thumbor/thumbor:")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf 'ghcr.io/thumbor/thumbor@sha256:%s ' *)
+          for attempt in 1 2 3 4 5; do
+            if docker buildx imagetools create \
+              --metadata-file /tmp/ghcr-metadata.json \
+              $(jq -cr '.tags | map(select(startswith("ghcr.io/thumbor/thumbor:")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+              $(printf 'ghcr.io/thumbor/thumbor@sha256:%s ' *); then
+              break
+            fi
+            [ "$attempt" -eq 5 ] && exit 1
+            echo "Digest not yet visible on GHCR, retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
+          echo "digest=$(jq -r '.["manifest.digest"]' /tmp/ghcr-metadata.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Attest GHCR image
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/thumbor/thumbor
+          subject-digest: ${{ steps.ghcr-manifest.outputs.digest }}
+          push-to-registry: true
 
       - name: Create and push Quay.io manifest
+        id: quay-manifest
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("quay.io/thumbor/thumbor:")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf 'quay.io/thumbor/thumbor@sha256:%s ' *)
+          for attempt in 1 2 3 4 5; do
+            if docker buildx imagetools create \
+              --metadata-file /tmp/quay-metadata.json \
+              $(jq -cr '.tags | map(select(startswith("quay.io/thumbor/thumbor:")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+              $(printf 'quay.io/thumbor/thumbor@sha256:%s ' *); then
+              break
+            fi
+            [ "$attempt" -eq 5 ] && exit 1
+            echo "Digest not yet visible on Quay.io, retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
+          echo "digest=$(jq -r '.["manifest.digest"]' /tmp/quay-metadata.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Attest Quay.io image
+        uses: actions/attest@v4
+        with:
+          subject-name: quay.io/thumbor/thumbor
+          subject-digest: ${{ steps.quay-manifest.outputs.digest }}
+          push-to-registry: true
 
       - name: Create and push Docker Hub manifest
+        id: dockerhub-manifest
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map(select(startswith("thumbororg/thumbor:")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf 'thumbororg/thumbor@sha256:%s ' *)
+          for attempt in 1 2 3 4 5; do
+            if docker buildx imagetools create \
+              --metadata-file /tmp/dockerhub-metadata.json \
+              $(jq -cr '.tags | map(select(startswith("thumbororg/thumbor:")) | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+              $(printf 'thumbororg/thumbor@sha256:%s ' *); then
+              break
+            fi
+            [ "$attempt" -eq 5 ] && exit 1
+            echo "Digest not yet visible on Docker Hub, retrying in $((attempt * 10))s..."
+            sleep $((attempt * 10))
+          done
+          echo "digest=$(jq -r '.["manifest.digest"]' /tmp/dockerhub-metadata.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Attest Docker Hub image
+        uses: actions/attest@v4
+        with:
+          subject-name: docker.io/thumbororg/thumbor
+          subject-digest: ${{ steps.dockerhub-manifest.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ on:
 permissions:
   contents: read
   packages: write
-  id-token: write
-  attestations: write
-  artifact-metadata: write
 
 env:
   CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
@@ -74,6 +71,9 @@ jobs:
     name: Upload to PyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -257,6 +257,11 @@ jobs:
     needs: docker-build
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,7 +359,7 @@ echo "digest=$(jq -er '.["containerimage.manifest.digest"]' /tmp/ghcr-metadata.j
             echo "Digest not yet visible on Quay.io, retrying in $((attempt * 10))s..."
             sleep $((attempt * 10))
           done
-          echo "digest=$(jq -r '.["manifest.digest"]' /tmp/quay-metadata.json)" >> "$GITHUB_OUTPUT"
+echo "digest=$(jq -er '.["containerimage.manifest.digest"]' /tmp/quay-metadata.json)" >> "$GITHUB_OUTPUT"
 
       - name: Attest Quay.io image
         uses: actions/attest@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,7 +383,7 @@ echo "digest=$(jq -er '.["containerimage.manifest.digest"]' /tmp/quay-metadata.j
             echo "Digest not yet visible on Docker Hub, retrying in $((attempt * 10))s..."
             sleep $((attempt * 10))
           done
-          echo "digest=$(jq -r '.["manifest.digest"]' /tmp/dockerhub-metadata.json)" >> "$GITHUB_OUTPUT"
+echo "digest=$(jq -er '.["containerimage.manifest.digest"]' /tmp/dockerhub-metadata.json)" >> "$GITHUB_OUTPUT"
 
       - name: Attest Docker Hub image
         uses: actions/attest@v4


### PR DESCRIPTION
Generate PEP 740 attestations for PyPI packages via Trusted Publishing, and SLSA build provenance attestations for each pushed Docker image (GHCR, Quay.io, Docker Hub). Also adds a retry-with-backoff around docker buildx imagetools create to tolerate GHCR's propagation delay for freshly pushed digests, which was causing intermittent "not found" failures in docker-manifest.