### PR TITLE
fix: keep AUTO_PNG_TO_JPG on when autojpg(true) is requested

### DIFF
--- a/tests/handlers/test_base_handler_with_auto_jpg.py
+++ b/tests/handlers/test_base_handler_with_auto_jpg.py
@@ -32,6 +32,7 @@ class ImageOperationsWithAutoJpgTestCase(BaseImagingTestCase):
         cfg.FILE_LOADER_ROOT_PATH = self.loader_path
         cfg.STORAGE = "thumbor.storages.no_storage"
         cfg.AUTO_JPG = True
+        cfg.FILTERS = [*cfg.FILTERS, "thumbor.filters.autojpg"]
 
         importer = Importer(cfg)
         importer.import_modules()
@@ -47,6 +48,17 @@ class ImageOperationsWithAutoJpgTestCase(BaseImagingTestCase):
         return await self.async_fetch(
             url, headers={"Accept": f"{mimetype};q=0.8"}
         )
+
+    @gen_test
+    async def test_autojpg_false_does_not_disable_auto_jpg(self):
+        response = await self.get_as_jpg(
+            "/unsafe/filters:autojpg(false)/"
+            "Giunchedi%2C_Filippo_January_2015_01.png",
+            MIMETYPE_JPEG,
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_jpeg()
 
     @gen_test
     async def test_can_auto_convert_avif_to_jpg_with_accept_all(self):

--- a/tests/handlers/test_base_handler_with_auto_png_to_jpg.py
+++ b/tests/handlers/test_base_handler_with_auto_png_to_jpg.py
@@ -29,6 +29,7 @@ class ImageOperationsWithAutoPngToJpgTestCase(BaseImagingTestCase):
         cfg.FILE_LOADER_ROOT_PATH = self.loader_path
         cfg.STORAGE = "thumbor.storages.no_storage"
         cfg.AUTO_PNG_TO_JPG = True
+        cfg.FILTERS = [*cfg.FILTERS, "thumbor.filters.autojpg"]
         cfg.RESULT_STORAGE = "thumbor.result_storages.file_storage"
         cfg.RESULT_STORAGE_EXPIRATION_SECONDS = 60
         cfg.RESULT_STORAGE_FILE_STORAGE_ROOT_PATH = self.root_path
@@ -168,6 +169,26 @@ class ImageOperationsWithAutoPngToJpgTestCase(BaseImagingTestCase):
         expect(response.code).to_equal(200)
         expect(response.headers).to_include("Vary")
         expect(response.body).to_be_webp()
+
+    @gen_test
+    async def test_should_auto_convert_png_to_jpg_with_autojpg_true(self):
+        response = await self.async_fetch(
+            "/unsafe/filters:autojpg(true)/"
+            "Giunchedi%2C_Filippo_January_2015_01.png"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_shouldnt_auto_convert_png_to_jpg_with_autojpg_false(self):
+        response = await self.async_fetch(
+            "/unsafe/filters:autojpg(false)/"
+            "Giunchedi%2C_Filippo_January_2015_01.png"
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
+        expect(response.body).to_be_png()
 
     @patch("thumbor.handlers.imaging.RequestParameters")
     @gen_test

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -404,8 +404,8 @@ class BaseHandler(tornado.web.RequestHandler):
         config = self.context.config
 
         enabled = (
-            request_override is None
-            if config.AUTO_PNG_TO_JPG
+            config.AUTO_PNG_TO_JPG
+            if request_override is None
             else request_override
         )
 


### PR DESCRIPTION
👉 Note: First of five PRs splitting up #1746.

With `AUTO_PNG_TO_JPG` enabled, requesting `filters:autojpg(true)` turned the conversion off instead of keeping it on: the condition evaluated `request_override is None` as the enabled value whenever the config flag was set, so any explicit filter value disabled the conversion.

Now the filter value wins when present and the config flag is only the default for requests without the filter: `autojpg(true)` keeps the conversion on, `autojpg(false)` turns it off, and `autojpg(false)` does not disable the `AUTO_JPG` conversion, which the filter never controlled.