### PR TITLE
fix: send Vary: Accept when AUTO_JPG or AUTO_PNG is enabled

### DIFF
--- a/tests/handlers/test_base_handler_with_auto_jpg.py
+++ b/tests/handlers/test_base_handler_with_auto_jpg.py
@@ -65,6 +65,7 @@ class ImageOperationsWithAutoJpgTestCase(BaseImagingTestCase):
         response = await self.get_as_jpg("/unsafe/image.avif", MIMETYPE_ALL)
 
         expect(response.code).to_equal(200)
+        expect(response.headers["Vary"]).to_include("Accept")
         expect(response.headers["Content-type"]).to_equal(MIMETYPE_JPEG)
         expect(response.body).to_be_jpeg()
 
@@ -115,6 +116,7 @@ class ImageOperationsWithAutoJpgTestCase(BaseImagingTestCase):
         response = await self.get_as_jpg("/unsafe/animated.gif", MIMETYPE_ALL)
 
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_gif()
 
     @gen_test

--- a/tests/handlers/test_base_handler_with_auto_png.py
+++ b/tests/handlers/test_base_handler_with_auto_png.py
@@ -51,6 +51,7 @@ class ImageOperationsWithAutoPngTestCase(BaseImagingTestCase):
         response = await self.get_as_png("/unsafe/image.jpg")
 
         expect(response.code).to_equal(200)
+        expect(response.headers["Vary"]).to_include("Accept")
         expect(response.headers["Content-type"]).to_equal(MIMETYPE)
         expect(response.body).to_be_png()
 
@@ -67,6 +68,7 @@ class ImageOperationsWithAutoPngTestCase(BaseImagingTestCase):
         response = await self.get_as_png("/unsafe/animated.gif")
 
         expect(response.code).to_equal(200)
+        expect(response.headers).not_to_include("Vary")
         expect(response.body).to_be_gif()
 
     @gen_test

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -741,7 +741,9 @@ class BaseHandler(tornado.web.RequestHandler):
         should_vary = (
             self.context.config.AUTO_WEBP
             or self.context.config.AUTO_AVIF
+            or self.context.config.AUTO_JPG
             or self.context.config.AUTO_HEIF
+            or self.context.config.AUTO_PNG
         )
         # we have image (not video)
         should_vary = should_vary and content_type.startswith("image/")


### PR DESCRIPTION
👉 Note: Second of five PRs splitting up #1746.

Responses converted by `AUTO_JPG` or `AUTO_PNG` depend on the request's `Accept` header, but the `Vary` header was only sent for `AUTO_WEBP`, `AUTO_AVIF` and `AUTO_HEIF`. A shared cache in front of thumbor could store a converted image and serve it to clients that do not accept that format.

Tests assert the header on converted responses and its absence for animated GIFs, which are never converted.