### PR TITLE
feat: parse the Accept header instead of searching substrings

### DIFF
--- a/tests/handlers/test_base_handler_compatibility.py
+++ b/tests/handlers/test_base_handler_compatibility.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2026 globo.com thumbor@googlegroups.com
+
+from types import SimpleNamespace
+from unittest import mock
+
+from preggy import expect
+
+from thumbor.config import Config
+from thumbor.context import RequestParameters
+from thumbor.handlers import BaseHandler
+
+
+def make_context(auto_webp=True, accepts_webp=True, headers=None):
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.can_convert_to_webp.return_value = True
+    request = SimpleNamespace(
+        accepts_webp=accepts_webp,
+        engine=engine,
+        headers=headers,
+    )
+
+    return SimpleNamespace(
+        config=SimpleNamespace(AUTO_WEBP=auto_webp),
+        request=request,
+    )
+
+
+def make_handler(context, handler_class=BaseHandler):
+    handler = object.__new__(handler_class)
+    handler.context = context
+    return handler
+
+
+def test_accepts_mime_type_keeps_legacy_header_lookup():
+    context = make_context(
+        headers={"Accept": "image/avif,image/webp,*/*;q=0.8"}
+    )
+    handler = make_handler(context)
+
+    expect(handler.accepts_mime_type("image/webp")).to_be_true()
+    expect(handler.accepts_mime_type("image/png")).to_be_false()
+
+
+def test_accepts_mime_type_without_headers_returns_false():
+    context = make_context(headers=None)
+    handler = make_handler(context)
+
+    expect(handler.accepts_mime_type("image/webp")).to_be_false()
+
+
+def test_accepts_mime_type_preserves_literal_wildcard_semantics():
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/jpeg"},
+    )
+    request = RequestParameters(request=tornado_request)
+    context = SimpleNamespace(request=request)
+    handler = make_handler(context)
+
+    expect(handler.accepts_mime_type("image/jpeg")).to_be_true()
+    expect(handler.accepts_mime_type("*/*")).to_be_false()
+
+
+def test_accepts_mime_type_super_call_uses_parsed_quality():
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(  # pylint: disable=useless-parent-delegation
+            self, mimetype=""
+        ):
+            return super().accepts_mime_type(mimetype)
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/avif;q=0,image/*;q=0.8"},
+    )
+    request = RequestParameters(request=tornado_request)
+    request.engine = engine
+    context = SimpleNamespace(
+        config=Config(AUTO_AVIF=True),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    expect(handler.accepts_mime_type("image/avif")).to_be_false()
+    expect(handler.can_auto_convert_to_avif()).to_be_false()
+
+
+def test_accepts_mime_type_super_call_honors_image_wildcard():
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(  # pylint: disable=useless-parent-delegation
+            self, mimetype=""
+        ):
+            return super().accepts_mime_type(mimetype)
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/*;q=0.8"},
+    )
+    request = RequestParameters(request=tornado_request)
+    request.engine = engine
+    context = SimpleNamespace(
+        config=Config(AUTO_AVIF=True),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    expect(handler.accepts_mime_type("image/avif")).to_be_true()
+    expect(handler.accepts_mime_type("application/json")).to_be_false()
+    expect(handler.accepts_mime_type("*/*")).to_be_false()
+    expect(handler.can_auto_convert_to_avif()).to_be_true()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -227,6 +227,10 @@ class RequestParametersTestCase(TestCase):
         expect(params.unsafe).to_be_false()
         expect(params.format).to_be_null()
         expect(params.accepts_webp).to_be_false()
+        expect(params.accepts_avif).to_be_false()
+        expect(params.accepts_heif).to_be_false()
+        expect(params.accepts_png).to_be_false()
+        expect(params.accepts_jpeg).to_be_false()
         expect(params.max_bytes).to_be_null()
         expect(params.max_age).to_be_null()
 
@@ -285,10 +289,137 @@ class RequestParametersTestCase(TestCase):
 
     @staticmethod
     def test_can_get_params_from_request():
-        request = mock.Mock(path="/test.jpg", headers={"Accept": "image/webp"})
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={
+                "Accept": "image/webp,image/avif,image/heif,image/png,image/jpeg"
+            },
+        )
         params = RequestParameters(request=request, image="/test.jpg")
         expect(params.accepts_webp).to_be_true()
+        expect(params.accepts_avif).to_be_true()
+        expect(params.accepts_heif).to_be_true()
+        expect(params.accepts_png).to_be_true()
+        expect(params.accepts_jpeg).to_be_true()
         expect(params.image_url).to_equal("/test.jpg")
+
+    @staticmethod
+    def test_accept_header_respects_quality_and_is_case_insensitive():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={
+                "Accept": "IMAGE/AVIF;Q=0, IMAGE/WEBP;Q=0.8, image/png;q=0"
+            },
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_avif).to_be_false()
+        expect(params.accepts_webp).to_be_true()
+        expect(params.accepts_png).to_be_false()
+
+    @staticmethod
+    def test_explicit_jpeg_rejection_overrides_accept_any():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "image/jpeg;q=0,*/*;q=0.8"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_jpeg).to_be_false()
+
+    @staticmethod
+    def test_accept_any_keeps_legacy_jpeg_support():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "*/*;q=0.8"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_jpeg).to_be_true()
+        expect(params.accepts_webp).to_be_false()
+
+    @staticmethod
+    def test_image_wildcard_accepts_image_formats():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "image/*;q=0.8"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_webp).to_be_true()
+        expect(params.accepts_avif).to_be_true()
+        expect(params.accepts_heif).to_be_true()
+        expect(params.accepts_png).to_be_true()
+        expect(params.accepts_jpeg).to_be_true()
+
+    @staticmethod
+    def test_image_wildcard_rejection_overrides_accept_any():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "image/*;q=0,*/*;q=0.8"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_webp).to_be_false()
+        expect(params.accepts_avif).to_be_false()
+        expect(params.accepts_heif).to_be_false()
+        expect(params.accepts_png).to_be_false()
+        expect(params.accepts_jpeg).to_be_false()
+
+    @staticmethod
+    def test_accept_header_parses_quoted_delimiters_before_quality():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": 'image/webp;profile="a,b;c";q=0,image/jpeg'},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_webp).to_be_false()
+        expect(params.accepts_jpeg).to_be_true()
+
+    @staticmethod
+    def test_unparameterized_media_range_controls_default_representation():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "image/webp;profile=foo;q=1,image/webp;q=0"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_webp).to_be_false()
+
+    @staticmethod
+    def test_canonical_jpeg_rejection_takes_precedence_over_jpg_alias():
+        request = mock.Mock(
+            path="/test.jpg",
+            headers={"Accept": "image/jpeg;q=0,image/jpg;q=1"},
+        )
+
+        params = RequestParameters(request=request)
+
+        expect(params.accepts_jpeg).to_be_false()
+
+    @staticmethod
+    def test_preserves_legacy_positional_arguments():
+        request = mock.Mock(
+            path="/legacy.jpg",
+            headers={"Accept": "image/webp"},
+        )
+        legacy_positional_arguments = [None] * 32
+        legacy_positional_arguments[28:] = [True, request, 3600, False]
+
+        params = RequestParameters(*legacy_positional_arguments)
+
+        expect(params.url).to_equal("/legacy.jpg")
+        expect(params.accepts_webp).to_be_true()
+        expect(params.max_age).to_equal(3600)
+        expect(params.auto_png_to_jpg).to_be_false()
 
 
 class ContextImporterTestCase(TestCase):

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -14,6 +14,95 @@ from thumbor.metrics.logger_metrics import Metrics
 from thumbor.threadpool import ThreadPool
 
 
+def _split_http_header(value, delimiter):
+    parts = []
+    current_part = []
+    quoted = False
+    escaped = False
+
+    for character in value:
+        if escaped:
+            current_part.append(character)
+            escaped = False
+            continue
+
+        if quoted and character == "\\":
+            current_part.append(character)
+            escaped = True
+            continue
+
+        if character == '"':
+            quoted = not quoted
+        elif character == delimiter and not quoted:
+            parts.append("".join(current_part))
+            current_part = []
+            continue
+
+        current_part.append(character)
+
+    parts.append("".join(current_part))
+    return parts
+
+
+def _parse_accept_quality(value):
+    try:
+        quality = float(value.strip())
+    except ValueError:
+        return 0.0
+
+    return quality if 0 <= quality <= 1 else 0.0
+
+
+def _parse_accept_media_range(media_range):
+    parts = [part.strip() for part in _split_http_header(media_range, ";")]
+    media_type = parts[0].lower()
+
+    if not media_type:
+        return None
+
+    for parameter in parts[1:]:
+        name, separator, value = parameter.partition("=")
+        if not separator:
+            continue
+
+        if name.strip().lower() == "q":
+            return media_type, _parse_accept_quality(value)
+
+        # Parameters before q apply to the media type itself. Since thumbor
+        # cannot match those variants, the media range is not applicable.
+        return None
+
+    return media_type, 1.0
+
+
+def _parse_accept_header(accept_header):
+    accepted_media_types = {}
+
+    for media_range in _split_http_header(accept_header or "", ","):
+        parsed_media_range = _parse_accept_media_range(media_range)
+        if parsed_media_range is None:
+            continue
+
+        media_type, quality = parsed_media_range
+        accepted_media_types[media_type] = max(
+            quality,
+            accepted_media_types.get(media_type, 0.0),
+        )
+
+    return accepted_media_types
+
+
+def _accepts_media_type(accepted_media_types, *media_types, allow_any=False):
+    for media_type in media_types:
+        if media_type in accepted_media_types:
+            return accepted_media_types[media_type] > 0
+
+    if "image/*" in accepted_media_types:
+        return accepted_media_types["image/*"] > 0
+
+    return allow_any and accepted_media_types.get("*/*", 0) > 0
+
+
 # Same logic as Importer. This class is very useful and will remain like so for now
 class Context:  # pylint: disable=too-many-instance-attributes
     """
@@ -170,6 +259,10 @@ class RequestParameters:  # pylint: disable=too-few-public-methods,too-many-inst
         request=None,
         max_age=None,
         auto_png_to_jpg=None,
+        accepts_avif=False,
+        accepts_heif=False,
+        accepts_png=False,
+        accepts_jpeg=False,
     ):
         self.debug = bool(debug)
         self.meta = bool(meta)
@@ -232,19 +325,59 @@ class RequestParameters:  # pylint: disable=too-few-public-methods,too-many-inst
         self.prevent_result_storage = False
         self.unsafe = unsafe == "unsafe" or unsafe is True
         self.format = None
-        self.accepts_webp = accepts_webp
+        self._set_accepted_image_formats(
+            (
+                accepts_webp,
+                accepts_avif,
+                accepts_heif,
+                accepts_png,
+                accepts_jpeg,
+            )
+        )
         self.max_bytes = None
         self.max_age = max_age
         self.auto_png_to_jpg = auto_png_to_jpg
         self.headers = None
+        self._accepted_media_types = {}
 
         if request:
-            self.url = request.path
-            self.accepts_webp = "image/webp" in request.headers.get(
-                "Accept", ""
+            self._set_request_headers(request)
+
+    def _set_request_headers(self, request):
+        accept_header = ""
+        self.url = request.path
+        if request.headers:
+            self.headers = request.headers
+            accept_header = request.headers.get("Accept", "")
+
+        self._set_accepted_image_formats_from_header(accept_header)
+
+    def _set_accepted_image_formats_from_header(self, accept_header):
+        accepted_media_types = _parse_accept_header(accept_header)
+        self._accepted_media_types = accepted_media_types
+        self._set_accepted_image_formats(
+            (
+                _accepts_media_type(accepted_media_types, "image/webp"),
+                _accepts_media_type(accepted_media_types, "image/avif"),
+                _accepts_media_type(accepted_media_types, "image/heif"),
+                _accepts_media_type(accepted_media_types, "image/png"),
+                _accepts_media_type(
+                    accepted_media_types,
+                    "image/jpeg",
+                    "image/jpg",
+                    allow_any=True,
+                ),
             )
-            if request.headers:
-                self.headers = request.headers
+        )
+
+    def _set_accepted_image_formats(self, accepted_formats):
+        (
+            self.accepts_webp,
+            self.accepts_avif,
+            self.accepts_heif,
+            self.accepts_png,
+            self.accepts_jpeg,
+        ) = accepted_formats
 
     @staticmethod
     def int_or_0(value):

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -415,8 +415,24 @@ class BaseHandler(tornado.web.RequestHandler):
         return False
 
     def accepts_mime_type(self, mimetype=""):
-        if self.context.request and self.context.request.headers:
-            return mimetype in self.context.request.headers.get("Accept", "")
+        request = self.context.request
+        if request and request.headers:
+            accepted_media_types = getattr(
+                request, "_accepted_media_types", None
+            )
+            if accepted_media_types is not None:
+                normalized_mimetype = mimetype.strip().lower()
+
+                if normalized_mimetype in accepted_media_types:
+                    return accepted_media_types[normalized_mimetype] > 0
+
+                return (
+                    normalized_mimetype.startswith("image/")
+                    and normalized_mimetype != "image/*"
+                    and accepted_media_types.get("image/*", 0) > 0
+                )
+
+            return mimetype in request.headers.get("Accept", "")
 
         return False
 


### PR DESCRIPTION
👉 Note: Third of five PRs splitting up #1746.

`RequestParameters` now parses the `Accept` header into media ranges with quality values, handling quoted parameters, whitespace and case. It exposes `accepts_avif`, `accepts_heif`, `accepts_png` and `accepts_jpeg` next to the existing `accepts_webp`, and `accepts_mime_type` answers from the parsed values.

Three behavior changes, all on purpose:

- A format listed with `q=0` is rejected. Before, `image/webp;q=0` still counted as accepting WebP because only the substring was checked.
- `image/*` accepts every image format. Before it matched nothing.
- `*/*` keeps its old meaning: it only enables JPEG, never the other formats, so existing `AUTO_WEBP` deployments keep the same behavior.

New keyword arguments were appended after the existing ones, so callers that pass positional arguments keep working. Handlers that build their own request objects keep the old substring lookup.

Big thanks, @marcelometal!