### PR TITLE
feat: separate result storage entries by accepted image formats

### DIFF
--- a/docs/custom_result_storages.rst
+++ b/docs/custom_result_storages.rst
@@ -7,3 +7,53 @@ Storage <https://github.com/thumbor/thumbor/blob/master/thumbor/result_storages/
 
 The required methods are ``put``, ``get``, ``validate_path`` and
 ``normalize_path``.
+
+Automatic image formats and cache keys
+--------------------------------------
+
+A result storage must keep responses for different automatic image-format
+capabilities in separate cache namespaces. This is required for the
+individual ``AUTO_*`` options. Otherwise, clients requesting the same
+thumbor URL but advertising different formats can receive an incompatible
+cached image.
+
+Use thumbor's cache-key helper when building the normalized path or key:
+
+.. code:: python
+
+   from thumbor.auto_image_format import get_auto_image_format_cache_key
+
+   format_key = get_auto_image_format_cache_key(
+       self.context.config,
+       self.context.request,
+   )
+   cache_namespace = format_key or "default"
+
+Treat the returned value as an opaque discriminator. It represents the
+active automatic formats accepted by the request and can contain more than
+one format. For configurations that require isolation from legacy cache
+entries, it also contains an internal namespace version. In that mode the
+helper returns a discriminator even when no configured format was accepted.
+Include it in both read and write keys before any cache lookup.
+
+If a custom handler overrides ``BaseHandler.accepts_mime_type`` while
+``AUTO_AVIF``, ``AUTO_HEIF``, ``AUTO_JPG`` or ``AUTO_PNG`` is active,
+thumbor bypasses result storage for that request. The override may depend
+on the image engine, filters or other state that does not exist during the
+pre-load cache lookup, so no safe cache discriminator can be calculated at
+that point. The override continues to run during output-format selection,
+at the same stage as before. The same bypass applies to request objects
+built by custom handler code without the parsed ``accepts_*`` attributes:
+their format decisions fall back to reading the Accept header, so no cache
+key computed from the missing attributes could be trusted.
+``AUTO_WEBP``-only and ``AUTO_PNG_TO_JPG``-only configurations are
+unaffected because this hook has never controlled those conversions.
+
+An entry from an older ``default`` or ``auto_webp`` namespace is not
+necessarily valid for the new namespace. Treat such an entry as a cache
+miss and regenerate it. Do not copy or move legacy objects into a new
+format namespace unless their actual content type has been verified.
+Existing custom storages that do not use the helper must adopt it before
+enabling these automatic formats. Purge their generated-image cache once
+during that rollout; purging without first isolating the new keys does not
+prevent future format collisions.

--- a/tests/handlers/test_base_handler_compatibility.py
+++ b/tests/handlers/test_base_handler_compatibility.py
@@ -7,12 +7,14 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2026 globo.com thumbor@googlegroups.com
 
+import datetime
 from types import SimpleNamespace
 from unittest import mock
 
 import pytest
 from preggy import expect
 
+from thumbor.auto_image_format import get_auto_image_format_cache_key
 from thumbor.config import Config
 from thumbor.context import RequestParameters
 from thumbor.handlers import BaseHandler
@@ -38,6 +40,26 @@ def make_handler(context, handler_class=BaseHandler):
     handler = object.__new__(handler_class)
     handler.context = context
     return handler
+
+
+def make_jpeg_handler(accept_header):
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(  # pylint: disable=useless-parent-delegation
+            self, mimetype=""
+        ):
+            return super().accepts_mime_type(mimetype)
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.has_transparency.return_value = False
+    tornado_request = mock.Mock(
+        path="/image.png",
+        headers={"Accept": accept_header},
+    )
+    request = RequestParameters(request=tornado_request)
+    request.engine = engine
+    context = SimpleNamespace(config=Config(AUTO_JPG=True), request=request)
+    return make_handler(context, CustomHandler)
 
 
 def test_accepts_mime_type_keeps_legacy_header_lookup():
@@ -68,60 +90,6 @@ def test_accepts_mime_type_preserves_literal_wildcard_semantics():
 
     expect(handler.accepts_mime_type("image/jpeg")).to_be_true()
     expect(handler.accepts_mime_type("*/*")).to_be_false()
-
-
-def test_accepts_mime_type_super_call_uses_parsed_quality():
-    class CustomHandler(BaseHandler):
-        def accepts_mime_type(  # pylint: disable=useless-parent-delegation
-            self, mimetype=""
-        ):
-            return super().accepts_mime_type(mimetype)
-
-    engine = mock.Mock()
-    engine.is_multiple.return_value = False
-    engine.can_auto_convert_to_avif.return_value = True
-    tornado_request = mock.Mock(
-        path="/image.jpg",
-        headers={"Accept": "image/avif;q=0,image/*;q=0.8"},
-    )
-    request = RequestParameters(request=tornado_request)
-    request.engine = engine
-    context = SimpleNamespace(
-        config=Config(AUTO_AVIF=True),
-        request=request,
-    )
-    handler = make_handler(context, CustomHandler)
-
-    expect(handler.accepts_mime_type("image/avif")).to_be_false()
-    expect(handler.can_auto_convert_to_avif()).to_be_false()
-
-
-def test_accepts_mime_type_super_call_honors_image_wildcard():
-    class CustomHandler(BaseHandler):
-        def accepts_mime_type(  # pylint: disable=useless-parent-delegation
-            self, mimetype=""
-        ):
-            return super().accepts_mime_type(mimetype)
-
-    engine = mock.Mock()
-    engine.is_multiple.return_value = False
-    engine.can_auto_convert_to_avif.return_value = True
-    tornado_request = mock.Mock(
-        path="/image.jpg",
-        headers={"Accept": "image/*;q=0.8"},
-    )
-    request = RequestParameters(request=tornado_request)
-    request.engine = engine
-    context = SimpleNamespace(
-        config=Config(AUTO_AVIF=True),
-        request=request,
-    )
-    handler = make_handler(context, CustomHandler)
-
-    expect(handler.accepts_mime_type("image/avif")).to_be_true()
-    expect(handler.accepts_mime_type("application/json")).to_be_false()
-    expect(handler.accepts_mime_type("*/*")).to_be_false()
-    expect(handler.can_auto_convert_to_avif()).to_be_true()
 
 
 @pytest.mark.parametrize(
@@ -189,6 +157,303 @@ def test_accepts_mime_type_override_can_reject_a_parsed_format():
     expect(handler.can_auto_convert_to_avif()).to_be_false()
 
 
+def test_accepts_mime_type_super_call_uses_parsed_quality():
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(  # pylint: disable=useless-parent-delegation
+            self, mimetype=""
+        ):
+            return super().accepts_mime_type(mimetype)
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/avif;q=0,image/*;q=0.8"},
+    )
+    request = RequestParameters(request=tornado_request)
+    request.engine = engine
+    context = SimpleNamespace(
+        config=Config(AUTO_AVIF=True),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    expect(handler.accepts_mime_type("image/avif")).to_be_false()
+    expect(handler.can_auto_convert_to_avif()).to_be_false()
+
+
+def test_accepts_mime_type_super_call_honors_image_wildcard():
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(  # pylint: disable=useless-parent-delegation
+            self, mimetype=""
+        ):
+            return super().accepts_mime_type(mimetype)
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/*;q=0.8"},
+    )
+    request = RequestParameters(request=tornado_request)
+    request.engine = engine
+    context = SimpleNamespace(
+        config=Config(AUTO_AVIF=True),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    expect(handler.accepts_mime_type("image/avif")).to_be_true()
+    expect(handler.accepts_mime_type("application/json")).to_be_false()
+    expect(handler.accepts_mime_type("*/*")).to_be_false()
+    expect(handler.can_auto_convert_to_avif()).to_be_true()
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+    expect(get_auto_image_format_cache_key(context.config, request)).to_equal(
+        "auto_format_v1_flags_preserve_avif"
+    )
+
+
+@pytest.mark.parametrize(
+    "accept_header",
+    [
+        "image/jpeg;q=0,*/*;q=0.8",
+        "image/jpg;q=0,*/*;q=0.8",
+        "image/*;q=0,*/*;q=0.8",
+        "image/jpeg;q=0,image/jpg;q=0.8",
+    ],
+)
+def test_custom_accepts_mime_type_honors_explicit_jpeg_rejection(
+    accept_header,
+):
+    handler = make_jpeg_handler(accept_header)
+
+    expect(handler.context.request.accepts_jpeg).to_be_false()
+    expect(handler.can_auto_convert_to_jpg()).to_be_false()
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+    expect(
+        get_auto_image_format_cache_key(
+            handler.context.config, handler.context.request
+        )
+    ).to_equal("auto_format_v1_flags_preserve_default")
+
+
+@pytest.mark.parametrize(
+    "accept_header",
+    [
+        "*/*;q=0.8",
+        "image/jpeg;q=0.8,image/*;q=0",
+    ],
+)
+def test_custom_accepts_mime_type_keeps_valid_jpeg_fallback(accept_header):
+    handler = make_jpeg_handler(accept_header)
+
+    expect(handler.can_auto_convert_to_jpg()).to_be_true()
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+    expect(
+        get_auto_image_format_cache_key(
+            handler.context.config, handler.context.request
+        )
+    ).to_equal("auto_format_v1_flags_preserve_jpg")
+
+
+def test_custom_accepts_mime_type_bypasses_result_storage_without_calling_it():
+    calls = []
+
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            calls.append(mimetype)
+            return "*/*" in self.context.request.headers.get("Accept", "")
+
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "*/*"},
+    )
+    request = RequestParameters(request=tornado_request)
+    config = Config(AUTO_AVIF=True)
+    context = SimpleNamespace(config=config, request=request)
+    handler = make_handler(context, CustomHandler)
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+
+    request.headers = {"Accept": ""}
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+    expect(calls).to_be_empty()
+
+
+def test_custom_accepts_mime_type_runs_after_engine_is_available():
+    calls = []
+
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            calls.append(mimetype)
+            return self.context.request.engine.accepts_mime_type(mimetype)
+
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/avif"},
+    )
+    request = RequestParameters(request=tornado_request)
+    context = SimpleNamespace(
+        config=Config(AUTO_AVIF=True),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+
+    expect(calls).to_be_empty()
+
+    engine = mock.Mock()
+    engine.accepts_mime_type.return_value = True
+    engine.is_multiple.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    request.engine = engine
+
+    expect(handler.can_auto_convert_to_avif()).to_be_true()
+    expect(calls).to_equal(["image/avif"])
+
+
+@pytest.mark.parametrize(
+    "config_overrides",
+    [
+        {"AUTO_AVIF": True},
+        {"AUTO_HEIF": True},
+        {"AUTO_JPG": True},
+        {"AUTO_PNG": True},
+    ],
+)
+def test_custom_accepts_mime_type_bypasses_extended_format_cache(
+    config_overrides,
+):
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            return True
+
+    context = SimpleNamespace(
+        config=Config(**config_overrides),
+        request=RequestParameters(),
+    )
+    handler = make_handler(context, CustomHandler)
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+
+
+@pytest.mark.parametrize(
+    "config_overrides,expected_cache_key",
+    [
+        ({"AUTO_WEBP": True}, "auto_webp"),
+        (
+            {"AUTO_PNG_TO_JPG": True},
+            "auto_format_v1_flags_png_to_jpg_default",
+        ),
+    ],
+)
+def test_custom_accepts_mime_type_keeps_webp_cache(
+    config_overrides,
+    expected_cache_key,
+):
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            return True
+
+    request = RequestParameters(accepts_webp=True)
+    context = SimpleNamespace(
+        config=Config(**config_overrides),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+    handler.accepts_mime_type = mock.Mock(return_value=True)
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_true()
+
+    handler.accepts_mime_type.assert_not_called()
+    expect(get_auto_image_format_cache_key(context.config, request)).to_equal(
+        expected_cache_key
+    )
+
+
+@pytest.mark.asyncio
+async def test_custom_accepts_mime_type_bypasses_result_storage_read_and_write():
+    calls = []
+
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            calls.append(mimetype)
+            return self.context.request.engine.accepts_mime_type(mimetype)
+
+    tornado_request = mock.Mock(
+        path="/image.jpg",
+        headers={"Accept": "image/avif"},
+    )
+    request = RequestParameters(request=tornado_request)
+    result_storage = mock.AsyncMock()
+    result_storage.get.return_value = None
+    filters_runner = SimpleNamespace(apply_filters=mock.AsyncMock())
+    filters_factory = mock.Mock()
+    filters_factory.create_instances.return_value = filters_runner
+    thread_pool = SimpleNamespace(
+        queue=mock.AsyncMock(return_value=(b"image", "image/jpeg"))
+    )
+    context = SimpleNamespace(
+        config=Config(AUTO_AVIF=True),
+        request=request,
+        modules=SimpleNamespace(result_storage=result_storage),
+        metrics=mock.Mock(),
+        filters_factory=filters_factory,
+        thread_pool=thread_pool,
+    )
+    handler = make_handler(context, CustomHandler)
+    handler._response_start = (  # pylint: disable=protected-access
+        datetime.datetime.now()
+    )
+    handler.request = SimpleNamespace(arguments={})
+    handler.get_image = mock.AsyncMock()
+
+    await handler.execute_image_operations()
+
+    result_storage.get.assert_not_awaited()
+    handler.get_image.assert_awaited_once_with()
+    expect(calls).to_be_empty()
+
+    handler._write_results_to_client = (  # pylint: disable=protected-access
+        mock.AsyncMock()
+    )
+    handler._cleanup = mock.Mock()  # pylint: disable=protected-access
+
+    await handler.finish_request()
+
+    result_storage.put.assert_not_awaited()
+    expect(request.prevent_result_storage).to_be_false()
+
+
 @pytest.mark.parametrize(
     "conversion_method,accept_header",
     [
@@ -222,3 +487,29 @@ def test_legacy_request_object_falls_back_to_the_accept_header(
     handler = make_handler(context)
 
     expect(getattr(handler, conversion_method)()).to_be_true()
+
+
+def test_legacy_request_object_bypasses_result_storage():
+    context = SimpleNamespace(
+        config=Config(AUTO_AVIF=True),
+        request=SimpleNamespace(headers={"Accept": "image/avif"}),
+    )
+    handler = make_handler(context)
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_false()
+
+
+def test_legacy_request_object_keeps_result_storage_with_webp_only():
+    context = SimpleNamespace(
+        config=Config(AUTO_WEBP=True),
+        request=SimpleNamespace(headers={"Accept": "image/webp"}),
+    )
+    handler = make_handler(context)
+
+    # pylint: disable=protected-access
+    expect(
+        handler._can_use_result_storage_with_auto_image_formats()
+    ).to_be_true()

--- a/tests/handlers/test_base_handler_compatibility.py
+++ b/tests/handlers/test_base_handler_compatibility.py
@@ -10,6 +10,7 @@
 from types import SimpleNamespace
 from unittest import mock
 
+import pytest
 from preggy import expect
 
 from thumbor.config import Config
@@ -121,3 +122,103 @@ def test_accepts_mime_type_super_call_honors_image_wildcard():
     expect(handler.accepts_mime_type("application/json")).to_be_false()
     expect(handler.accepts_mime_type("*/*")).to_be_false()
     expect(handler.can_auto_convert_to_avif()).to_be_true()
+
+
+@pytest.mark.parametrize(
+    "conversion_method,accepted_mimetype",
+    [
+        ("can_auto_convert_to_avif", "image/avif"),
+        ("can_auto_convert_to_heif", "image/heif"),
+        ("can_auto_convert_to_jpg", "image/jpeg"),
+        ("can_auto_convert_to_png", "image/png"),
+    ],
+)
+def test_accepts_mime_type_remains_an_extension_point(
+    conversion_method, accepted_mimetype
+):
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            return mimetype == accepted_mimetype
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.has_transparency.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    engine.can_auto_convert_to_heif.return_value = True
+    request = SimpleNamespace(
+        accepts_avif=False,
+        accepts_heif=False,
+        accepts_jpeg=False,
+        accepts_png=False,
+        engine=engine,
+        headers=None,
+    )
+    context = SimpleNamespace(
+        config=SimpleNamespace(
+            AUTO_AVIF=True,
+            AUTO_HEIF=True,
+            AUTO_JPG=True,
+            AUTO_PNG=True,
+        ),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    expect(getattr(handler, conversion_method)()).to_be_true()
+
+
+def test_accepts_mime_type_override_can_reject_a_parsed_format():
+    class CustomHandler(BaseHandler):
+        def accepts_mime_type(self, mimetype=""):
+            return False
+
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    request = SimpleNamespace(
+        accepts_avif=True,
+        engine=engine,
+        headers={"Accept": "image/avif"},
+    )
+    context = SimpleNamespace(
+        config=SimpleNamespace(AUTO_AVIF=True),
+        request=request,
+    )
+    handler = make_handler(context, CustomHandler)
+
+    expect(handler.can_auto_convert_to_avif()).to_be_false()
+
+
+@pytest.mark.parametrize(
+    "conversion_method,accept_header",
+    [
+        ("can_auto_convert_to_avif", "image/avif"),
+        ("can_auto_convert_to_heif", "image/heif"),
+        ("can_auto_convert_to_jpg", "image/jpeg"),
+        ("can_auto_convert_to_png", "image/png"),
+    ],
+)
+def test_legacy_request_object_falls_back_to_the_accept_header(
+    conversion_method, accept_header
+):
+    engine = mock.Mock()
+    engine.is_multiple.return_value = False
+    engine.has_transparency.return_value = False
+    engine.can_auto_convert_to_avif.return_value = True
+    engine.can_auto_convert_to_heif.return_value = True
+    request = SimpleNamespace(
+        engine=engine,
+        headers={"Accept": accept_header},
+    )
+    context = SimpleNamespace(
+        config=SimpleNamespace(
+            AUTO_AVIF=True,
+            AUTO_HEIF=True,
+            AUTO_JPG=True,
+            AUTO_PNG=True,
+        ),
+        request=request,
+    )
+    handler = make_handler(context)
+
+    expect(getattr(handler, conversion_method)()).to_be_true()

--- a/tests/result_storages/test_file_storage.py
+++ b/tests/result_storages/test_file_storage.py
@@ -7,14 +7,17 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
+import hashlib
 import tempfile
 from datetime import datetime
-from os.path import abspath, dirname, join
+from os.path import abspath, dirname, exists, join
 from unittest import mock
+from urllib.parse import unquote
 
 from preggy import expect
 from tornado.testing import gen_test
 
+from thumbor.auto_image_format import get_auto_image_format_cache_key
 from thumbor.config import Config
 from thumbor.context import RequestParameters
 from thumbor.result_storages import ResultStorageResult
@@ -50,6 +53,14 @@ class BaseFileStorageTestCase(TestCase):
     def get_fixture_path():
         return abspath(join(dirname(__file__), "../fixtures/result_storages"))
 
+    @staticmethod
+    def get_image_fixture_path(filename):
+        return abspath(join(dirname(__file__), "../fixtures/images", filename))
+
+    def read_image_fixture(self, filename):
+        with open(self.get_image_fixture_path(filename), "rb") as image_file:
+            return image_file.read()
+
     def get_context(self):
         ctx = super().get_context()
         cfg = self.get_config()
@@ -63,8 +74,60 @@ class BaseFileStorageTestCase(TestCase):
     def get_http_path():
         return "http://example.com/path/to/a.jpg"
 
+    def put_legacy_fixture(self, filename):
+        legacy_path = self.file_storage.normalize_path_legacy(
+            self.context.request.url
+        )
+        self.file_storage.ensure_dir(dirname(legacy_path))
+
+        image_bytes = self.read_image_fixture(filename)
+
+        with open(legacy_path, "wb") as legacy_file:
+            legacy_file.write(image_bytes)
+
+        return legacy_path, image_bytes
+
+    def put_previous_hashed_fixture(self, prefix, filename):
+        path = self.context.request.url
+        # This reproduces the legacy cache layout; SHA-1 is not used for
+        # security or integrity checks.
+        digest = hashlib.sha1(
+            unquote(path).encode("utf-8"), usedforsecurity=False
+        ).hexdigest()
+        previous_path = join(
+            self.storage_path.name,
+            prefix,
+            digest[:2],
+            digest[2:4],
+            digest[4:],
+        )
+        self.file_storage.ensure_dir(dirname(previous_path))
+
+        image_bytes = self.read_image_fixture(filename)
+
+        with open(previous_path, "wb") as previous_file:
+            previous_file.write(image_bytes)
+
+        return previous_path, image_bytes
+
 
 class FileStorageTestCase(BaseFileStorageTestCase):
+    def test_is_not_legacy_auto_webp(self):
+        expect(self.file_storage.is_auto_webp).to_be_false()
+
+    def test_is_auto_webp_override_controls_legacy_cache_key(self):
+        class CustomFileStorage(FileStorage):
+            @property
+            def is_auto_webp(self):
+                return True
+
+        custom_storage = CustomFileStorage(self.context)
+
+        expect(custom_storage.normalize_path(self.get_http_path())).to_equal(
+            f"{self.storage_path.name}/auto_webp/b6/be/"
+            "a3e916129541a9e7146f69a15eb4d7c77c98"
+        )
+
     @gen_test
     async def test_normalized_path(self):
         expect(self.file_storage).not_to_be_null()
@@ -74,6 +137,32 @@ class FileStorageTestCase(BaseFileStorageTestCase):
             f"{self.storage_path.name}/default/b6/be/"
             "a3e916129541a9e7146f69a15eb4d7c77c98"
         )
+
+    @gen_test
+    async def test_normalized_path_without_request(self):
+        del self.context.request
+
+        expect(self.file_storage).not_to_be_null()
+        expect(
+            self.file_storage.normalize_path(self.get_http_path())
+        ).to_equal(
+            f"{self.storage_path.name}/default/b6/be/"
+            "a3e916129541a9e7146f69a15eb4d7c77c98"
+        )
+
+    @gen_test
+    async def test_migrates_legacy_default_cache(self):
+        self.context.request.url = self.get_http_path()
+        legacy_path, image_bytes = self.put_legacy_fixture("image.jpg")
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result.buffer).to_equal(image_bytes)
+        expect(exists(legacy_path)).to_be_false()
+        expect(exists(current_path)).to_be_true()
 
 
 class WebPFileStorageTestCase(BaseFileStorageTestCase):
@@ -93,6 +182,22 @@ class WebPFileStorageTestCase(BaseFileStorageTestCase):
     def get_request(self):  # pylint: disable=arguments-differ
         return RequestParameters(accepts_webp=True)
 
+    def test_preserves_legacy_is_auto_webp_property(self):
+        expect(self.file_storage.is_auto_webp).to_be_true()
+
+    def test_is_auto_webp_override_can_disable_legacy_cache_key(self):
+        class CustomFileStorage(FileStorage):
+            @property
+            def is_auto_webp(self):
+                return False
+
+        custom_storage = CustomFileStorage(self.context)
+
+        expect(custom_storage.normalize_path(self.get_http_path())).to_equal(
+            f"{self.storage_path.name}/default/b6/be/"
+            "a3e916129541a9e7146f69a15eb4d7c77c98"
+        )
+
     @gen_test
     async def test_normalized_path_with_auto_webp_path(self):
         expect(self.file_storage).not_to_be_null()
@@ -102,6 +207,159 @@ class WebPFileStorageTestCase(BaseFileStorageTestCase):
             f"{self.storage_path.name}/auto_webp/b6/be/"
             "a3e916129541a9e7146f69a15eb4d7c77c98"
         )
+
+    @gen_test
+    async def test_migrates_legacy_auto_webp_cache(self):
+        self.context.request.url = self.get_http_path()
+        legacy_path, image_bytes = self.put_legacy_fixture("image.webp")
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result.buffer).to_equal(image_bytes)
+        expect(exists(legacy_path)).to_be_false()
+        expect(exists(current_path)).to_be_true()
+
+
+class AutoAvifFileStorageTestCase(BaseFileStorageTestCase):
+    def get_config(self):
+        self.storage_path = (
+            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        )
+        return Config(
+            AUTO_AVIF=True,
+            RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=self.storage_path.name,
+        )
+
+    def get_request(self):  # pylint: disable=arguments-differ
+        return RequestParameters(url=self.get_http_path())
+
+    @gen_test
+    async def test_does_not_migrate_unsafe_legacy_default_cache(self):
+        legacy_path, _ = self.put_legacy_fixture("image.jpg")
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(legacy_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+    def test_uses_isolated_default_namespace(self):
+        expect(
+            self.file_storage.normalize_path(self.context.request.url)
+        ).to_equal(
+            f"{self.storage_path.name}/"
+            "auto_format_v1_flags_preserve_default/b6/be/"
+            "a3e916129541a9e7146f69a15eb4d7c77c98"
+        )
+
+
+class AutoPngToJpgFileStorageTestCase(BaseFileStorageTestCase):
+    def get_config(self):
+        self.storage_path = (
+            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        )
+        return Config(
+            AUTO_PNG_TO_JPG=True,
+            RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=self.storage_path.name,
+        )
+
+    def get_request(self):  # pylint: disable=arguments-differ
+        return RequestParameters(url=self.get_http_path())
+
+    @gen_test
+    async def test_does_not_read_previous_default_cache(self):
+        previous_path, _ = self.put_previous_hashed_fixture(
+            "default", "1x1.png"
+        )
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(previous_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+
+class AutoWebPAndAvifFileStorageTestCase(BaseFileStorageTestCase):
+    def get_config(self):
+        self.storage_path = (
+            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        )
+        return Config(
+            AUTO_WEBP=True,
+            AUTO_AVIF=True,
+            RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=self.storage_path.name,
+        )
+
+    def get_request(self):  # pylint: disable=arguments-differ
+        return RequestParameters(url=self.get_http_path(), accepts_webp=True)
+
+    @gen_test
+    async def test_does_not_migrate_contaminated_legacy_webp_cache(self):
+        legacy_path, _ = self.put_legacy_fixture("image.avif")
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(legacy_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+
+class AutoImageFormatCacheKeyTestCase(TestCase):
+    def test_extended_formats_use_isolated_cache_keys(self):
+        config = Config(AUTO_AVIF=True)
+
+        expect(
+            get_auto_image_format_cache_key(
+                config, RequestParameters(accepts_avif=True)
+            )
+        ).to_equal("auto_format_v1_flags_preserve_avif")
+        expect(
+            get_auto_image_format_cache_key(config, RequestParameters())
+        ).to_equal("auto_format_v1_flags_preserve_default")
+
+    def test_cache_key_separates_png_to_jpg_fallback(self):
+        request = RequestParameters(accepts_heif=True)
+        flags_without_fallback = Config(AUTO_HEIF=True, AUTO_PNG_TO_JPG=False)
+        flags_with_fallback = Config(AUTO_HEIF=True, AUTO_PNG_TO_JPG=True)
+
+        cache_keys = {
+            get_auto_image_format_cache_key(flags_without_fallback, request),
+            get_auto_image_format_cache_key(flags_with_fallback, request),
+        }
+
+        expect(len(cache_keys)).to_equal(2)
+
+    def test_png_to_jpg_only_uses_isolated_cache_key(self):
+        expect(
+            get_auto_image_format_cache_key(
+                Config(AUTO_PNG_TO_JPG=True), RequestParameters()
+            )
+        ).to_equal("auto_format_v1_flags_png_to_jpg_default")
+
+    def test_quality_zero_does_not_enter_legacy_webp_cache(self):
+        request = mock.Mock(
+            path="http://example.com/path/to/a.jpg",
+            headers={"Accept": "image/webp;q=0"},
+        )
+
+        expect(
+            get_auto_image_format_cache_key(
+                Config(AUTO_WEBP=True),
+                RequestParameters(request=request),
+            )
+        ).to_be_null()
 
 
 class ResultStorageResultTestCase(BaseFileStorageTestCase):

--- a/thumbor/auto_image_format.py
+++ b/thumbor/auto_image_format.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2025 globo.com thumbor@googlegroups.com
+
+DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE = ("webp", "avif", "jpg", "heif", "png")
+AUTO_IMAGE_FORMAT_CACHE_KEY_PREFIX = "auto_format_v1"
+
+AUTO_IMAGE_FORMAT_CONFIG_FLAGS = {
+    "webp": "AUTO_WEBP",
+    "avif": "AUTO_AVIF",
+    "jpg": "AUTO_JPG",
+    "heif": "AUTO_HEIF",
+    "png": "AUTO_PNG",
+}
+
+AUTO_IMAGE_FORMAT_ACCEPT_ATTRS = {
+    "webp": "accepts_webp",
+    "avif": "accepts_avif",
+    "jpg": "accepts_jpeg",
+    "heif": "accepts_heif",
+    "png": "accepts_png",
+}
+
+
+def get_active_auto_image_formats(config):
+    active_formats = []
+
+    for image_format in DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE:
+        config_flag = AUTO_IMAGE_FORMAT_CONFIG_FLAGS[image_format]
+
+        if getattr(config, config_flag, False):
+            active_formats.append(image_format)
+
+    return tuple(active_formats)
+
+
+def requires_auto_image_format_cache_isolation(config):
+    """Return whether legacy ``default``/``auto_webp`` keys are unsafe."""
+    return getattr(config, "AUTO_PNG_TO_JPG", False) or any(
+        getattr(config, AUTO_IMAGE_FORMAT_CONFIG_FLAGS[image_format], False)
+        for image_format in DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE
+        if image_format != "webp"
+    )
+
+
+def get_auto_image_format_cache_key(config, request):
+    """Return the cache variant for an auto-format request.
+
+    Result storage implementations can use this helper to keep responses for
+    different ``Accept`` capabilities in separate cache namespaces.
+    """
+    active_formats = get_active_auto_image_formats(config)
+    cache_isolation_required = requires_auto_image_format_cache_isolation(
+        config
+    )
+
+    if not active_formats and not cache_isolation_required:
+        return None
+
+    accepted_formats = []
+
+    for image_format in active_formats:
+        accept_attr = AUTO_IMAGE_FORMAT_ACCEPT_ATTRS[image_format]
+
+        if getattr(request, accept_attr, False):
+            accepted_formats.append(image_format)
+
+    if cache_isolation_required:
+        fallback = (
+            "png_to_jpg"
+            if getattr(config, "AUTO_PNG_TO_JPG", False)
+            else "preserve"
+        )
+        variant = "-".join(accepted_formats) or "default"
+        return (
+            f"{AUTO_IMAGE_FORMAT_CACHE_KEY_PREFIX}_flags_"
+            f"{fallback}_{variant}"
+        )
+
+    if not accepted_formats:
+        return None
+
+    return "auto_" + "-".join(accepted_formats)
+
+
+def get_legacy_auto_image_format_cache_key(config, request):
+    """Return the cache variant used by the legacy ``v2`` file layout."""
+    if getattr(config, "AUTO_WEBP", False) and getattr(
+        request, "accepts_webp", False
+    ):
+        return "auto_webp"
+
+    return None

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -31,6 +31,10 @@ from thumbor.utils import CONTENT_TYPE, EXTENSION, logger
 
 HTTP_DATE_FMT = "%a, %d %b %Y %H:%M:%S GMT"
 
+MIMETYPE_IMAGE_WILDCARD = "image/*"
+MIMETYPE_JPEG = "image/jpeg"
+MIMETYPE_JPG = "image/jpg"
+
 DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE = ("webp", "avif", "jpg", "heif", "png")
 
 LEGACY_AUTO_IMAGE_FORMAT_METHODS = {
@@ -456,19 +460,68 @@ class BaseHandler(tornado.web.RequestHandler):
 
                 return (
                     normalized_mimetype.startswith("image/")
-                    and normalized_mimetype != "image/*"
-                    and accepted_media_types.get("image/*", 0) > 0
+                    and normalized_mimetype != MIMETYPE_IMAGE_WILDCARD
+                    and accepted_media_types.get(MIMETYPE_IMAGE_WILDCARD, 0)
+                    > 0
                 )
 
             return mimetype in request.headers.get("Accept", "")
 
         return False
 
+    def _custom_accepts_jpeg(self, accepts_mime_type_method):
+        accepted_media_types = getattr(
+            self.context.request,
+            "_accepted_media_types",
+            None,
+        )
+        if accepted_media_types is not None:
+            for mimetype in (
+                MIMETYPE_JPEG,
+                MIMETYPE_JPG,
+                MIMETYPE_IMAGE_WILDCARD,
+                "*/*",
+            ):
+                if mimetype in accepted_media_types:
+                    if accepted_media_types[mimetype] <= 0:
+                        return False
+                    break
+
+        return any(
+            accepts_mime_type_method(mimetype)
+            for mimetype in ("*/*", MIMETYPE_JPG, MIMETYPE_JPEG)
+        )
+
+    def _has_custom_accepts_mime_type(self):
+        accepts_mime_type_method = self.accepts_mime_type
+        return (
+            getattr(accepts_mime_type_method, "__func__", None)
+            is not BaseHandler.accepts_mime_type
+        )
+
+    def _accepts_parsed_mime_type(self, accept_attr, *mimetypes):
+        accepts_mime_type_method = self.accepts_mime_type
+        if self._has_custom_accepts_mime_type():
+            if accept_attr == "accepts_jpeg":
+                return self._custom_accepts_jpeg(accepts_mime_type_method)
+
+            return any(
+                accepts_mime_type_method(mimetype) for mimetype in mimetypes
+            )
+
+        request = self.context.request
+        if hasattr(request, accept_attr):
+            return bool(getattr(request, accept_attr))
+
+        return any(
+            accepts_mime_type_method(mimetype) for mimetype in mimetypes
+        )
+
     def _supports_avif(self):
         request = self.context.request
 
         return (
-            self.accepts_mime_type("image/avif")
+            self._accepts_parsed_mime_type("accepts_avif", "image/avif")
             and not request.engine.is_multiple()
             and request.engine.can_auto_convert_to_avif()
         )
@@ -480,7 +533,7 @@ class BaseHandler(tornado.web.RequestHandler):
         request = self.context.request
 
         return (
-            self.accepts_mime_type("image/heif")
+            self._accepts_parsed_mime_type("accepts_heif", "image/heif")
             and not request.engine.is_multiple()
             and request.engine.can_auto_convert_to_heif()
         )
@@ -490,10 +543,8 @@ class BaseHandler(tornado.web.RequestHandler):
 
     def _supports_jpg(self):
         request = self.context.request
-        accepts_jpg = (
-            self.accepts_mime_type("*/*")
-            or self.accepts_mime_type("image/jpg")
-            or self.accepts_mime_type("image/jpeg")
+        accepts_jpg = self._accepts_parsed_mime_type(
+            "accepts_jpeg", "*/*", MIMETYPE_JPG, MIMETYPE_JPEG
         )
 
         return (
@@ -515,7 +566,7 @@ class BaseHandler(tornado.web.RequestHandler):
         request = self.context.request
 
         return (
-            self.accepts_mime_type("image/png")
+            self._accepts_parsed_mime_type("accepts_png", "image/png")
             and not request.engine.is_multiple()
         )
 

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -31,6 +31,24 @@ from thumbor.utils import CONTENT_TYPE, EXTENSION, logger
 
 HTTP_DATE_FMT = "%a, %d %b %Y %H:%M:%S GMT"
 
+DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE = ("webp", "avif", "jpg", "heif", "png")
+
+LEGACY_AUTO_IMAGE_FORMAT_METHODS = {
+    "webp": "can_auto_convert_to_webp",
+    "avif": "can_auto_convert_to_avif",
+    "jpg": "_can_auto_convert_to_jpg_in_legacy_mode",
+    "heif": "can_auto_convert_to_heif",
+    "png": "can_auto_convert_to_png",
+}
+
+LEGACY_AUTO_IMAGE_FORMAT_LOG_MESSAGES = {
+    "webp": "Image format set by AUTO_WEBP as %s.",
+    "avif": "Image format set by AUTO_AVIF as %s.",
+    "jpg": "Image format set by AUTO_PNG_TO_JPG or AUTO_JPG as %s.",
+    "heif": "Image format set by AUTO_HEIF as %s.",
+    "png": "Image format set by AUTO_PNG as %s.",
+}
+
 # Handlers should not override __init__ pylint: disable=attribute-defined-outside-init,arguments-differ
 # pylint: disable=broad-except,abstract-method,too-many-branches,too-many-return-statements,too-many-statements,too-many-lines
 
@@ -349,13 +367,23 @@ class BaseHandler(tornado.web.RequestHandler):
 
         await self.finish_request()
 
-    def is_webp(self, context):
+    def _supports_webp(self, context=None):
+        if context is None:
+            context = self.context
+
+        request = context.request
+
         return (
-            context.config.AUTO_WEBP
-            and context.request.accepts_webp
-            and not context.request.engine.is_multiple()
-            and context.request.engine.can_convert_to_webp()
+            request.accepts_webp
+            and not request.engine.is_multiple()
+            and request.engine.can_convert_to_webp()
         )
+
+    def is_webp(self, context):
+        return context.config.AUTO_WEBP and self._supports_webp(context)
+
+    def can_auto_convert_to_webp(self):
+        return self.is_webp(self.context)
 
     def is_animated_gif(self, data):
         if data[:6] not in [b"GIF87a", b"GIF89a"]:
@@ -436,62 +464,84 @@ class BaseHandler(tornado.web.RequestHandler):
 
         return False
 
+    def _supports_avif(self):
+        request = self.context.request
+
+        return (
+            self.accepts_mime_type("image/avif")
+            and not request.engine.is_multiple()
+            and request.engine.can_auto_convert_to_avif()
+        )
+
     def can_auto_convert_to_avif(self):
-        auto_avif = self.context.config.AUTO_AVIF
-        accepts_avif = self.accepts_mime_type("image/avif")
+        return self.context.config.AUTO_AVIF and self._supports_avif()
 
-        if (
-            auto_avif is True
-            and accepts_avif is True
-            and not self.context.request.engine.is_multiple()
-        ):
-            return self.context.request.engine.can_auto_convert_to_avif()
+    def _supports_heif(self):
+        request = self.context.request
 
-        return False
+        return (
+            self.accepts_mime_type("image/heif")
+            and not request.engine.is_multiple()
+            and request.engine.can_auto_convert_to_heif()
+        )
 
     def can_auto_convert_to_heif(self):
-        auto_heif = self.context.config.AUTO_HEIF
-        accepts_heif = self.accepts_mime_type("image/heif")
+        return self.context.config.AUTO_HEIF and self._supports_heif()
 
-        if (
-            auto_heif
-            and accepts_heif
-            and not self.context.request.engine.is_multiple()
-        ):
-            return self.context.request.engine.can_auto_convert_to_heif()
-
-        return False
-
-    def can_auto_convert_to_jpg(self):
-        auto_jpg = self.context.config.AUTO_JPG
+    def _supports_jpg(self):
+        request = self.context.request
         accepts_jpg = (
             self.accepts_mime_type("*/*")
             or self.accepts_mime_type("image/jpg")
             or self.accepts_mime_type("image/jpeg")
         )
 
-        if (
-            auto_jpg
-            and accepts_jpg
-            and not self.context.request.engine.is_multiple()
-            and not self.context.request.engine.has_transparency()
-        ):
-            return True
+        return (
+            accepts_jpg
+            and not request.engine.is_multiple()
+            and not request.engine.has_transparency()
+        )
 
-        return False
+    def can_auto_convert_to_jpg(self):
+        return self.context.config.AUTO_JPG and self._supports_jpg()
+
+    def _can_auto_convert_to_jpg_in_legacy_mode(self):
+        return (
+            self.can_auto_convert_png_to_jpg()
+            or self.can_auto_convert_to_jpg()
+        )
+
+    def _supports_png(self):
+        request = self.context.request
+
+        return (
+            self.accepts_mime_type("image/png")
+            and not request.engine.is_multiple()
+        )
 
     def can_auto_convert_to_png(self):
-        auto_png = self.context.config.AUTO_PNG
-        accepts_png = self.accepts_mime_type("image/png")
+        return self.context.config.AUTO_PNG and self._supports_png()
 
-        if (
-            auto_png
-            and accepts_png
-            and not self.context.request.engine.is_multiple()
-        ):
-            return True
+    def _resolve_auto_image_extension(self, context):
+        for image_format in DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE:
+            method_name = LEGACY_AUTO_IMAGE_FORMAT_METHODS[image_format]
 
-        return False
+            if getattr(self, method_name)():
+                image_extension = f".{image_format}"
+                logger.debug(
+                    LEGACY_AUTO_IMAGE_FORMAT_LOG_MESSAGES[image_format],
+                    image_extension,
+                )
+
+                return image_extension
+
+        image_extension = context.request.engine.extension
+        logger.debug(
+            "No image format specified. Retrieving from engine extension: %s.",
+            image_extension,
+        )
+
+        return image_extension
 
     def define_image_type(self, context, result):
         if result is not None:
@@ -499,6 +549,7 @@ class BaseHandler(tornado.web.RequestHandler):
                 buffer = result.buffer
             else:
                 buffer = result
+
             image_extension = EXTENSION.get(
                 BaseEngine.get_mimetype(buffer), ".jpg"
             )
@@ -513,42 +564,9 @@ class BaseHandler(tornado.web.RequestHandler):
         if image_extension is not None:
             image_extension = f".{image_extension}"
             logger.debug("Image format specified as %s.", image_extension)
-        elif self.is_webp(context):
-            image_extension = ".webp"
-            logger.debug(
-                "Image format set by AUTO_WEBP as %s.", image_extension
-            )
-        elif self.can_auto_convert_to_avif():
-            image_extension = ".avif"
-            logger.debug(
-                "Image format set by AUTO_AVIF as %s.", image_extension
-            )
-        elif (
-            self.can_auto_convert_png_to_jpg()
-            or self.can_auto_convert_to_jpg()
-        ):
-            image_extension = ".jpg"
-            logger.debug(
-                "Image format set by AUTO_PNG_TO_JPG or AUTO_JPG as %s.",
-                image_extension,
-            )
-        elif self.can_auto_convert_to_heif():
-            image_extension = ".heif"
-            logger.debug(
-                "Image format set by AUTO_HEIF as %s.", image_extension
-            )
-        elif self.can_auto_convert_to_png():
-            image_extension = ".png"
-            logger.debug(
-                "Image format set by AUTO_PNG as %s.", image_extension
-            )
+
         else:
-            image_extension = context.request.engine.extension
-            logger.debug(
-                "No image format specified. Retrieving "
-                "from the image extension: %s.",
-                image_extension,
-            )
+            image_extension = self._resolve_auto_image_extension(context)
 
         content_type = CONTENT_TYPE.get(image_extension, CONTENT_TYPE[".jpg"])
 

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -19,6 +19,11 @@ from tornado.locks import Condition
 
 import thumbor.filters
 from thumbor import __version__
+from thumbor.auto_image_format import (
+    AUTO_IMAGE_FORMAT_ACCEPT_ATTRS,
+    DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE,
+    get_active_auto_image_formats,
+)
 from thumbor.context import Context, RequestParameters
 from thumbor.engines import BaseEngine, EngineResult
 from thumbor.engines.json_engine import JSONEngine
@@ -34,8 +39,6 @@ HTTP_DATE_FMT = "%a, %d %b %Y %H:%M:%S GMT"
 MIMETYPE_IMAGE_WILDCARD = "image/*"
 MIMETYPE_JPEG = "image/jpeg"
 MIMETYPE_JPG = "image/jpg"
-
-DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE = ("webp", "avif", "jpg", "heif", "png")
 
 LEGACY_AUTO_IMAGE_FORMAT_METHODS = {
     "webp": "can_auto_convert_to_webp",
@@ -160,7 +163,11 @@ class BaseHandler(tornado.web.RequestHandler):
             or not self.context.request.unsafe
         )
 
-        if self.context.modules.result_storage and should_store:
+        if (
+            self.context.modules.result_storage
+            and should_store
+            and self._can_use_result_storage_with_auto_image_formats()
+        ):
             start = datetime.datetime.now()
 
             try:
@@ -499,6 +506,24 @@ class BaseHandler(tornado.web.RequestHandler):
             is not BaseHandler.accepts_mime_type
         )
 
+    def _can_use_result_storage_with_auto_image_formats(self):
+        active_formats = get_active_auto_image_formats(self.context.config)
+        has_extended_format = any(
+            image_format != "webp" for image_format in active_formats
+        )
+
+        if not has_extended_format:
+            return True
+
+        if self._has_custom_accepts_mime_type():
+            return False
+
+        request = self.context.request
+        return all(
+            hasattr(request, AUTO_IMAGE_FORMAT_ACCEPT_ATTRS[image_format])
+            for image_format in active_formats
+        )
+
     def _accepts_parsed_mime_type(self, accept_attr, *mimetypes):
         accepts_mime_type_method = self.accepts_mime_type
         if self._has_custom_accepts_mime_type():
@@ -735,6 +760,7 @@ class BaseHandler(tornado.web.RequestHandler):
         should_store = (
             result_storage
             and not context.request.prevent_result_storage
+            and self._can_use_result_storage_with_auto_image_formats()
             and (
                 context.config.RESULT_STORAGE_STORES_UNSAFE
                 or not context.request.unsafe

--- a/thumbor/result_storages/file_storage.py
+++ b/thumbor/result_storages/file_storage.py
@@ -16,6 +16,11 @@ from uuid import uuid4
 
 import pytz
 
+from thumbor.auto_image_format import (
+    get_auto_image_format_cache_key,
+    get_legacy_auto_image_format_cache_key,
+    requires_auto_image_format_cache_isolation,
+)
 from thumbor.engines import BaseEngine
 from thumbor.result_storages import BaseStorage, ResultStorageResult
 from thumbor.utils import deprecated, logger
@@ -26,8 +31,14 @@ class Storage(BaseStorage):
 
     @property
     def is_auto_webp(self):
+        """Whether the request used the WebP variant in the legacy layout."""
+        request = getattr(self.context, "request", None)
+
         return (
-            self.context.config.AUTO_WEBP and self.context.request.accepts_webp
+            get_legacy_auto_image_format_cache_key(
+                self.context.config, request
+            )
+            == "auto_webp"
         )
 
     async def put(self, image_bytes):
@@ -75,7 +86,7 @@ class Storage(BaseStorage):
 
         if not exists(file_abspath):
             legacy_path = self.normalize_path_legacy(path)
-            if isfile(legacy_path):
+            if self.can_migrate_legacy_path() and isfile(legacy_path):
                 logger.debug(
                     "[RESULT_STORAGE] migrating image from old location at %s",
                     legacy_path,
@@ -120,9 +131,35 @@ class Storage(BaseStorage):
                 "/"
             )
         )
-        prefix = "auto_webp" if self.is_auto_webp else "default"
+        prefix = self.get_auto_image_format_cache_key() or "default"
 
         return f"{root_path}/{prefix}/{digest[:2]}/{digest[2:4]}/{digest[4:]}"
+
+    def get_auto_image_format_cache_key(self):
+        request = getattr(self.context, "request", None)
+
+        if request is None:
+            return None
+
+        if (
+            not requires_auto_image_format_cache_isolation(self.context.config)
+            and type(self).is_auto_webp is not Storage.is_auto_webp
+        ):
+            return "auto_webp" if self.is_auto_webp else None
+
+        return get_auto_image_format_cache_key(self.context.config, request)
+
+    def can_migrate_legacy_path(self):
+        request = getattr(self.context, "request", None)
+
+        if request is None:
+            return False
+
+        if requires_auto_image_format_cache_isolation(self.context.config):
+            return False
+
+        legacy_cache_key = "auto_webp" if self.is_auto_webp else None
+        return self.get_auto_image_format_cache_key() == legacy_cache_key
 
     def normalize_path_legacy(self, path):
         path = unquote(path)


### PR DESCRIPTION
👉 Note: Fourth of five PRs splitting up #1746.

Result storage keyed every response by URL only, but with `AUTO_AVIF`, `AUTO_JPG`, `AUTO_HEIF` or `AUTO_PNG` enabled the same URL produces different formats for different clients — so a cached AVIF could be served to a client that never accepts AVIF. Two commits:

1. **Format decisions read the parsed `Accept` values.** `can_auto_convert_to_avif/heif/jpg/png` now use the `accepts_*` attributes from #1858, so the decision and the cache key always see the same reading of the header. Handlers that override `accepts_mime_type` keep working, and an explicit `q=0` rejection of JPEG wins over such an override.

2. **Result storage entries are separated by accepted formats.** The new `thumbor.auto_image_format` module computes a cache-key discriminator; the file result storage uses it as its namespace. `AUTO_WEBP`-only setups keep the legacy `auto_webp`/`default` namespaces and their migration. Setups with the other `AUTO_*` flags or `AUTO_PNG_TO_JPG` get an isolated namespace, because their old `default` namespace can hold a different format for the same URL. When a handler overrides `accepts_mime_type` and one of those formats is active, result storage is skipped for that request — no safe key can be computed before the engine exists.

⚠️ Upgrade note: deployments running `AUTO_AVIF`, `AUTO_JPG`, `AUTO_HEIF`, `AUTO_PNG` or `AUTO_PNG_TO_JPG` start with an empty result-storage namespace after this change — every cached result is regenerated once. Old entries are not removed automatically. Custom result storages should adopt `get_auto_image_format_cache_key` (see the new docs section).

Big thanks, @marcelometal 🤘 