### PR TITLE
Support proxy environment variables in HTTP loader

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1296,6 +1296,10 @@ Example of Configuration File
    ## Defaults to: None
    #HTTP_LOADER_PROXY_PASSWORD = None
 
+   ## When HTTP_LOADER_PROXY_HOST/PORT are not set, the HTTP loader also
+   ## honors http_proxy, https_proxy, all_proxy and no_proxy environment
+   ## variables. Targets matching no_proxy bypass the environment proxy.
+
    ## The filename of CA certificates in PEM format
    ## Defaults to: None
    #HTTP_LOADER_CA_CERTS = None

--- a/tests/loaders/test_http_loader.py
+++ b/tests/loaders/test_http_loader.py
@@ -10,6 +10,7 @@
 # Test file
 # pylint: disable=protected-access
 
+import os
 import re
 import time
 from os.path import abspath, dirname, join
@@ -62,6 +63,18 @@ class HandlerMock:
 class RequestMock:
     def __init__(self, headers):
         self.headers = headers
+
+
+class CurlMock:
+    LOW_SPEED_LIMIT = "LOW_SPEED_LIMIT"
+    LOW_SPEED_TIME = "LOW_SPEED_TIME"
+    PROXY = "PROXY"
+
+    def __init__(self):
+        self.options = {}
+
+    def setopt(self, option, value):
+        self.options[option] = value
 
 
 class ResponseMock:
@@ -205,6 +218,91 @@ class NormalizeUrlTestCase(TestCase):
         assert result == expected
 
 
+class EnvironmentProxyTestCase(TestCase):
+    def test_should_use_http_proxy_environment_variable(self):
+        env = {"http_proxy": "http://proxy.example:3128"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            proxy_url, has_environment_proxy = loader._get_environment_proxy(
+                "http://images.example/image.jpg"  # NOSONAR
+            )
+
+        assert proxy_url == "http://proxy.example:3128"
+        assert has_environment_proxy
+
+    def test_should_use_https_proxy_environment_variable(self):
+        env = {"https_proxy": "http://proxy.example:3128"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            proxy_url, has_environment_proxy = loader._get_environment_proxy(
+                "https://images.example/image.jpg"
+            )
+
+        assert proxy_url == "http://proxy.example:3128"
+        assert has_environment_proxy
+
+    def test_should_fallback_to_all_proxy_environment_variable(self):
+        env = {"all_proxy": "http://proxy.example:3128"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            proxy_url, has_environment_proxy = loader._get_environment_proxy(
+                "https://images.example/image.jpg"
+            )
+
+        assert proxy_url == "http://proxy.example:3128"
+        assert has_environment_proxy
+
+    def test_should_respect_no_proxy_environment_variable(self):
+        env = {
+            "http_proxy": "http://proxy.example:3128",
+            "no_proxy": "images.example:8888",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            proxy_url, has_environment_proxy = loader._get_environment_proxy(
+                "http://images.example:8888/image.jpg"  # NOSONAR
+            )
+
+        assert proxy_url is None
+        assert has_environment_proxy
+
+    def test_should_ignore_no_proxy_without_proxy_environment_variable(self):
+        env = {"no_proxy": "images.example"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            proxy_url, has_environment_proxy = loader._get_environment_proxy(
+                "http://images.example/image.jpg"  # NOSONAR
+            )
+
+        assert proxy_url is None
+        assert not has_environment_proxy
+
+
+class PrepareCurlCallbackTestCase(TestCase):
+    def test_should_return_none_without_curl_options(self):
+        assert loader._get_prepare_curl_callback(Config()) is None
+
+    def test_should_set_environment_proxy_url(self):
+        callback = loader._get_prepare_curl_callback(
+            Config(), "http://proxy.example:3128"
+        )
+        curl = CurlMock()
+
+        callback(curl)
+
+        assert curl.options[CurlMock.PROXY] == "http://proxy.example:3128"
+
+    def test_should_set_proxy_and_low_speed_options(self):
+        config = Config()
+        config.HTTP_LOADER_CURL_LOW_SPEED_TIME = 1
+        config.HTTP_LOADER_CURL_LOW_SPEED_LIMIT = 100
+        callback = loader._get_prepare_curl_callback(
+            config, "http://proxy.example:3128"
+        )
+        curl = CurlMock()
+
+        callback(curl)
+
+        assert curl.options[CurlMock.PROXY] == "http://proxy.example:3128"
+        assert curl.options[CurlMock.LOW_SPEED_TIME] == 1
+        assert curl.options[CurlMock.LOW_SPEED_LIMIT] == 100
+
+
 class DummyAsyncHttpClientTestCase(TestCase):
     # By default Tornado allows to create one (Async)HttpClient per
     # IOLoop instance
@@ -232,6 +330,91 @@ class HttpLoaderTestCase(DummyAsyncHttpClientTestCase):
         application = tornado.web.Application([(r"/", MainHandler)])
 
         return application
+
+    @gen_test
+    async def test_load_should_configure_environment_proxy(self):
+        config = Config()
+        ctx = Context(None, config, None)
+        client = mock.Mock()
+        client.fetch = mock.AsyncMock(
+            return_value=ResponseMock(body=b"Hello", code=200)
+        )
+        prepare_curl_callback = mock.Mock()
+        return_contents = mock.Mock(return_value=mock.sentinel.result)
+        env = {"http_proxy": "http://proxy.example:3128"}
+
+        with (
+            mock.patch.dict(os.environ, env, clear=True),
+            mock.patch.object(
+                loader,
+                "_get_prepare_curl_callback",
+                return_value=prepare_curl_callback,
+            ) as get_prepare_curl_callback,
+            mock.patch.object(
+                tornado.httpclient,
+                "AsyncHTTPClient",
+                return_value=client,
+            ) as async_http_client,
+        ):
+            result = await loader.load(
+                ctx,
+                "images.example/image.jpg",
+                return_contents_fn=return_contents,
+            )
+
+        async_http_client.configure.assert_called_once_with(
+            "tornado.curl_httpclient.CurlAsyncHTTPClient",
+            max_clients=config.HTTP_LOADER_MAX_CLIENTS,
+        )
+        get_prepare_curl_callback.assert_called_once_with(
+            config, "http://proxy.example:3128"
+        )
+        request = client.fetch.await_args.args[0]
+        assert request.url == "http://images.example/image.jpg"  # NOSONAR
+        assert request.prepare_curl_callback is prepare_curl_callback
+        assert result is mock.sentinel.result
+
+    @gen_test
+    async def test_load_should_not_apply_proxy_for_no_proxy_target(self):
+        config = Config()
+        ctx = Context(None, config, None)
+        client = mock.Mock()
+        client.fetch = mock.AsyncMock(
+            return_value=ResponseMock(body=b"Hello", code=200)
+        )
+        return_contents = mock.Mock(return_value=mock.sentinel.result)
+        env = {
+            "http_proxy": "http://proxy.example:3128",
+            "no_proxy": "images.example",
+        }
+
+        with (
+            mock.patch.dict(os.environ, env, clear=True),
+            mock.patch.object(
+                loader,
+                "_get_prepare_curl_callback",
+                wraps=loader._get_prepare_curl_callback,
+            ) as get_prepare_curl_callback,
+            mock.patch.object(
+                tornado.httpclient,
+                "AsyncHTTPClient",
+                return_value=client,
+            ) as async_http_client,
+        ):
+            result = await loader.load(
+                ctx,
+                "http://images.example/image.jpg",  # NOSONAR
+                return_contents_fn=return_contents,
+            )
+
+        async_http_client.configure.assert_called_once_with(
+            "tornado.curl_httpclient.CurlAsyncHTTPClient",
+            max_clients=config.HTTP_LOADER_MAX_CLIENTS,
+        )
+        get_prepare_curl_callback.assert_called_once_with(config, None)
+        request = client.fetch.await_args.args[0]
+        assert request.prepare_curl_callback is None
+        assert result is mock.sentinel.result
 
     @gen_test
     async def test_load_with_callback(self):

--- a/thumbor/loaders/http_loader.py
+++ b/thumbor/loaders/http_loader.py
@@ -12,6 +12,7 @@ import re
 import socket
 from typing import Pattern
 from urllib.parse import quote, unquote, urlparse
+from urllib.request import getproxies_environment, proxy_bypass_environment
 
 import tornado.httpclient
 
@@ -43,6 +44,41 @@ def encode(string):
 
 def quote_url(url):
     return encode_url(unquote(url))
+
+
+def _proxy_bypass_host(parsed_url):
+    if not parsed_url.hostname:
+        return ""
+
+    try:
+        port = parsed_url.port
+    except ValueError:
+        port = None
+
+    if port:
+        return f"{parsed_url.hostname}:{port}"
+
+    return parsed_url.hostname
+
+
+def _get_environment_proxy(
+    url,
+    getproxies_fn=getproxies_environment,
+    proxy_bypass_fn=proxy_bypass_environment,
+):
+    parsed_url = urlparse(url)
+    if not parsed_url.scheme or not parsed_url.hostname:
+        return None, False
+
+    proxies = getproxies_fn()
+    proxy_url = proxies.get(parsed_url.scheme.lower()) or proxies.get("all")
+    if not proxy_url:
+        return None, False
+
+    if proxy_bypass_fn(_proxy_bypass_host(parsed_url), proxies):
+        return None, True
+
+    return proxy_url, True
 
 
 def _normalize_url(url):
@@ -141,15 +177,24 @@ async def load(
     return_contents_fn=return_contents,
     encode_fn=encode,
 ):
-    using_proxy = (
+    url = normalize_url_func(url)
+    environment_proxy_url, has_environment_proxy = _get_environment_proxy(url)
+    using_config_proxy = (
         context.config.HTTP_LOADER_PROXY_HOST
         and context.config.HTTP_LOADER_PROXY_PORT
     )
-    if using_proxy or context.config.HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT:
+    if (
+        using_config_proxy
+        or has_environment_proxy
+        or context.config.HTTP_LOADER_CURL_ASYNC_HTTP_CLIENT
+    ):
         http_client_implementation = (
             "tornado.curl_httpclient.CurlAsyncHTTPClient"
         )
-        prepare_curl_callback = _get_prepare_curl_callback(context.config)
+        prepare_curl_callback = _get_prepare_curl_callback(
+            context.config,
+            None if using_config_proxy else environment_proxy_url,
+        )
     else:
         http_client_implementation = None  # default
         prepare_curl_callback = None
@@ -182,7 +227,6 @@ async def load(
     if user_agent is None and "User-Agent" not in headers:
         user_agent = context.config.HTTP_LOADER_DEFAULT_USER_AGENT
 
-    url = normalize_url_func(url)
     req = tornado.httpclient.HTTPRequest(
         url=url,
         headers=headers,
@@ -222,18 +266,32 @@ async def load(
     )
 
 
-def _get_prepare_curl_callback(config):
-    if (
-        config.HTTP_LOADER_CURL_LOW_SPEED_TIME == 0
-        or config.HTTP_LOADER_CURL_LOW_SPEED_LIMIT == 0
-    ):
+def _get_prepare_curl_callback(config, environment_proxy_url=None):
+    using_low_speed_timeout = (
+        config.HTTP_LOADER_CURL_LOW_SPEED_TIME != 0
+        and config.HTTP_LOADER_CURL_LOW_SPEED_LIMIT != 0
+    )
+    if not using_low_speed_timeout and not environment_proxy_url:
         return None
 
     class CurlOpts:
-        def __init__(self, config):
+        def __init__(
+            self,
+            config,
+            environment_proxy_url,
+            using_low_speed_timeout,
+        ):
             self.config = config
+            self.environment_proxy_url = environment_proxy_url
+            self.using_low_speed_timeout = using_low_speed_timeout
 
         def prepare_curl_callback(self, curl):
+            if self.environment_proxy_url:
+                curl.setopt(curl.PROXY, self.environment_proxy_url)
+
+            if not self.using_low_speed_timeout:
+                return
+
             curl.setopt(
                 curl.LOW_SPEED_TIME,
                 self.config.HTTP_LOADER_CURL_LOW_SPEED_TIME,
@@ -243,4 +301,8 @@ def _get_prepare_curl_callback(config):
                 self.config.HTTP_LOADER_CURL_LOW_SPEED_LIMIT,
             )
 
-    return CurlOpts(config).prepare_curl_callback
+    return CurlOpts(
+        config,
+        environment_proxy_url,
+        using_low_speed_timeout,
+    ).prepare_curl_callback


### PR DESCRIPTION
## Summary

- honor `http_proxy`, `https_proxy`, `all_proxy`, and `no_proxy`
  in the built-in HTTP loader
- keep `HTTP_LOADER_PROXY_HOST` and `HTTP_LOADER_PROXY_PORT` as the
  explicit configuration with precedence over the environment
- add focused tests and document the supported environment variables

## Why

The built-in HTTP loader only selected and configured the curl client when
Thumbor proxy settings were explicit. As a result, standard proxy environment
variables were ignored. This change resolves that gap and applies `no_proxy`
for each target URL.

Ref #1768.

## User impact

Existing explicit proxy configuration keeps its current behavior. Deployments
without explicit proxy configuration will now honor inherited proxy environment
variables. This is an intentional behavior change: an unexpectedly inherited
proxy variable can change the network path used by image requests. Users who do
not want this behavior should remove those variables from the Thumbor process
environment or continue using explicit Thumbor proxy configuration.
