### PR TITLE
feat: add AUTO_IMAGE_FORMAT_PREFERENCE

### DIFF
--- a/docs/autojpg.rst
+++ b/docs/autojpg.rst
@@ -6,12 +6,15 @@ Usage: `autojpg(enabled)`
 Description
 -----------
 
-This filter overrides ``AUTO_PNG_TO_JPG`` config variable.
+This filter overrides only the ``AUTO_PNG_TO_JPG`` fallback for the current
+request. It does not enable or disable a ``jpg`` entry explicitly configured
+in ``AUTO_IMAGE_FORMAT_PREFERENCE``.
 
 Arguments
 ---------
 
--  enabled - Passing ``True``, which is the default value, you will override the ``AUTO_PNG_TO_JPG`` config variable and False to keep the default behavior of thus config.
+- ``enabled`` - ``True`` enables PNG-to-JPEG fallback and ``False`` disables
+  it for this request. The default is ``True``.
 
 Example
 -------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -397,6 +397,12 @@ Images with texts, for example, the result image maybe will be distorted.
 Dark images, for example, the size of result image maybe will be bigger.
 You have to evaluate the majority of your use cases to take a decision about the usage of this conf.
 
+This conversion remains independent of ``AUTO_IMAGE_FORMAT_PREFERENCE``.
+When a preference list is configured and none of its entries can be used,
+thumbor still applies ``AUTO_PNG_TO_JPG`` as a fallback. The ``autojpg()``
+filter enables or disables this fallback for an individual request; it does
+not enable or disable a ``jpg`` entry in the preference list.
+
 .. code:: python
 
    AUTO_PNG_TO_JPG = True
@@ -433,6 +439,71 @@ specifies that the browser supports "image/heif" and pillow-heif is enabled.
 .. code:: python
 
    AUTO_HEIF = True
+
+AUTO\_IMAGE\_FORMAT\_PREFERENCE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This option defines the order in which thumbor attempts automatic output
+formats. The valid tokens are ``webp``, ``avif``, ``jpg``, ``heif`` and
+``png``. Values are stripped of surrounding whitespace and converted to
+lowercase. Duplicate values after the first occurrence, non-string values
+and unknown tokens are ignored.
+
+For each entry, thumbor checks the request's ``Accept`` header and the
+current engine's capabilities, then selects the first eligible format. AVIF
+and HEIF therefore require their respective engine support, JPEG is not
+selected for an image with transparency, and preference entries are not
+selected for multi-image input. Media types are matched case-insensitively,
+and an entry with an explicit quality value of ``q=0`` is not eligible.
+``image/*`` applies to all supported image formats, while the less specific
+``*/*`` retains the legacy behavior of enabling JPEG only. If no entry is
+eligible, thumbor preserves the engine's output format, except for the
+independent ``AUTO_PNG_TO_JPG`` fallback described above.
+
+A preference list containing at least one valid entry overrides
+``AUTO_WEBP``, ``AUTO_AVIF``, ``AUTO_JPG``, ``AUTO_PNG`` and ``AUTO_HEIF``.
+If any entries are invalid, thumbor logs one warning listing the ignored
+values. If every entry is invalid, thumbor treats the preference as empty.
+An empty preference uses the individual settings in their legacy order:
+``webp``, ``avif``, ``jpg``, ``heif``, then ``png``.
+
+.. code:: python
+
+   # Prioritize AVIF over WebP.
+   AUTO_IMAGE_FORMAT_PREFERENCE = ["avif", "webp", "jpg", "png", "heif"]
+
+   # Or prioritize JPEG for workloads where that is preferable.
+   AUTO_IMAGE_FORMAT_PREFERENCE = ["jpg", "webp", "avif", "png", "heif"]
+
+The result-storage cache key must vary with the active formats accepted by
+the request. The built-in file result storage does this automatically and
+uses an isolated namespace whenever a preference, ``AUTO_AVIF``,
+``AUTO_JPG``, ``AUTO_HEIF``, ``AUTO_PNG`` or ``AUTO_PNG_TO_JPG`` is active.
+It migrates legacy entries only for configurations where the old ``default``
+or WebP namespace is unambiguous. Custom result storages must use
+``thumbor.auto_image_format.get_auto_image_format_cache_key`` as described
+in :doc:`custom_result_storages`. When enabling or reordering this setting,
+do not migrate a legacy cached object into a new format namespace unless its
+content type is verified; a cache purge is the safest upgrade path for
+storages that cannot isolate the old entries.
+
+This namespace change also applies on upgrade when the preference remains
+empty but ``AUTO_AVIF``, ``AUTO_JPG``, ``AUTO_HEIF``, ``AUTO_PNG`` or
+``AUTO_PNG_TO_JPG`` is already enabled. Existing generated images in the
+legacy ``default`` namespace are deliberately treated as cache misses and
+regenerated. Plan for a temporarily cold cache, pre-warm it or use a gradual
+rollout if the additional origin and processing load would be significant.
+Legacy files are not removed automatically, so account for their disk usage
+until they are cleaned up separately. An ``AUTO_WEBP``-only configuration
+keeps its existing cache namespace.
+
+The default is an empty list, which retains the individual ``AUTO_*``
+settings.
+
+.. code:: python
+
+   # Use individual AUTO_* settings (default behavior).
+   AUTO_IMAGE_FORMAT_PREFERENCE = []
 
 Queueing - Redis Single Node
 ----------------------------
@@ -979,6 +1050,12 @@ Example of Configuration File
    ## to take a decision about the usage of this conf.
    ## Defaults to: False
    #AUTO_PNG_TO_JPG = False
+
+   ## Ordered list of preferred automatic output formats. Valid formats are
+   ## webp, avif, jpg, heif and png. A non-empty normalized list overrides the
+   ## individual AUTO_* settings. AUTO_PNG_TO_JPG remains independent.
+   ## Defaults to: []
+   #AUTO_IMAGE_FORMAT_PREFERENCE = []
 
    ## Specify the ratio between 1in and 1px for SVG images. This is only used
    ## whenrasterizing SVG images having their size units in cm or inches.

--- a/docs/custom_result_storages.rst
+++ b/docs/custom_result_storages.rst
@@ -12,10 +12,10 @@ Automatic image formats and cache keys
 --------------------------------------
 
 A result storage must keep responses for different automatic image-format
-capabilities in separate cache namespaces. This is required for the
-individual ``AUTO_*`` options. Otherwise, clients requesting the same
-thumbor URL but advertising different formats can receive an incompatible
-cached image.
+capabilities in separate cache namespaces. This is required both for the
+individual ``AUTO_*`` options and for ``AUTO_IMAGE_FORMAT_PREFERENCE``.
+Otherwise, clients requesting the same thumbor URL but advertising different
+formats can receive an incompatible cached image.
 
 Use thumbor's cache-key helper when building the normalized path or key:
 
@@ -37,23 +37,23 @@ helper returns a discriminator even when no configured format was accepted.
 Include it in both read and write keys before any cache lookup.
 
 If a custom handler overrides ``BaseHandler.accepts_mime_type`` while
-``AUTO_AVIF``, ``AUTO_HEIF``, ``AUTO_JPG`` or ``AUTO_PNG`` is active,
-thumbor bypasses result storage for that request. The override may depend
-on the image engine, filters or other state that does not exist during the
-pre-load cache lookup, so no safe cache discriminator can be calculated at
-that point. The override continues to run during output-format selection,
-at the same stage as before. The same bypass applies to request objects
-built by custom handler code without the parsed ``accepts_*`` attributes:
-their format decisions fall back to reading the Accept header, so no cache
-key computed from the missing attributes could be trusted.
-``AUTO_WEBP``-only and ``AUTO_PNG_TO_JPG``-only configurations are
+``AUTO_AVIF``, ``AUTO_HEIF``, ``AUTO_JPG``, ``AUTO_PNG`` or a preference
+containing one of those formats is active, thumbor bypasses result storage for
+that request. The override may depend on the image engine, filters or other
+state that does not exist during the pre-load cache lookup, so no safe cache
+discriminator can be calculated at that point. The override continues to run
+during output-format selection, at the same stage as before. The same bypass
+applies to request objects built by custom handler code without the parsed
+``accepts_*`` attributes: their format decisions fall back to reading the
+Accept header, so no cache key computed from the missing attributes could be
+trusted. ``AUTO_WEBP``-only and ``AUTO_PNG_TO_JPG``-only configurations are
 unaffected because this hook has never controlled those conversions.
 
-An entry from an older ``default`` or ``auto_webp`` namespace is not
-necessarily valid for the new namespace. Treat such an entry as a cache
-miss and regenerate it. Do not copy or move legacy objects into a new
-format namespace unless their actual content type has been verified.
-Existing custom storages that do not use the helper must adopt it before
-enabling these automatic formats. Purge their generated-image cache once
-during that rollout; purging without first isolating the new keys does not
-prevent future format collisions.
+When enabling or reordering ``AUTO_IMAGE_FORMAT_PREFERENCE``, an entry from
+an older ``default`` or ``auto_webp`` namespace is not necessarily valid for
+the new namespace. Treat such an entry as a cache miss and regenerate it.
+Do not copy or move legacy objects into a new format namespace unless their
+actual content type has been verified. Existing custom storages that do not
+use the helper must adopt it before enabling these automatic formats. Purge
+their generated-image cache once during that rollout; purging without first
+isolating the new keys does not prevent future format collisions.

--- a/tests/handlers/test_base_handler_compatibility.py
+++ b/tests/handlers/test_base_handler_compatibility.py
@@ -62,6 +62,27 @@ def make_jpeg_handler(accept_header):
     return make_handler(context, CustomHandler)
 
 
+def test_is_webp_keeps_legacy_behavior():
+    context = make_context()
+    handler = make_handler(context)
+
+    expect(handler.is_webp(context)).to_be_true()
+
+    context.config.AUTO_WEBP = False
+    expect(handler.is_webp(context)).to_be_false()
+
+
+def test_can_auto_convert_to_webp_keeps_is_webp_extension_point():
+    class CustomHandler(BaseHandler):
+        def is_webp(self, context):
+            return True
+
+    context = make_context(auto_webp=False)
+    handler = make_handler(context, CustomHandler)
+
+    expect(handler.can_auto_convert_to_webp()).to_be_true()
+
+
 def test_accepts_mime_type_keeps_legacy_header_lookup():
     context = make_context(
         headers={"Accept": "image/avif,image/webp,*/*;q=0.8"}
@@ -342,6 +363,7 @@ def test_custom_accepts_mime_type_runs_after_engine_is_available():
         {"AUTO_HEIF": True},
         {"AUTO_JPG": True},
         {"AUTO_PNG": True},
+        {"AUTO_IMAGE_FORMAT_PREFERENCE": ["webp", "jpg"]},
     ],
 )
 def test_custom_accepts_mime_type_bypasses_extended_format_cache(
@@ -367,6 +389,10 @@ def test_custom_accepts_mime_type_bypasses_extended_format_cache(
     "config_overrides,expected_cache_key",
     [
         ({"AUTO_WEBP": True}, "auto_webp"),
+        (
+            {"AUTO_IMAGE_FORMAT_PREFERENCE": ["webp"]},
+            "auto_format_v1_preference_preserve_webp",
+        ),
         (
             {"AUTO_PNG_TO_JPG": True},
             "auto_format_v1_flags_png_to_jpg_default",

--- a/tests/handlers/test_base_handler_with_auto_image_format_preference.py
+++ b/tests/handlers/test_base_handler_with_auto_image_format_preference.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2025 globo.com thumbor@googlegroups.com
+
+from shutil import which
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from preggy import expect
+from tornado.testing import gen_test
+
+from tests.handlers.test_base_handler import BaseImagingTestCase
+from thumbor.config import Config
+from thumbor.context import Context, ServerParameters
+from thumbor.handlers import BaseHandler
+from thumbor.importer import Importer
+
+
+def resolve_preferred_extension(
+    preference, accepted_formats=None, multiple=False, transparent=False
+):
+    accepted_formats = accepted_formats or set(preference)
+    engine = mock.Mock(extension=".gif")
+    engine.is_multiple.return_value = multiple
+    engine.has_transparency.return_value = transparent
+    engine.can_convert_to_webp.return_value = "webp" in accepted_formats
+    engine.can_auto_convert_to_avif.return_value = "avif" in accepted_formats
+    engine.can_auto_convert_to_heif.return_value = "heif" in accepted_formats
+    engine.can_auto_convert_png_to_jpg.return_value = False
+    request = SimpleNamespace(
+        accepts_webp="webp" in accepted_formats,
+        accepts_avif="avif" in accepted_formats,
+        accepts_heif="heif" in accepted_formats,
+        accepts_jpeg="jpg" in accepted_formats,
+        accepts_png="png" in accepted_formats,
+        auto_png_to_jpg=None,
+        engine=engine,
+    )
+    context = SimpleNamespace(
+        config=Config(AUTO_IMAGE_FORMAT_PREFERENCE=preference),
+        request=request,
+    )
+    handler = object.__new__(BaseHandler)
+    handler.context = context
+
+    # pylint: disable=protected-access
+    return handler._resolve_auto_image_extension(context)
+
+
+@pytest.mark.parametrize(
+    "image_format", ["webp", "avif", "jpg", "heif", "png"]
+)
+def test_resolves_every_supported_preferred_format(image_format):
+    expect(resolve_preferred_extension([image_format])).to_equal(
+        f".{image_format}"
+    )
+
+
+def test_skips_unsupported_preferred_format():
+    expect(
+        resolve_preferred_extension(
+            ["avif", "webp"], accepted_formats={"webp"}
+        )
+    ).to_equal(".webp")
+
+
+def test_skips_jpg_for_transparent_image():
+    expect(resolve_preferred_extension(["jpg"], transparent=True)).to_equal(
+        ".gif"
+    )
+
+
+def test_skips_preferred_formats_for_multiple_images():
+    expect(
+        resolve_preferred_extension(["webp", "png"], multiple=True)
+    ).to_equal(".gif")
+
+
+class ImageOperationsWithAutoImageFormatPreferenceTestCase(
+    BaseImagingTestCase
+):
+    def get_context(self):
+        cfg = Config(SECURITY_KEY="ACME-SEC")
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = self.loader_path
+        cfg.STORAGE = "thumbor.storages.no_storage"
+        cfg.AUTO_WEBP = True
+        cfg.AUTO_AVIF = True
+        cfg.AUTO_IMAGE_FORMAT_PREFERENCE = ["avif", "webp", "jpg", "png"]
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(
+            8889, "localhost", "thumbor.conf", None, "info", None
+        )
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, cfg, importer)
+        ctx.server.gifsicle_path = which("gifsicle")
+        return ctx
+
+    async def get_as_webp_first(self, url):
+        return await self.async_fetch(
+            url, headers={"Accept": "image/webp,image/avif,*/*;q=0.8"}
+        )
+
+    @gen_test
+    async def test_can_auto_convert_to_avif(self):
+        response = await self.get_as_webp_first("/unsafe/image.jpg")
+        expect(response.code).to_equal(200)
+        expect(response.headers).to_include("Vary")
+        expect(response.headers["Vary"]).to_include("Accept")
+
+        expect(response.body).to_be_avif()
+
+    @gen_test
+    async def test_skips_preferred_format_rejected_with_quality_zero(self):
+        response = await self.async_fetch(
+            "/unsafe/image.jpg",
+            headers={"Accept": "image/avif;q=0,image/webp;q=0.8"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.headers["Vary"]).to_include("Accept")
+        expect(response.body).to_be_webp()
+
+    @gen_test
+    async def test_falls_back_to_engine_extension_when_no_match_exists(self):
+        response = await self.async_fetch(
+            "/unsafe/image.jpg", headers={"Accept": "image/tiff"}
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers).to_include("Vary")
+        expect(response.headers["Vary"]).to_include("Accept")
+
+        expect(response.body).to_be_jpeg()
+
+
+class ImageOperationsWithoutAutoImageFormatPreferenceTestCase(
+    BaseImagingTestCase
+):
+    def get_context(self):
+        cfg = Config(SECURITY_KEY="ACME-SEC")
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = self.loader_path
+        cfg.STORAGE = "thumbor.storages.no_storage"
+        cfg.AUTO_WEBP = True
+        cfg.AUTO_AVIF = True
+        cfg.AUTO_IMAGE_FORMAT_PREFERENCE = []
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(
+            8889, "localhost", "thumbor.conf", None, "info", None
+        )
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, cfg, importer)
+        ctx.server.gifsicle_path = which("gifsicle")
+        return ctx
+
+    async def get_as_webp_first(self, url):
+        return await self.async_fetch(
+            url, headers={"Accept": "image/webp,image/avif,*/*;q=0.8"}
+        )
+
+    @gen_test
+    async def test_can_auto_convert_to_webp(self):
+        response = await self.get_as_webp_first("/unsafe/image.jpg")
+        expect(response.code).to_equal(200)
+        expect(response.headers).to_include("Vary")
+        expect(response.headers["Vary"]).to_include("Accept")
+
+        expect(response.body).to_be_webp()
+
+
+class ImageOperationsWithAutoImageFormatPreferenceOverrideTestCase(
+    BaseImagingTestCase
+):
+    def get_context(self):
+        cfg = Config(SECURITY_KEY="ACME-SEC")
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = self.loader_path
+        cfg.STORAGE = "thumbor.storages.no_storage"
+        cfg.AUTO_WEBP = False
+        cfg.AUTO_AVIF = False
+        cfg.AUTO_JPG = False
+        cfg.AUTO_PNG = False
+        cfg.AUTO_HEIF = False
+        cfg.AUTO_IMAGE_FORMAT_PREFERENCE = [" invalid ", " WebP ", "webp"]
+        cfg.FILTERS = [*cfg.FILTERS, "thumbor.filters.autojpg"]
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(
+            8889, "localhost", "thumbor.conf", None, "info", None
+        )
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, cfg, importer)
+        ctx.server.gifsicle_path = which("gifsicle")
+        return ctx
+
+    @gen_test
+    async def test_preference_overrides_auto_flags(self):
+        response = await self.async_fetch(
+            "/unsafe/image.jpg", headers={"Accept": "image/webp,*/*;q=0.8"}
+        )
+        expect(response.code).to_equal(200)
+        expect(response.headers).to_include("Vary")
+        expect(response.headers["Vary"]).to_include("Accept")
+
+        expect(response.body).to_be_webp()
+
+    @gen_test
+    async def test_autojpg_false_does_not_override_explicit_jpg_preference(
+        self,
+    ):
+        self.context.config.AUTO_IMAGE_FORMAT_PREFERENCE = ["jpg"]
+
+        response = await self.async_fetch(
+            "/unsafe/filters:autojpg(false)/"
+            "Giunchedi%2C_Filippo_January_2015_01.png",
+            headers={"Accept": "image/jpeg"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_jpeg()
+
+
+class ImageOperationsWithPreferenceAndAutoPngToJpgTestCase(
+    BaseImagingTestCase
+):
+    def get_context(self):
+        cfg = Config(SECURITY_KEY="ACME-SEC")
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = self.loader_path
+        cfg.STORAGE = "thumbor.storages.no_storage"
+        cfg.AUTO_PNG_TO_JPG = True
+        cfg.AUTO_IMAGE_FORMAT_PREFERENCE = ["webp"]
+        cfg.FILTERS = [*cfg.FILTERS, "thumbor.filters.autojpg"]
+
+        importer = Importer(cfg)
+        importer.import_modules()
+        server = ServerParameters(
+            8889, "localhost", "thumbor.conf", None, "info", None
+        )
+        server.security_key = "ACME-SEC"
+        ctx = Context(server, cfg, importer)
+        ctx.server.gifsicle_path = which("gifsicle")
+        return ctx
+
+    @gen_test
+    async def test_preferred_format_wins_over_auto_png_to_jpg(self):
+        response = await self.async_fetch(
+            "/unsafe/Giunchedi%2C_Filippo_January_2015_01.png",
+            headers={"Accept": "image/webp"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_webp()
+
+    @gen_test
+    async def test_auto_png_to_jpg_is_fallback_after_preference(self):
+        response = await self.async_fetch(
+            "/unsafe/Giunchedi%2C_Filippo_January_2015_01.png",
+            headers={"Accept": "image/png"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_jpeg()
+
+    @gen_test
+    async def test_autojpg_false_disables_only_png_to_jpg_fallback(self):
+        response = await self.async_fetch(
+            "/unsafe/filters:autojpg(false)/"
+            "Giunchedi%2C_Filippo_January_2015_01.png",
+            headers={"Accept": "image/png"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_png()
+
+    @gen_test
+    async def test_autojpg_true_keeps_png_to_jpg_fallback_enabled(self):
+        response = await self.async_fetch(
+            "/unsafe/filters:autojpg(true)/"
+            "Giunchedi%2C_Filippo_January_2015_01.png",
+            headers={"Accept": "image/png"},
+        )
+
+        expect(response.code).to_equal(200)
+        expect(response.body).to_be_jpeg()

--- a/tests/result_storages/test_file_storage.py
+++ b/tests/result_storages/test_file_storage.py
@@ -7,6 +7,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
+import asyncio
 import hashlib
 import tempfile
 from datetime import datetime
@@ -17,7 +18,11 @@ from urllib.parse import unquote
 from preggy import expect
 from tornado.testing import gen_test
 
-from thumbor.auto_image_format import get_auto_image_format_cache_key
+from thumbor.auto_image_format import (
+    get_active_auto_image_formats,
+    get_auto_image_format_cache_key,
+    get_normalized_auto_image_format_preference,
+)
 from thumbor.config import Config
 from thumbor.context import RequestParameters
 from thumbor.result_storages import ResultStorageResult
@@ -223,6 +228,122 @@ class WebPFileStorageTestCase(BaseFileStorageTestCase):
         expect(exists(current_path)).to_be_true()
 
 
+class PreferredFormatsFileStorageTestCase(BaseFileStorageTestCase):
+    def get_config(self):
+        self.storage_path = (
+            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        )
+        return Config(
+            AUTO_IMAGE_FORMAT_PREFERENCE=[" avif ", "webp", "invalid"],
+            RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=self.storage_path.name,
+        )
+
+    def get_request(self):  # pylint: disable=arguments-differ
+        return RequestParameters(accepts_webp=True, accepts_avif=True)
+
+    @gen_test
+    async def test_normalized_path_with_preferred_formats_path(self):
+        expect(self.file_storage).not_to_be_null()
+        expect(
+            self.file_storage.normalize_path(self.get_http_path())
+        ).to_equal(
+            f"{self.storage_path.name}/"
+            "auto_format_v1_preference_preserve_avif-webp/b6/be/"
+            "a3e916129541a9e7146f69a15eb4d7c77c98"
+        )
+
+    @gen_test
+    async def test_put_and_get_keep_accept_variants_separate(self):
+        self.context.request.url = self.get_http_path()
+        avif_bytes = await asyncio.to_thread(
+            self.read_image_fixture, "image.avif"
+        )
+
+        await self.file_storage.put(avif_bytes)
+        avif_webp_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        self.context.request = RequestParameters(
+            url=self.get_http_path(), accepts_webp=True
+        )
+        webp_bytes = await asyncio.to_thread(
+            self.read_image_fixture, "image.webp"
+        )
+
+        await self.file_storage.put(webp_bytes)
+        webp_path = self.file_storage.normalize_path(self.context.request.url)
+
+        expect(avif_webp_path).not_to_equal(webp_path)
+        expect((await self.file_storage.get()).buffer).to_equal(webp_bytes)
+
+        self.context.request = RequestParameters(
+            url=self.get_http_path(), accepts_webp=True, accepts_avif=True
+        )
+        expect((await self.file_storage.get()).buffer).to_equal(avif_bytes)
+
+
+class PreferredWebPFileStorageTestCase(BaseFileStorageTestCase):
+    def get_config(self):
+        self.storage_path = (
+            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        )
+        return Config(
+            AUTO_WEBP=False,
+            AUTO_IMAGE_FORMAT_PREFERENCE=["webp"],
+            RESULT_STORAGE_FILE_STORAGE_ROOT_PATH=self.storage_path.name,
+        )
+
+    def get_request(self):  # pylint: disable=arguments-differ
+        return RequestParameters(url=self.get_http_path(), accepts_webp=True)
+
+    @gen_test
+    async def test_does_not_migrate_legacy_default_into_auto_webp(self):
+        legacy_path, _ = self.put_legacy_fixture("image.jpg")
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(legacy_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+    @gen_test
+    async def test_does_not_read_previous_auto_webp_namespace(self):
+        previous_path, _ = self.put_previous_hashed_fixture(
+            "auto_webp", "image.avif"
+        )
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(previous_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+    @gen_test
+    async def test_does_not_read_previous_default_namespace(self):
+        self.context.request = RequestParameters(
+            url=self.get_http_path(), accepts_webp=False
+        )
+        previous_path, _ = self.put_previous_hashed_fixture(
+            "default", "image.avif"
+        )
+        current_path = self.file_storage.normalize_path(
+            self.context.request.url
+        )
+
+        result = await self.file_storage.get()
+
+        expect(result).to_be_null()
+        expect(exists(previous_path)).to_be_true()
+        expect(exists(current_path)).to_be_false()
+
+
 class AutoAvifFileStorageTestCase(BaseFileStorageTestCase):
     def get_config(self):
         self.storage_path = (
@@ -329,17 +450,22 @@ class AutoImageFormatCacheKeyTestCase(TestCase):
             get_auto_image_format_cache_key(config, RequestParameters())
         ).to_equal("auto_format_v1_flags_preserve_default")
 
-    def test_cache_key_separates_png_to_jpg_fallback(self):
+    def test_cache_key_separates_policies_and_png_to_jpg_fallback(self):
         request = RequestParameters(accepts_heif=True)
         flags_without_fallback = Config(AUTO_HEIF=True, AUTO_PNG_TO_JPG=False)
         flags_with_fallback = Config(AUTO_HEIF=True, AUTO_PNG_TO_JPG=True)
+        preference_with_fallback = Config(
+            AUTO_IMAGE_FORMAT_PREFERENCE=["heif"],
+            AUTO_PNG_TO_JPG=True,
+        )
 
         cache_keys = {
             get_auto_image_format_cache_key(flags_without_fallback, request),
             get_auto_image_format_cache_key(flags_with_fallback, request),
+            get_auto_image_format_cache_key(preference_with_fallback, request),
         }
 
-        expect(len(cache_keys)).to_equal(2)
+        expect(len(cache_keys)).to_equal(3)
 
     def test_png_to_jpg_only_uses_isolated_cache_key(self):
         expect(
@@ -360,6 +486,62 @@ class AutoImageFormatCacheKeyTestCase(TestCase):
                 RequestParameters(request=request),
             )
         ).to_be_null()
+
+    @mock.patch("thumbor.auto_image_format.logger.warning")
+    def test_invalid_preference_warns_once_and_uses_legacy_flags(
+        self, warning
+    ):
+        config = Config(
+            AUTO_WEBP=True,
+            AUTO_IMAGE_FORMAT_PREFERENCE=["invalid", 1, "INVALID"],
+        )
+        request = RequestParameters(accepts_webp=True)
+
+        expect(get_normalized_auto_image_format_preference(config)).to_equal(
+            ()
+        )
+        expect(get_active_auto_image_formats(config)).to_equal(("webp",))
+        expect(get_auto_image_format_cache_key(config, request)).to_equal(
+            "auto_webp"
+        )
+        get_normalized_auto_image_format_preference(config)
+
+        warning.assert_called_once_with(
+            "Ignoring invalid AUTO_IMAGE_FORMAT_PREFERENCE values: %r. "
+            "Valid formats are: %s.",
+            ["invalid", 1, "INVALID"],
+            "webp, avif, jpg, heif, png",
+        )
+
+    def test_normalized_preference_cache_is_published_atomically(self):
+        class ReentrantConfig:
+            def __init__(self):
+                self.AUTO_IMAGE_FORMAT_PREFERENCE = [  # pylint: disable=invalid-name
+                    "avif"
+                ]
+                self.observed_preferences = []
+                self.inspecting_cache_write = False
+
+            def __setattr__(self, name, value):
+                object.__setattr__(self, name, value)
+
+                if not name.startswith(
+                    "_AUTO_IMAGE_FORMAT_PREFERENCE_"
+                ) or object.__getattribute__(self, "inspecting_cache_write"):
+                    return
+
+                object.__setattr__(self, "inspecting_cache_write", True)
+                self.observed_preferences.append(
+                    get_normalized_auto_image_format_preference(self)
+                )
+                object.__setattr__(self, "inspecting_cache_write", False)
+
+        config = ReentrantConfig()
+
+        expect(get_normalized_auto_image_format_preference(config)).to_equal(
+            ("avif",)
+        )
+        expect(config.observed_preferences).to_equal([("avif",)])
 
 
 class ResultStorageResultTestCase(BaseFileStorageTestCase):

--- a/thumbor/auto_image_format.py
+++ b/thumbor/auto_image_format.py
@@ -7,7 +7,10 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2025 globo.com thumbor@googlegroups.com
 
+from thumbor.utils import logger
+
 DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE = ("webp", "avif", "jpg", "heif", "png")
+VALID_AUTO_IMAGE_FORMATS = frozenset(DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE)
 AUTO_IMAGE_FORMAT_CACHE_KEY_PREFIX = "auto_format_v1"
 
 AUTO_IMAGE_FORMAT_CONFIG_FLAGS = {
@@ -27,7 +30,69 @@ AUTO_IMAGE_FORMAT_ACCEPT_ATTRS = {
 }
 
 
+def _get_raw_auto_image_format_preference(config):
+    return tuple(getattr(config, "AUTO_IMAGE_FORMAT_PREFERENCE", ()) or ())
+
+
+def has_auto_image_format_preference(config):
+    return bool(get_normalized_auto_image_format_preference(config))
+
+
+def get_normalized_auto_image_format_preference(config):
+    raw_preference = _get_raw_auto_image_format_preference(config)
+    cached_preference = getattr(
+        config,
+        "_AUTO_IMAGE_FORMAT_PREFERENCE_CACHE",
+        None,
+    )
+
+    if cached_preference is None or cached_preference[0] != raw_preference:
+        normalized_preference = []
+        invalid_formats = []
+        seen_formats = set()
+
+        for image_format in raw_preference:
+            if not isinstance(image_format, str):
+                invalid_formats.append(image_format)
+                continue
+
+            normalized_format = image_format.strip().lower()
+
+            if normalized_format not in VALID_AUTO_IMAGE_FORMATS:
+                invalid_formats.append(image_format)
+                continue
+
+            if normalized_format in seen_formats:
+                continue
+
+            seen_formats.add(normalized_format)
+            normalized_preference.append(normalized_format)
+
+        if invalid_formats:
+            logger.warning(
+                "Ignoring invalid AUTO_IMAGE_FORMAT_PREFERENCE values: %r. "
+                "Valid formats are: %s.",
+                invalid_formats,
+                ", ".join(DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE),
+            )
+
+        cached_preference = (
+            raw_preference,
+            tuple(normalized_preference),
+        )
+        setattr(
+            config,
+            "_AUTO_IMAGE_FORMAT_PREFERENCE_CACHE",
+            cached_preference,
+        )
+
+    return cached_preference[1]
+
+
 def get_active_auto_image_formats(config):
+    if has_auto_image_format_preference(config):
+        return get_normalized_auto_image_format_preference(config)
+
     active_formats = []
 
     for image_format in DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE:
@@ -41,6 +106,9 @@ def get_active_auto_image_formats(config):
 
 def requires_auto_image_format_cache_isolation(config):
     """Return whether legacy ``default``/``auto_webp`` keys are unsafe."""
+    if has_auto_image_format_preference(config):
+        return True
+
     return getattr(config, "AUTO_PNG_TO_JPG", False) or any(
         getattr(config, AUTO_IMAGE_FORMAT_CONFIG_FLAGS[image_format], False)
         for image_format in DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE
@@ -54,6 +122,7 @@ def get_auto_image_format_cache_key(config, request):
     Result storage implementations can use this helper to keep responses for
     different ``Accept`` capabilities in separate cache namespaces.
     """
+    preference_enabled = has_auto_image_format_preference(config)
     active_formats = get_active_auto_image_formats(config)
     cache_isolation_required = requires_auto_image_format_cache_isolation(
         config
@@ -71,6 +140,7 @@ def get_auto_image_format_cache_key(config, request):
             accepted_formats.append(image_format)
 
     if cache_isolation_required:
+        policy = "preference" if preference_enabled else "flags"
         fallback = (
             "png_to_jpg"
             if getattr(config, "AUTO_PNG_TO_JPG", False)
@@ -78,7 +148,7 @@ def get_auto_image_format_cache_key(config, request):
         )
         variant = "-".join(accepted_formats) or "default"
         return (
-            f"{AUTO_IMAGE_FORMAT_CACHE_KEY_PREFIX}_flags_"
+            f"{AUTO_IMAGE_FORMAT_CACHE_KEY_PREFIX}_{policy}_"
             f"{fallback}_{variant}"
         )
 

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -236,6 +236,15 @@ Config.define(
     "Imaging",
 )
 Config.define(
+    "AUTO_IMAGE_FORMAT_PREFERENCE",
+    [],
+    "Ordered list of preferred formats to be used automatically. "
+    "Valid formats are webp, avif, jpg, heif and png. A list containing at "
+    "least one valid format overrides all individual AUTO_* format settings, "
+    "but AUTO_PNG_TO_JPG remains an independent fallback.",
+    "Imaging",
+)
+Config.define(
     "SVG_DPI",
     150,
     "Specify the ratio between 1in and 1px for SVG images. This is only used when "

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -23,6 +23,8 @@ from thumbor.auto_image_format import (
     AUTO_IMAGE_FORMAT_ACCEPT_ATTRS,
     DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE,
     get_active_auto_image_formats,
+    get_normalized_auto_image_format_preference,
+    has_auto_image_format_preference,
 )
 from thumbor.context import Context, RequestParameters
 from thumbor.engines import BaseEngine, EngineResult
@@ -39,6 +41,14 @@ HTTP_DATE_FMT = "%a, %d %b %Y %H:%M:%S GMT"
 MIMETYPE_IMAGE_WILDCARD = "image/*"
 MIMETYPE_JPEG = "image/jpeg"
 MIMETYPE_JPG = "image/jpg"
+
+PREFERENCE_AUTO_IMAGE_FORMAT_METHODS = {
+    "webp": "_supports_webp",
+    "avif": "_supports_avif",
+    "jpg": "_supports_jpg",
+    "heif": "_supports_heif",
+    "png": "_supports_png",
+}
 
 LEGACY_AUTO_IMAGE_FORMAT_METHODS = {
     "webp": "can_auto_convert_to_webp",
@@ -599,6 +609,41 @@ class BaseHandler(tornado.web.RequestHandler):
         return self.context.config.AUTO_PNG and self._supports_png()
 
     def _resolve_auto_image_extension(self, context):
+        if has_auto_image_format_preference(context.config):
+            for image_format in get_normalized_auto_image_format_preference(
+                context.config
+            ):
+                method_name = PREFERENCE_AUTO_IMAGE_FORMAT_METHODS[
+                    image_format
+                ]
+
+                if getattr(self, method_name)():
+                    image_extension = f".{image_format}"
+                    logger.debug(
+                        "Image format set by AUTO_IMAGE_FORMAT_PREFERENCE as %s.",
+                        image_extension,
+                    )
+
+                    return image_extension
+
+            if self.can_auto_convert_png_to_jpg():
+                image_extension = ".jpg"
+                logger.debug(
+                    "Image format set by AUTO_PNG_TO_JPG as %s.",
+                    image_extension,
+                )
+
+                return image_extension
+
+            image_extension = context.request.engine.extension
+            logger.debug(
+                "No preferred image format matched. Retrieving from engine "
+                "extension: %s.",
+                image_extension,
+            )
+
+            return image_extension
+
         for image_format in DEFAULT_AUTO_IMAGE_FORMAT_PREFERENCE:
             method_name = LEGACY_AUTO_IMAGE_FORMAT_METHODS[image_format]
 
@@ -849,13 +894,7 @@ class BaseHandler(tornado.web.RequestHandler):
             buffer = results
 
         # auto-convert configured?
-        should_vary = (
-            self.context.config.AUTO_WEBP
-            or self.context.config.AUTO_AVIF
-            or self.context.config.AUTO_JPG
-            or self.context.config.AUTO_HEIF
-            or self.context.config.AUTO_PNG
-        )
+        should_vary = bool(get_active_auto_image_formats(self.context.config))
         # we have image (not video)
         should_vary = should_vary and content_type.startswith("image/")
         # output format is not requested via format filter

--- a/thumbor/thumbor.conf
+++ b/thumbor/thumbor.conf
@@ -49,6 +49,12 @@ home = expanduser("~")
 ## pillow-heif is enabled
 # AUTO_HEIF = False
 
+## Preferred order for automatic output formats. Valid values are webp, avif,
+## jpg, heif and png. Invalid values are ignored with a warning. A list with at
+## least one valid value overrides all individual AUTO_* options above; an empty
+## list or one with no valid values keeps legacy behavior.
+# AUTO_IMAGE_FORMAT_PREFERENCE = []
+
 ## Automatically converts PNG to JPG if PNG has no transparency.
 ## WARNING: Depending on case, this is not a good deal. This
 ## transformation maybe causes distortions or the size of image can increase.


### PR DESCRIPTION
👉 Note: Fifth and last of five PRs splitting up #1746.

The automatic formats are walked in a fixed order, WebP first. Browsers that accept AVIF also accept WebP, so they always get WebP and `AUTO_AVIF = True` does nothing — that's #1688, and @peleteiro hit it in production at Bíblia Online ([his report on #1746](https://github.com/thumbor/thumbor/pull/1746#issuecomment-4957420967), with AVIF at −27% bytes for the same quality). Fixes #1688.

This adds `AUTO_IMAGE_FORMAT_PREFERENCE`: an ordered list of preferred automatic output formats. Valid values are `webp`, `avif`, `jpg`, `heif` and `png`; values are trimmed, lowercased and deduplicated, and invalid values are ignored with one warning. A list with at least one valid value overrides the individual `AUTO_*` format settings; an empty or fully invalid list keeps them, so existing setups are unaffected.

```python
# For example:
AUTO_IMAGE_FORMAT_PREFERENCE = ["avif", "webp", "jpg", "png", "heif"]
```

With a preference configured, thumbor goes through the list in order and picks the first format that the client says it accepts (its `Accept` header) and that the engine can produce. When no entry matches, `AUTO_PNG_TO_JPG` still applies as an independent fallback, and the engine extension is kept otherwise.

The same URL can now return different formats to different clients, and a cache that stores by URL alone would hand one client's format to another — e.g. a cached AVIF to a browser that can't show it. So thumbor sends [`Vary: Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary) whenever any automatic format is active. Result storage is separated the same way (#1859): files created with a preference are stored apart from files created with the `AUTO_*` settings, so turning the preference on or off never serves a file created the other way.

⚠️ Upgrade note: turning the preference on (or off) starts with an empty result-storage namespace — every cached result is regenerated once. Old entries are not removed automatically.

@peleteiro, taking you up on the offer: this is the PR to test in production.

Big thanks, @marcelometal 🤘
