### PR TITLE
fix: serve grayscale over indexed PNGs instead of raising 500

### DIFF
--- a/tests/engines/test_pil.py
+++ b/tests/engines/test_pil.py
@@ -15,7 +15,7 @@ from unittest import TestCase, mock
 
 import piexif
 import pytest
-from PIL import Image
+from PIL import Image, ImageChops
 from preggy import expect
 
 from tests.base import (
@@ -280,6 +280,12 @@ class PilEngineTestCase(TestCase):
 
         expect(img.mode).to_equal("P")
         expect(img.format.lower()).to_equal("png")
+
+        # Every pixel must be grey, so that neither a no-op grayscale nor
+        # colour reintroduced by the quantization goes unnoticed
+        red, green, blue = img.convert("RGB").split()
+        expect(ImageChops.difference(red, green).getextrema()[1]).to_equal(0)
+        expect(ImageChops.difference(green, blue).getextrema()[1]).to_equal(0)
 
         transparent_pixels_count = sum(
             img.convert("RGBA")

--- a/tests/engines/test_pil.py
+++ b/tests/engines/test_pil.py
@@ -262,6 +262,34 @@ class PilEngineTestCase(TestCase):
         # Image has total of 200x150=30000 pixels. Most of them should be transparent
         expect(transparent_pixels_count).to_be_greater_than(19000)
 
+    def test_should_preserve_png_transparency_after_grayscale(self):
+        engine = Engine(self.context)
+
+        with open(
+            join(STORAGE_PATH, "paletted-transparent.png"), "rb"
+        ) as image_file:
+            buffer = image_file.read()
+
+        engine.load(buffer, "png")
+        expect(engine.original_mode).to_equal("P")
+        engine.resize(200, 150)
+        # Leaves the image in LA mode, which quantize() does not accept
+        engine.convert_to_grayscale()
+
+        img = Image.open(BytesIO(engine.read(".png")))
+
+        expect(img.mode).to_equal("P")
+        expect(img.format.lower()).to_equal("png")
+
+        transparent_pixels_count = sum(
+            img.convert("RGBA")
+            .split()[3]
+            .point(lambda x: 0 if x else 1)
+            .getdata()
+        )
+
+        expect(transparent_pixels_count).to_be_greater_than(19000)
+
     @skip_unless_avif
     def test_convert_jpg_to_avif(self):
         engine = Engine(self.context)

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -262,10 +262,11 @@ class Engine(BaseEngine):
             if self.original_mode == "1":
                 self.image = self.image.convert("1")
             else:
-                # quantize() only takes L, P, RGB and RGBA. Filters that
-                # convert to grayscale leave images carrying alpha in LA
-                # mode, which it rejects with "image has wrong mode".
-                if self.image.mode == "LA":
+                # quantize() only takes L, P, RGB and RGBA, and rejects
+                # every other mode with "image has wrong mode". Filters are
+                # pluggable and can leave any of them behind: grayscale(),
+                # for one, leaves images carrying alpha in LA mode.
+                if self.image.mode not in ("L", "P", "RGB", "RGBA"):
                     self.image = self.image.convert("RGBA")
 
                 # libimagequant might not be enabled on compile time

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -262,6 +262,12 @@ class Engine(BaseEngine):
             if self.original_mode == "1":
                 self.image = self.image.convert("1")
             else:
+                # quantize() only takes L, P, RGB and RGBA. Filters that
+                # convert to grayscale leave images carrying alpha in LA
+                # mode, which it rejects with "image has wrong mode".
+                if self.image.mode == "LA":
+                    self.image = self.image.convert("RGBA")
+
                 # libimagequant might not be enabled on compile time
                 # but it's better than default octree for RGBA images
                 quantize_method = (


### PR DESCRIPTION
Fixes #1862.

`filters:grayscale()` over a palette PNG answered **500 with an empty body**:

1. `resize()` widens indexed images to RGB(A).
2. `convert_to_grayscale()` returns mode **`LA`** when the image carries alpha.
3. `read()` restores the original indexed mode via `Image.quantize()` when
   `PILLOW_PRESERVE_INDEXED_MODE` is on (the default).
4. Pillow's `quantize()` takes `L`, `P`, `RGB` and `RGBA` — for `RGBA` it picks
   FASTOCTREE itself — but rejects `LA` with `ValueError: image has wrong mode`.

Widening `LA` to `RGBA` right before quantizing keeps the palette, the grey pixels and
the alpha channel, so the output is still the indexed PNG the setting asks for. No
flattening, no forced JPEG.

Only `grayscale` leaves the image in `LA` among the built-in filters, and GIFs use
`GIF_ENGINE`, so this is the whole surface. It applies to `master` and to 7.8.0 alike,
and #1774 does not cover it (it only touches `resize()`).

### Verification

The new test is red before the change and green after:

```
$ git stash && pytest tests/engines/test_pil.py -k after_grayscale
    self.image = self.image.quantize(method=quantize_method)
ValueError: image has wrong mode
FAILED (errors=1)

$ git stash pop && pytest tests/engines/test_pil.py -k after_grayscale
Ran 1 tests in 0.01s
OK
```

Full file, and the wider engine/filter selection with no new failures (the 10 that fail
do so identically on unmodified `master` here, for want of a local `gifsicle` and an SVG
converter):

```
$ pytest tests/engines/test_pil.py
Ran 30 tests in 0.54s
OK (skipped=5, expected failures=2)

$ pytest tests/engines/ tests/filters/     # this branch
Ran 180 tests ... errors=5, failures=5
$ pytest tests/engines/ tests/filters/     # master
Ran 179 tests ... errors=5, failures=5     # same names, pre-existing
```

Style gates:

```
$ black --check thumbor/engines/pil.py tests/engines/test_pil.py   # unchanged
$ isort --check-only ...                                           # clean
$ flake8 --config .flake8 ...                                      # clean
$ pylint --rcfile=pylintrc ...                                     # 10.00/10
```

The test reuses the existing `tests/fixtures/images/paletted-transparent.png` fixture
(mode `P` + `tRNS`), so no new binary is added, and it sits next to
`test_should_preserve_png_transparency`, which covers the same fixture without the
filter.
