### PR TITLE
Validate security key paths before reading

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -7,6 +7,8 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import TestCase, mock
 
 from preggy import expect
@@ -182,6 +184,89 @@ class ServerParametersTestCase(TestCase):
                 fd="fd",
                 gifsicle_path="gifsicle_path",
             )
+
+    @staticmethod
+    def test_cant_load_relative_security_key_outside_working_directory():
+        with TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            working_directory = temporary_path / "working-directory"
+            working_directory.mkdir()
+            (temporary_path / "thumbor.key").write_text(
+                "SECURITY_KEY_FILE", encoding="utf-8"
+            )
+
+            expected_msg = (
+                "Security key file path ../thumbor.key resolves outside "
+                "its allowed directory. Please verify the keypath argument."
+            )
+
+            with mock.patch(
+                "thumbor.context.Path.cwd", return_value=working_directory
+            ):
+                with expect.error_to_happen(ValueError, message=expected_msg):
+                    ServerParameters(
+                        port=8888,
+                        ip="0.0.0.0",
+                        config_path="/my/config_path.conf",
+                        keyfile="../thumbor.key",
+                        log_level="debug",
+                        app_class="app",
+                        fd="fd",
+                        gifsicle_path="gifsicle_path",
+                    )
+
+    @staticmethod
+    def test_can_load_absolute_security_key_outside_working_directory():
+        with TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            working_directory = temporary_path / "working-directory"
+            working_directory.mkdir()
+            keyfile = temporary_path / "thumbor.key"
+            keyfile.write_text("SECURITY_KEY_FILE", encoding="utf-8")
+
+            with mock.patch(
+                "thumbor.context.Path.cwd", return_value=working_directory
+            ):
+                params = ServerParameters(
+                    port=8888,
+                    ip="0.0.0.0",
+                    config_path="/my/config_path.conf",
+                    keyfile=str(keyfile),
+                    log_level="debug",
+                    app_class="app",
+                    fd="fd",
+                    gifsicle_path="gifsicle_path",
+                )
+
+            expect(params.security_key).to_equal("SECURITY_KEY_FILE")
+
+    @staticmethod
+    def test_cant_load_absolute_security_key_symlink_outside_its_directory():
+        with TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            allowed_directory = temporary_path / "keys"
+            allowed_directory.mkdir()
+            keyfile = temporary_path / "thumbor.key"
+            keyfile.write_text("SECURITY_KEY_FILE", encoding="utf-8")
+            keyfile_symlink = allowed_directory / "thumbor.key"
+            keyfile_symlink.symlink_to(keyfile)
+
+            expected_msg = (
+                f"Security key file path {keyfile_symlink} resolves outside "
+                "its allowed directory. Please verify the keypath argument."
+            )
+
+            with expect.error_to_happen(ValueError, message=expected_msg):
+                ServerParameters(
+                    port=8888,
+                    ip="0.0.0.0",
+                    config_path="/my/config_path.conf",
+                    keyfile=str(keyfile_symlink),
+                    log_level="debug",
+                    app_class="app",
+                    fd="fd",
+                    gifsicle_path="gifsicle_path",
+                )
 
 
 class RequestParametersTestCase(TestCase):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase, mock
 
+import pytest
 from preggy import expect
 
 from thumbor.config import Config
@@ -203,7 +204,7 @@ class ServerParametersTestCase(TestCase):
             with mock.patch(
                 "thumbor.context.Path.cwd", return_value=working_directory
             ):
-                with expect.error_to_happen(ValueError, message=expected_msg):
+                with pytest.raises(ValueError) as error:
                     ServerParameters(
                         port=8888,
                         ip="0.0.0.0",
@@ -214,6 +215,8 @@ class ServerParametersTestCase(TestCase):
                         fd="fd",
                         gifsicle_path="gifsicle_path",
                     )
+
+            assert str(error.value) == expected_msg
 
     @staticmethod
     def test_can_load_absolute_security_key_outside_working_directory():
@@ -238,7 +241,7 @@ class ServerParametersTestCase(TestCase):
                     gifsicle_path="gifsicle_path",
                 )
 
-            expect(params.security_key).to_equal("SECURITY_KEY_FILE")
+            assert params.security_key == b"SECURITY_KEY_FILE"
 
     @staticmethod
     def test_cant_load_absolute_security_key_symlink_outside_its_directory():
@@ -256,7 +259,7 @@ class ServerParametersTestCase(TestCase):
                 "its allowed directory. Please verify the keypath argument."
             )
 
-            with expect.error_to_happen(ValueError, message=expected_msg):
+            with pytest.raises(ValueError) as error:
                 ServerParameters(
                     port=8888,
                     ip="0.0.0.0",
@@ -267,6 +270,8 @@ class ServerParametersTestCase(TestCase):
                     fd="fd",
                     gifsicle_path="gifsicle_path",
                 )
+
+            assert str(error.value) == expected_msg
 
 
 class RequestParametersTestCase(TestCase):

--- a/thumbor/context.py
+++ b/thumbor/context.py
@@ -7,7 +7,7 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
-from os.path import abspath, exists
+from pathlib import Path
 
 from thumbor.filters import FiltersFactory
 from thumbor.metrics.logger_metrics import Metrics
@@ -208,9 +208,36 @@ class ServerParameters:  # pylint: disable=too-many-instance-attributes
         if not self.keyfile:
             return
 
-        path = abspath(self.keyfile)
+        configured_path = Path(self.keyfile)
+        path = configured_path
 
-        if not exists(path):
+        try:
+            if configured_path.is_absolute():
+                allowed_directory = configured_path.parent.resolve(strict=True)
+                path = allowed_directory / configured_path.name
+            else:
+                allowed_directory = Path.cwd().resolve(strict=True)
+                path = allowed_directory / configured_path
+
+            path = path.resolve(strict=True)
+        except (OSError, RuntimeError) as error:
+            raise ValueError(
+                (
+                    f"Could not find security key file at {path.absolute()}. "
+                    "Please verify the keypath argument."
+                )
+            ) from error
+
+        if not path.is_relative_to(allowed_directory):
+            raise ValueError(
+                (
+                    f"Security key file path {configured_path} resolves "
+                    "outside its allowed directory. Please verify the "
+                    "keypath argument."
+                )
+            )
+
+        if not path.is_file():
             raise ValueError(
                 (
                     f"Could not find security key file at {path}. "
@@ -218,7 +245,7 @@ class ServerParameters:  # pylint: disable=too-many-instance-attributes
                 )
             )
 
-        with open(path, "rb") as security_key_file:
+        with path.open("rb") as security_key_file:
             security_key = security_key_file.read().strip()
 
         self.security_key = security_key


### PR DESCRIPTION
Resolve key file paths against an allowed directory before opening them, rejecting traversal and symlink escapes. Add regression coverage for relative traversal, valid absolute paths, and symlink targets.