### PR TITLE
fix(pil): detect tRNS transparency, not just alpha modes

### DIFF
--- a/tests/engines/test_pil.py
+++ b/tests/engines/test_pil.py
@@ -290,6 +290,77 @@ class PilEngineTestCase(TestCase):
 
         assert transparent_pixels_count > 19000
 
+    def test_convert_to_grayscale_should_preserve_palette_transparency(self):
+        engine = Engine(self.context)
+
+        with open(
+            join(STORAGE_PATH, "paletted-transparent.png"), "rb"
+        ) as image_file:
+            buffer = image_file.read()
+
+        engine.load(buffer, "png")
+        assert engine.original_mode == "P"
+        expected_alpha = engine.image.convert("RGBA").getchannel("A").tobytes()
+
+        image = engine.convert_to_grayscale()
+
+        assert image.mode == "LA"
+        assert image.getchannel("A").tobytes() == expected_alpha
+
+    def test_image_data_as_rgb_should_preserve_colorkey_transparency(self):
+        engine = Engine(self.context)
+
+        gray = Image.new("L", (5, 5), 128)
+        png_buffer = BytesIO()
+        gray.save(png_buffer, "PNG", transparency=128)
+
+        engine.load(png_buffer.getvalue(), "png")
+        assert engine.original_mode == "L"
+        expected_alpha = engine.image.convert("RGBA").getchannel("A").tobytes()
+
+        mode, data = engine.image_data_as_rgb()
+
+        assert mode == "RGBA"
+        assert data[3::4] == expected_alpha
+
+    def test_image_data_as_rgb_should_preserve_rgb_colorkey_transparency(
+        self,
+    ):
+        engine = Engine(self.context)
+
+        magenta = Image.new("RGB", (5, 5), (255, 0, 255))
+        png_buffer = BytesIO()
+        magenta.save(png_buffer, "PNG", transparency=(255, 0, 255))
+
+        engine.load(png_buffer.getvalue(), "png")
+        assert engine.original_mode == "RGB"
+        expected_alpha = engine.image.convert("RGBA").getchannel("A").tobytes()
+
+        mode, data = engine.image_data_as_rgb()
+
+        assert mode == "RGBA"
+        assert data[3::4] == expected_alpha
+
+    def test_read_should_quantize_grayscale_images_with_alpha(self):
+        engine = Engine(self.context)
+
+        palette = Image.new("RGBA", (5, 5), (255, 0, 255, 0)).quantize()
+        png_buffer = BytesIO()
+        palette.save(png_buffer, "PNG")
+
+        engine.load(png_buffer.getvalue(), "png")
+        assert engine.original_mode == "P"
+        engine.convert_to_grayscale()
+        assert engine.image.mode == "LA"
+        expected_alpha = engine.image.getchannel("A").tobytes()
+
+        image = Image.open(BytesIO(engine.read(".png")))
+
+        assert image.mode == "P"
+        assert (
+            image.convert("RGBA").getchannel("A").tobytes() == expected_alpha
+        )
+
     @skip_unless_avif
     def test_convert_jpg_to_avif(self):
         engine = Engine(self.context)

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -483,13 +483,13 @@ class Engine(BaseEngine):
     def image_data_as_rgb(self, update_image=True):
         converted_image = self.image
 
-        if converted_image.mode not in ["RGB", "RGBA"]:
-            if "A" in converted_image.mode:
+        if converted_image.mode != "RGBA":
+            if self.has_transparency():
                 converted_image = converted_image.convert("RGBA")
             elif converted_image.mode == "P":
                 # convert() figures out RGB or RGBA based on palette used
                 converted_image = converted_image.convert(None)
-            else:
+            elif converted_image.mode != "RGB":
                 converted_image = converted_image.convert("RGB")
 
         if update_image:
@@ -498,7 +498,7 @@ class Engine(BaseEngine):
         return converted_image.mode, converted_image.tobytes()
 
     def convert_to_grayscale(self, update_image=True, alpha=True):
-        if "A" in self.image.mode and alpha:
+        if alpha and self.has_transparency():
             image = self.image.convert("LA")
         else:
             image = self.image.convert("L")


### PR DESCRIPTION
Deciding on transparency by looking for "A" in the mode misses images that store it in a tRNS chunk instead of an alpha channel: palette PNGs, and grayscale or truecolor PNGs with a colorkey. Two spots did that:

- `convert_to_grayscale()` flattened those images to opaque `L` — `filters:grayscale()` over a transparent palette PNG, no resize involved, returned the image with its transparency gone, silently.
- `image_data_as_rgb()` handed filters `RGB` data with the colorkey dropped — and its old gate never let a truecolor image with a colorkey enter the conversion at all.

Both now decide with `has_transparency()`, which also checks tRNS.

Four tests, all comparing alpha bytes exactly: palette PNG through grayscale, gray and truecolor colorkey PNGs through `image_data_as_rgb()`, and the no-resize path through `read()`.