### PR TITLE
fix: avoid polynomial regex in format detection

### DIFF
--- a/tests/handlers/test_base_handler_compatibility.py
+++ b/tests/handlers/test_base_handler_compatibility.py
@@ -238,6 +238,33 @@ def test_accepts_mime_type_super_call_honors_image_wildcard():
     )
 
 
+@pytest.mark.asyncio
+async def test_malformed_format_filter_does_not_suppress_vary():
+    context = SimpleNamespace(
+        config=Config(AUTO_WEBP=True),
+        request=SimpleNamespace(
+            max_age=None,
+            prevent_result_storage=False,
+            detection_error=None,
+            format="png",
+            # This shape caused polynomial backtracking in the old regex.
+            filters="format(" * 10_000,
+        ),
+        headers=None,
+    )
+    handler = make_handler(context)
+    handler._headers = {}  # pylint: disable=protected-access
+    handler.set_header = mock.Mock()
+    handler.write = mock.Mock()
+    handler.finish = mock.Mock()
+
+    await handler._write_results_to_client(  # pylint: disable=protected-access
+        b"image", "image/png"
+    )
+
+    handler.set_header.assert_any_call("Vary", "Accept")
+
+
 @pytest.mark.parametrize(
     "accept_header",
     [

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -9,7 +9,6 @@
 
 import datetime
 import functools
-import re
 import sys
 import traceback
 
@@ -65,6 +64,29 @@ LEGACY_AUTO_IMAGE_FORMAT_LOG_MESSAGES = {
     "heif": "Image format set by AUTO_HEIF as %s.",
     "png": "Image format set by AUTO_PNG as %s.",
 }
+
+
+def _has_explicit_format_filter(filters):
+    if not isinstance(filters, str):
+        return False
+
+    marker = "format("
+    search_from = 0
+
+    while True:
+        match_start = filters.find(marker, search_from)
+        if match_start == -1:
+            return False
+
+        argument_start = match_start + len(marker)
+        closing_parenthesis = filters.find(")", argument_start)
+        if closing_parenthesis == -1:
+            return False
+        if closing_parenthesis > argument_start:
+            return True
+
+        search_from = argument_start
+
 
 # Handlers should not override __init__ pylint: disable=attribute-defined-outside-init,arguments-differ
 # pylint: disable=broad-except,abstract-method,too-many-branches,too-many-return-statements,too-many-statements,too-many-lines
@@ -900,9 +922,7 @@ class BaseHandler(tornado.web.RequestHandler):
         # output format is not requested via format filter
         should_vary = should_vary and not (
             self.context.request.format
-            and bool(  # format is supported by filter
-                re.search(r"format\([^)]+\)", self.context.request.filters)
-            )  # filter is in request
+            and _has_explicit_format_filter(self.context.request.filters)
         )
         # our image is not animated gif
         should_vary = should_vary and not self.is_animated_gif(buffer)


### PR DESCRIPTION
## Summary

- replace the polynomial regular expression used to detect an explicit `format(...)` filter with a linear scanner
- preserve the original two-part decision: the requested format must be supported and the filter must be explicitly present in the request
- add a regression test using repeated, unterminated `format(` prefixes

## Context

The regular expression was introduced by commit [`dc08f2442`](https://github.com/thumbor/thumbor/commit/dc08f24429718edddf0e0e86eb4d12e0ab0e97f0) in [#839](https://github.com/thumbor/thumbor/pull/839). That change avoided unpacking images from result storage solely to decide whether the response needed `Vary: Accept`, reducing CPU usage on the cache-hit path.

The original condition deliberately combined two signals:

1. `request.format` confirms that the requested format was accepted by the format filter.
2. Inspecting `request.filters` confirms that the format was explicitly requested in the URL.

This PR keeps that distinction instead of relying only on `request.format`. It changes only how the raw filter string is inspected.

## Security

The previous `format\([^)]+\)` search could perform polynomial backtracking on user-controlled strings containing many `format(` prefixes without a closing parenthesis. The replacement always advances or returns, runs in linear time, and uses constant additional memory.

Addresses https://github.com/thumbor/thumbor/security/code-scanning/11.

## Validation

- 141 relevant handler and automatic-format tests pass
- Black, Flake8, isort, and Pylint pass
- pre-commit hooks pass
