### PR TITLE
fix: preserve fill canvas with no_upscale

### DIFF
--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -166,6 +166,46 @@ class ImagingOperationsTestCase(BaseImagingTestCase):
         assert response.code == 200
 
     @gen_test
+    async def test_no_upscale_preserves_fill_canvas(self):
+        filter_orders = (
+            "no_upscale():fill(ff0000)",
+            "fill(ff0000):no_upscale()",
+        )
+
+        for filters in filter_orders:
+            response = await self.async_fetch(
+                f"/unsafe/fit-in/400x300/filters:{filters}:format(png)/"
+                "20x20.jpg"
+            )
+
+            assert response.code == 200
+
+            engine = Engine(self.context)
+            engine.load(response.body, ".png")
+
+            assert engine.size == (400, 300)
+
+    @gen_test
+    async def test_no_upscale_preserves_adaptive_fill_orientation(self):
+        expected = await self.async_fetch(
+            "/unsafe/adaptive-fit-in/400x300/"
+            "filters:fill(ff0000):format(png)/image.jpg"
+        )
+        response = await self.async_fetch(
+            "/unsafe/adaptive-fit-in/400x300/"
+            "filters:no_upscale():fill(ff0000):format(png)/image.jpg"
+        )
+
+        assert expected.code == 200
+        assert response.code == 200
+
+        engine = Engine(self.context)
+        engine.load(response.body, ".png")
+
+        assert engine.size == (300, 400)
+        assert_similar_to(response.body, expected.body)
+
+    @gen_test
     async def test_can_get_image_with_invalid_quantization_table(self):
         response = await self.async_fetch("/unsafe/invalid_quantization.jpg")
         assert response.code == 200

--- a/thumbor/filters/fill.py
+++ b/thumbor/filters/fill.py
@@ -13,6 +13,12 @@ from thumbor.filters.blur import apply_blur
 
 
 class Filter(BaseFilter):
+    @staticmethod
+    def target_dimension(requested, transformed, image_size):
+        requested = image_size if requested in (0, "orig") else requested
+        transformed = image_size if transformed in (0, "orig") else transformed
+        return max(requested, transformed)
+
     def get_median_color(self):
         mode, data = self.engine.image_data_as_rgb()
         red, green, blue = _fill.apply(mode, data)
@@ -25,15 +31,15 @@ class Filter(BaseFilter):
     @filter_method(r"[\w]+", BaseFilter.Boolean)
     async def fill(self, color, fill_transparent=False):
         self.fill_engine = self.engine.__class__(self.context)
-        target_width = (
-            self.context.request.width
-            if self.context.request.width != 0
-            else self.engine.size[0]
+        target_width = self.target_dimension(
+            self.context.transformer.requested_width,
+            self.context.request.width,
+            self.engine.size[0],
         )
-        target_height = (
-            self.context.request.height
-            if self.context.request.height != 0
-            else self.engine.size[1]
+        target_height = self.target_dimension(
+            self.context.transformer.requested_height,
+            self.context.request.height,
+            self.engine.size[1],
         )
 
         # if the color is 'auto'

--- a/thumbor/transformer.py
+++ b/thumbor/transformer.py
@@ -27,6 +27,8 @@ class Transformer:
         self.focal_points = None
         self.target_height = None
         self.target_width = None
+        self.requested_height = self.context.request.height
+        self.requested_width = self.context.request.width
 
     async def transform(self):
         if self.context.config.RESPECT_ORIENTATION:
@@ -71,34 +73,45 @@ class Transformer:
             self.context.request.crop["right"] -= box[0]
             self.context.request.crop["bottom"] -= box[1]
 
-    def _calculate_target_dimensions(self):
+    def _calculate_dimensions(self, width, height):
         source_width, source_height = self.engine.size
         source_width = float(source_width)
         source_height = float(source_height)
 
-        if not self.context.request.width and not self.context.request.height:
-            self.target_width = source_width
-            self.target_height = source_height
+        if not width and not height:
+            target_width = source_width
+            target_height = source_height
         else:
-            if self.context.request.width:
-                if self.context.request.width == "orig":
-                    self.target_width = source_width
+            if width:
+                if width == "orig":
+                    target_width = source_width
                 else:
-                    self.target_width = float(self.context.request.width)
+                    target_width = float(width)
             else:
-                self.target_width = self.engine.get_proportional_width(
-                    self.context.request.height
-                )
+                target_width = self.engine.get_proportional_width(height)
 
-            if self.context.request.height:
-                if self.context.request.height == "orig":
-                    self.target_height = source_height
+            if height:
+                if height == "orig":
+                    target_height = source_height
                 else:
-                    self.target_height = float(self.context.request.height)
+                    target_height = float(height)
             else:
-                self.target_height = self.engine.get_proportional_height(
-                    self.context.request.width
-                )
+                target_height = self.engine.get_proportional_height(width)
+
+        return target_width, target_height
+
+    def _calculate_target_dimensions(self):
+        self.target_width, self.target_height = self._calculate_dimensions(
+            self.context.request.width,
+            self.context.request.height,
+        )
+
+    @staticmethod
+    def _limit_dimension(dimension, source_dimension):
+        if dimension == "orig":
+            return source_dimension
+
+        return min(dimension, source_dimension)
 
     def get_target_dimensions(self):
         """
@@ -355,25 +368,49 @@ class Transformer:
 
     def fit_in_resize(self):
         source_width, source_height = self.engine.size
+        requested_width, requested_height = self._calculate_dimensions(
+            self.requested_width,
+            self.requested_height,
+        )
 
         # invert width and height if image orientation is not the
         # same as request orientation and need adaptive
         if self.context.request.adaptive and (
             (
                 source_width < source_height
-                and self.target_width > self.target_height
+                and requested_width > requested_height
             )
             or (
                 source_width > source_height
-                and self.target_width < self.target_height
+                and requested_width < requested_height
             )
         ):
+            # An after-load filter may have limited the request along the
+            # original axes. Reapply those limits after the adaptive swap.
+            request_was_limited = (
+                self.context.request.width != self.requested_width
+                or self.context.request.height != self.requested_height
+            )
             tmp = self.context.request.width
             self.context.request.width = self.context.request.height
             self.context.request.height = tmp
+            tmp = self.requested_width
+            self.requested_width = self.requested_height
+            self.requested_height = tmp
             tmp = self.target_width
             self.target_width = self.target_height
             self.target_height = tmp
+
+            if request_was_limited:
+                self.context.request.width = self._limit_dimension(
+                    self.requested_width,
+                    source_width,
+                )
+                self.context.request.height = self._limit_dimension(
+                    self.requested_height,
+                    source_height,
+                )
+                self._calculate_target_dimensions()
 
         sign = 1
         if self.context.request.full:


### PR DESCRIPTION
## Summary

- preserve the originally requested canvas before `no_upscale` clamps the
  resize dimensions
- let `fill` use the requested canvas while retaining transformed dimensions
  needed by `full-fit-in`
- preserve adaptive orientation when `no_upscale` limits the request before
  transformation
- add handler regression coverage for both filter orders and the adaptive
  portrait case

Fixes #1883

## Validation

- regression reproduced on thumbor 7.7.7: both filter orders returned 20x20
  before the fix
- adaptive regression uses a 300x400 source with a 400x300 request and verifies
  that `no_upscale():fill()` returns 300x400 and matches the complete fill-only
  image
- 56 focused tests covering the handler, `fill`, `no_upscale`, and Transformer
  pass
- Black, isort, Flake8, and Pylint pass
