### PR TITLE
fix: support orig dimensions in no_upscale

### DIFF
--- a/tests/filters/test_no_upscale.py
+++ b/tests/filters/test_no_upscale.py
@@ -22,7 +22,54 @@ class FakeNoUpscaleEngine:
         return 1
 
 
+class FakeOrientedNoUpscaleEngine:
+    @property
+    def size(self):
+        return (100, 200)
+
+    def get_orientation(self):
+        return 6
+
+
 class NoUpscaleFilterTestCase(FilterTestCase):
+    @gen_test
+    async def test_original_dimensions_respect_orientation(self):
+        fltr = self.get_filter(
+            "thumbor.filters.no_upscale",
+            "no_upscale()",
+        )
+        self.context.config.RESPECT_ORIENTATION = True
+        self.context.request.width = "orig"
+        self.context.request.height = "orig"
+        self.context.request.engine = FakeOrientedNoUpscaleEngine()
+
+        await fltr.run()
+
+        assert self.context.request.width == 200
+        assert self.context.request.height == 100
+
+    @gen_test
+    async def test_no_upscale_filter_with_original_dimensions(self):
+        dimensions = (
+            ("orig", "orig", 300, 200),
+            ("orig", 100, 300, 100),
+            (150, "orig", 150, 200),
+        )
+
+        for width, height, expected_width, expected_height in dimensions:
+            fltr = self.get_filter(
+                "thumbor.filters.no_upscale",
+                "no_upscale()",
+            )
+            self.context.request.width = width
+            self.context.request.height = height
+            self.context.request.engine = FakeNoUpscaleEngine()
+
+            await fltr.run()
+
+            assert self.context.request.width == expected_width
+            assert self.context.request.height == expected_height
+
     @gen_test
     async def test_no_upscale_filter_request_bigger_than_image(self):
         def config_context(context):

--- a/tests/handlers/test_base_handler.py
+++ b/tests/handlers/test_base_handler.py
@@ -166,6 +166,20 @@ class ImagingOperationsTestCase(BaseImagingTestCase):
         assert response.code == 200
 
     @gen_test
+    async def test_no_upscale_accepts_original_dimensions(self):
+        response = await self.async_fetch(
+            "/unsafe/fit-in/origxorig/"
+            "filters:no_upscale():format(png)/20x20.jpg"
+        )
+
+        assert response.code == 200
+
+        engine = Engine(self.context)
+        engine.load(response.body, ".png")
+
+        assert engine.size == (20, 20)
+
+    @gen_test
     async def test_can_get_image_with_invalid_quantization_table(self):
         response = await self.async_fetch("/unsafe/invalid_quantization.jpg")
         assert response.code == 200

--- a/thumbor/filters/no_upscale.py
+++ b/thumbor/filters/no_upscale.py
@@ -12,6 +12,13 @@ import thumbor.filters
 from thumbor.filters import BaseFilter, filter_method
 
 
+def limit_dimension(requested, image_dimension):
+    if requested == "orig":
+        return image_dimension
+
+    return min(requested, image_dimension)
+
+
 class Filter(BaseFilter):
     phase = thumbor.filters.PHASE_AFTER_LOAD
 
@@ -27,9 +34,11 @@ class Filter(BaseFilter):
             8,
         ]:
             image_size = (image_size[1], image_size[0])
-        self.context.request.width = min(
-            self.context.request.width, image_size[0]
+        self.context.request.width = limit_dimension(
+            self.context.request.width,
+            image_size[0],
         )
-        self.context.request.height = min(
-            self.context.request.height, image_size[1]
+        self.context.request.height = limit_dimension(
+            self.context.request.height,
+            image_size[1],
         )


### PR DESCRIPTION
## Summary

- resolve `orig` to the source image dimension before applying the no-upscale
  limit
- preserve the existing behavior for numeric dimensions
- cover `origxorig`, `origxN`, and `Nxorig`
- add handler regression coverage for the URL that previously returned HTTP
  500
- verify that `orig` resolves against the displayed dimensions when
  `RESPECT_ORIENTATION` is enabled

## Context

This pre-existing error was found while validating #1884 for #1883. Requests
such as `fit-in/origxorig/filters:no_upscale()` raised a `TypeError` because
`no_upscale` compared the string `orig` with an integer using `min()`.

## Validation

- 40 focused filter and handler tests pass
- Black, isort, Flake8, and Pylint pass
- the full GitHub Actions matrix passes
