### PR TITLE
fix(pil): preserve transparency in indexed GIF output

### DIFF
--- a/tests/engines/test_pil.py
+++ b/tests/engines/test_pil.py
@@ -256,6 +256,27 @@ class PilEngineTestCase(TestCase):
         )
         assert transparent_pixels_count > 19000
 
+    def test_should_preserve_gif_transparency_from_indexed_source(self):
+        source = Image.new("P", (200, 200))
+        source.putpalette([255, 0, 0] + [0, 0, 0] * 255)
+        source.paste(1, (0, 100, 200, 200))
+
+        source_buffer = BytesIO()
+        source.save(source_buffer, "GIF", transparency=1)
+
+        engine = Engine(self.context)
+        engine.load(source_buffer.getvalue(), ".gif")
+        engine.resize(100, 100)
+
+        image = Image.open(BytesIO(engine.read(".gif")))
+        rgba_image = image.convert("RGBA")
+
+        assert image.mode == "P"
+        assert image.format == "GIF"
+        assert "transparency" in image.info
+        assert rgba_image.getpixel((50, 25))[3] == 255
+        assert rgba_image.getpixel((50, 75))[3] == 0
+
     def test_should_preserve_png_transparency_after_grayscale(self):
         engine = Engine(self.context)
 

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -241,6 +241,16 @@ class Engine(BaseEngine):
 
         return ".jpeg"
 
+    def _preserve_gif_transparency(self):
+        """Set GIF's transparency index from an RGBA palette."""
+        if self.image.palette is None or self.image.palette.mode != "RGBA":
+            return
+
+        for color, index in self.image.palette.colors.items():
+            if color[3] == 0:
+                self.image.info["transparency"] = index
+                return
+
     # TODO: Refactor this
     def read(  # noqa
         self, extension=None, quality=None
@@ -277,6 +287,9 @@ class Engine(BaseEngine):
                     else None
                 )
                 self.image = self.image.quantize(method=quantize_method)
+
+                if requested_extension == ".gif":
+                    self._preserve_gif_transparency()
 
         ext = requested_extension or self.get_default_extension()
 


### PR DESCRIPTION
## Summary

- restore the GIF transparency index after indexed-mode quantization
- keep the `PILLOW_PRESERVE_INDEXED_MODE` path and its palette-size benefits
- add a regression test generated from a palette GIF with binary alpha

Fixes #1886

## Cause

After resizing a palette source, Pillow converts it to RGBA. Thumbor then
quantizes it back to `P` when `PILLOW_PRESERVE_INDEXED_MODE` is enabled. The
quantized RGBA palette retains alpha, which the PNG writer can encode, but it
does not set `image.info["transparency"]`. Because the GIF writer receives an
already indexed image, it does not infer that single transparent index and
saves the result as opaque.

This change finds the fully transparent entry in the quantized RGBA palette
and exposes its index to the GIF writer.

## Relationship to #1879

#1879 preserves tRNS transparency when converting image data or applying
grayscale. This PR changes the later GIF encoding path in `read()` and can be
merged independently.

## Validation

- the #1886 reproducer now retains `info["transparency"] == 1` and all 4,800
  transparent output pixels with the default configuration
- all 65 engine tests pass (3 expected skips and 2 expected failures)
- Black, isort, Flake8, and Pylint pass
