### PR TITLE
fix: preserve animated WebP input frames

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -336,6 +336,24 @@ This option indicates whether animated gifs should be supported.
 
    ALLOW_ANIMATED_GIFS = True
 
+ALLOW\_ANIMATED\_WEBP
+~~~~~~~~~~~~~~~~~~~~~
+
+Preserves animated WebP inputs when using the Pillow engine. Defaults to
+``True``. Frames, frame durations, loop count and transparency are retained
+when the output is WebP, including after resizing and filtering.
+
+Set this option to ``False`` to process only the first frame, as in earlier
+versions. This setting is independent of ``ALLOW_ANIMATED_GIFS`` and
+``USE_GIFSICLE_ENGINE``. Static WebP inputs keep their existing behavior.
+An explicit ``format(...)`` conversion to another output format uses the
+first transformed frame. Animated PNG and AVIF inputs are not enabled by
+this option.
+
+.. code:: python
+
+   ALLOW_ANIMATED_WEBP = True
+
 USE\_GIFSICLE\_ENGINE
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -1098,6 +1116,11 @@ Example of Configuration File
    ## gifs.
    ## Defaults to: True
    #ALLOW_ANIMATED_GIFS = True
+
+   ## Preserves animated WebP inputs when using the Pillow engine.
+   ## Disable to process only the first frame.
+   ## Defaults to: True
+   #ALLOW_ANIMATED_WEBP = True
 
    ## Indicates whether thumbor should use gifsicle engine. Please note that smart
    ## cropping and filters are not supported for gifs using gifsicle (but won't

--- a/tests/engines/test_animated_webp.py
+++ b/tests/engines/test_animated_webp.py
@@ -1,0 +1,136 @@
+from io import BytesIO
+from unittest.mock import Mock, patch
+
+import pytest
+from PIL import Image, ImageCms
+
+from tests.fixtures.animated_webp import (
+    DURATIONS,
+    animation_bytes,
+    decoded_frames,
+)
+from thumbor.config import Config
+from thumbor.context import Context
+from thumbor.engines.pil import Engine
+
+
+def load_engine(data, **settings):
+    engine = Engine(Context(config=Config(**settings)))
+    engine.load(data, None)
+    return engine
+
+
+@pytest.mark.parametrize("loop", [0, 2])
+@pytest.mark.parametrize("allow_gifs", [True, False])
+def test_webp_roundtrip_preserves_frames_timing_and_loop(loop, allow_gifs):
+    source = animation_bytes(loop=loop)
+    engine = load_engine(source, ALLOW_ANIMATED_GIFS=allow_gifs)
+    assert engine.is_multiple()
+    assert engine.frame_count == 3
+    result = engine.read(quality=100)
+    with Image.open(BytesIO(result)) as image:
+        assert image.format == "WEBP"
+        assert image.n_frames == 3
+        assert image.info["loop"] == loop
+    actual = decoded_frames(result)
+    assert [frame.info["duration"] for frame in actual] == DURATIONS
+    assert [frame.tobytes() for frame in actual] == [
+        frame.tobytes() for frame in decoded_frames(source)
+    ]
+
+
+@pytest.mark.parametrize(
+    "operation", ["resize", "crop", "flip_horizontally", "flip_vertically"]
+)
+def test_webp_transforms_every_frame(operation):
+    source = animation_bytes()
+    engine = load_engine(source, QUALITY=100)
+    expected = decoded_frames(source)
+    if operation == "resize":
+        engine.resize(32, 16)
+        expected = [
+            im.resize((32, 16), Image.Resampling.LANCZOS) for im in expected
+        ]
+    elif operation == "crop":
+        engine.crop(4, 2, 44, 22)
+        expected = [im.crop((4, 2, 44, 22)) for im in expected]
+    else:
+        getattr(engine, operation)()
+        transpose = (
+            Image.Transpose.FLIP_LEFT_RIGHT
+            if operation == "flip_horizontally"
+            else Image.Transpose.FLIP_TOP_BOTTOM
+        )
+        expected = [im.transpose(transpose) for im in expected]
+    actual = decoded_frames(engine.read())
+    assert len(actual) == 3
+    assert [im.size for im in actual] == [im.size for im in expected]
+    assert [im.tobytes() for im in actual] == [im.tobytes() for im in expected]
+    assert [im.info["duration"] for im in actual] == DURATIONS
+
+
+def test_webp_animation_can_be_disabled_independently():
+    source = animation_bytes()
+    engine = load_engine(source, ALLOW_ANIMATED_WEBP=False)
+    assert not engine.is_multiple()
+    actual = decoded_frames(engine.read(quality=100))
+    assert len(actual) == 1
+    assert actual[0].tobytes() == decoded_frames(source)[0].tobytes()
+    gif = load_engine(animation_bytes("GIF"), ALLOW_ANIMATED_WEBP=False)
+    assert gif.is_multiple()
+
+
+def test_static_webp_keeps_the_single_image_path():
+    with BytesIO() as stream:
+        Image.new("RGB", (16, 16), "red").save(stream, "WEBP")
+        engine = load_engine(stream.getvalue())
+    assert not engine.is_multiple()
+    assert len(decoded_frames(engine.read())) == 1
+
+
+@pytest.mark.parametrize("extension", [".jpg", ".png"])
+def test_explicit_static_conversion_uses_the_transformed_first_frame(
+    extension,
+):
+    engine = load_engine(animation_bytes())
+    engine.resize(32, 16)
+    with Image.open(BytesIO(engine.read(extension=extension))) as image:
+        assert getattr(image, "n_frames", 1) == 1
+        assert image.size == (32, 16)
+
+
+def test_webp_animation_is_enabled_by_default():
+    assert Config().ALLOW_ANIMATED_WEBP is True
+
+
+def test_encoder_failure_does_not_return_a_static_fallback():
+    engine = load_engine(animation_bytes())
+    with patch.dict(
+        Image.SAVE_ALL,
+        {"WEBP": Mock(side_effect=OSError("encoder unavailable"))},
+    ):
+        with pytest.raises(OSError, match="encoder unavailable"):
+            engine.read()
+
+
+@pytest.mark.parametrize("strip", [False, True])
+def test_animation_respects_metadata_preservation_and_strip_operations(strip):
+    profile = ImageCms.ImageCmsProfile(
+        ImageCms.createProfile("sRGB")
+    ).tobytes()
+    exif = Image.Exif()
+    exif[270] = "Synthetic animation"
+    source = animation_bytes(icc_profile=profile, exif=exif.tobytes())
+    engine = load_engine(source, PRESERVE_EXIF_INFO=True)
+    if strip:
+        for frame_engine in engine.frame_engines():
+            frame_engine.strip_icc()
+            frame_engine.strip_exif()
+    with Image.open(BytesIO(engine.read())) as result:
+        assert result.n_frames == 3
+        if strip:
+            assert "icc_profile" not in result.info
+            assert not result.getexif()
+        else:
+            assert result.info["icc_profile"] == profile
+            assert result.getexif()[270] == "Synthetic animation"

--- a/tests/engines/test_animated_webp.py
+++ b/tests/engines/test_animated_webp.py
@@ -39,6 +39,21 @@ def test_webp_roundtrip_preserves_frames_timing_and_loop(loop, allow_gifs):
     ]
 
 
+@pytest.mark.parametrize("durations", [[0, 0, 0], [0, 80, 0]])
+def test_webp_roundtrip_preserves_zero_duration_frames(durations):
+    source = animation_bytes(duration=durations)
+    engine = load_engine(source)
+    assert engine.is_multiple()
+    assert engine.frame_count == 3
+
+    actual = decoded_frames(engine.read(quality=100))
+    assert len(actual) == 3
+    assert [frame.info["duration"] for frame in actual] == durations
+    assert [frame.tobytes() for frame in actual] == [
+        frame.tobytes() for frame in decoded_frames(source)
+    ]
+
+
 @pytest.mark.parametrize(
     "operation", ["resize", "crop", "flip_horizontally", "flip_vertically"]
 )

--- a/tests/fixtures/animated_webp.py
+++ b/tests/fixtures/animated_webp.py
@@ -19,13 +19,13 @@ def animation_bytes(file_format="WEBP", loop=2, **metadata):
                 pixels.append(tuple(color))
         frame.putdata(pixels)
         frames.append(frame)
+    metadata.setdefault("duration", DURATIONS)
     with BytesIO() as stream:
         frames[0].save(
             stream,
             file_format,
             save_all=True,
             append_images=frames[1:],
-            duration=DURATIONS,
             loop=loop,
             lossless=True,
             **metadata,

--- a/tests/fixtures/animated_webp.py
+++ b/tests/fixtures/animated_webp.py
@@ -1,0 +1,42 @@
+"""Small synthetic animations with distinct colors, alpha and frame delays."""
+
+from io import BytesIO
+
+from PIL import Image
+
+DURATIONS = [80, 130, 210]
+
+
+def animation_bytes(file_format="WEBP", loop=2, **metadata):
+    frames = []
+    for channel in range(3):
+        frame = Image.new("RGBA", (64, 32))
+        pixels = []
+        for y in range(32):
+            for x in range(64):
+                color = [x * 3, y * 7, (x + y) * 2, 128 + (x % 2) * 127]
+                color[channel] = 255
+                pixels.append(tuple(color))
+        frame.putdata(pixels)
+        frames.append(frame)
+    with BytesIO() as stream:
+        frames[0].save(
+            stream,
+            file_format,
+            save_all=True,
+            append_images=frames[1:],
+            duration=DURATIONS,
+            loop=loop,
+            lossless=True,
+            **metadata,
+        )
+        return stream.getvalue()
+
+
+def decoded_frames(data):
+    with Image.open(BytesIO(data)) as image:
+        frames = []
+        for index in range(image.n_frames):
+            image.seek(index)
+            frames.append(image.convert("RGBA"))
+        return frames

--- a/tests/handlers/test_animated_webp.py
+++ b/tests/handlers/test_animated_webp.py
@@ -1,0 +1,104 @@
+import json
+import tempfile
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from PIL import Image
+from tornado.testing import gen_test
+
+from tests.base import TestCase
+from tests.fixtures.animated_webp import (
+    DURATIONS,
+    animation_bytes,
+    decoded_frames,
+)
+from thumbor.config import Config
+
+
+class AnimatedWebPTestCase(TestCase):
+    def setUp(self):
+        # Keep the directory alive through asynchronous requests and tearDown.
+        # pylint: disable-next=consider-using-with
+        self.source_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.source_directory.cleanup)
+        root = Path(self.source_directory.name)
+        (root / "animated.webp").write_bytes(animation_bytes())
+        (root / "animated.gif").write_bytes(animation_bytes("GIF"))
+        super().setUp()
+
+    def get_config(self):
+        return Config(
+            SECURITY_KEY="ACME-SEC",
+            LOADER="thumbor.loaders.file_loader",
+            FILE_LOADER_ROOT_PATH=self.source_directory.name,
+            STORAGE="thumbor.storages.no_storage",
+            RESULT_STORAGE="thumbor.result_storages.no_storage",
+            QUALITY=100,
+        )
+
+    @gen_test
+    async def test_http_preserves_animation_through_resize_and_grayscale(self):
+        for operations, size, grayscale in (
+            ("", (64, 32), False),
+            ("50x0/", (50, 25), False),
+            ("filters:grayscale()/", (64, 32), True),
+            ("50x0/filters:grayscale()/", (50, 25), True),
+        ):
+            with self.subTest(operations=operations):
+                response = await self.async_fetch(
+                    f"/unsafe/{operations}animated.webp"
+                )
+                assert response.code == 200
+                assert response.headers["Content-Type"] == "image/webp"
+                with Image.open(BytesIO(response.body)) as image:
+                    assert image.n_frames == 3
+                    assert image.info["loop"] == 2
+                frames = decoded_frames(response.body)
+                assert [im.size for im in frames] == [size] * 3
+                assert [im.info["duration"] for im in frames] == DURATIONS
+                if grayscale:
+                    for frame in frames:
+                        red, green, blue, alpha = frame.split()
+                        assert (
+                            red.tobytes() == green.tobytes() == blue.tobytes()
+                        )
+                        assert alpha.getextrema()[0] < 255
+
+    @gen_test
+    async def test_http_metadata_reports_all_frames(self):
+        response = await self.async_fetch("/unsafe/meta/animated.webp")
+        assert response.code == 200
+        assert (
+            json.loads(response.body)["thumbor"]["source"]["frameCount"] == 3
+        )
+
+    @gen_test
+    async def test_auto_format_does_not_flatten_webp_animation(self):
+        self.config.AUTO_JPG = True
+        response = await self.async_fetch(
+            "/unsafe/animated.webp", headers={"Accept": "image/jpeg"}
+        )
+        assert response.code == 200
+        assert response.headers["Content-Type"] == "image/webp"
+        assert len(decoded_frames(response.body)) == 3
+
+    @gen_test
+    async def test_gif_control_retains_frames_after_resize(self):
+        response = await self.async_fetch("/unsafe/32x0/animated.gif")
+        assert response.code == 200
+        frames = decoded_frames(response.body)
+        assert len(frames) == 3
+        for frame in frames:
+            assert frame.size == (32, 16)
+
+    @gen_test
+    async def test_encoder_failure_returns_an_error_instead_of_a_static_image(
+        self,
+    ):
+        with patch.dict(
+            Image.SAVE_ALL,
+            {"WEBP": Mock(side_effect=OSError("encoder unavailable"))},
+        ):
+            response = await self.async_fetch("/unsafe/animated.webp")
+        assert response.code == 500

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -315,6 +315,14 @@ Config.define(
 )
 
 Config.define(
+    "ALLOW_ANIMATED_WEBP",
+    True,
+    "Preserves animated WebP inputs when using the Pillow engine. "
+    "Disable to process only the first frame.",
+    "Imaging",
+)
+
+Config.define(
     "USE_GIFSICLE_ENGINE",
     False,
     "Indicates whether thumbor should use gifsicle engine. "

--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -203,9 +203,11 @@ class BaseEngine:
         except Exception as error:  # pylint: disable=broad-except
             logger.error("Error reading image metadata: %s", error)
 
-        if self.context.config.ALLOW_ANIMATED_GIFS and isinstance(
-            image_or_frames, (list, tuple)
-        ):
+        allow_animation = self.context.config.ALLOW_ANIMATED_GIFS or (
+            self.extension == ".webp"
+            and self.context.config.ALLOW_ANIMATED_WEBP
+        )
+        if allow_animation and isinstance(image_or_frames, (list, tuple)):
             self.image = image_or_frames[0]
             if len(image_or_frames) > 1:
                 self.multiple_engine = MultipleEngine(self)

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -78,6 +78,8 @@ class Engine(BaseEngine):
         self.original_mode = None
         self.exif = None
         self.iptc = None
+        self._webp_durations = None
+        self._webp_loop = 0
 
         try:
             if self.context.config.MAX_PIXELS is None or int(
@@ -99,6 +101,17 @@ class Engine(BaseEngine):
         img = Image.new("RGBA", size, color)
 
         return img
+
+    def wrap(self, multiple_engine):
+        read = self.read
+        super().wrap(multiple_engine)
+        if self._webp_durations is not None:
+            # Use the regular encoder for WebP quality and metadata options.
+            # Keep the existing read_multiple contract for other engines/GIFs.
+            self.read = read
+            for frame_engine in multiple_engine.frame_engines:
+                frame_engine.icc_profile = self.icc_profile
+                frame_engine.exif = self.exif
 
     def create_image(self, buffer):
         try:
@@ -122,6 +135,19 @@ class Engine(BaseEngine):
                 self.subsampling = None
 
         self.qtables = getattr(img, "quantization", None)
+
+        if (
+            self.extension == ".webp"
+            and self.context.config.ALLOW_ANIMATED_WEBP
+            and getattr(img, "is_animated", False)
+        ):
+            # copy() loads each WebP frame before copying its duration, which
+            # Pillow populates lazily. Keep full color and alpha, not a palette.
+            frames = [frame.copy() for frame in ImageSequence.Iterator(img)]
+            self._webp_durations = [frame.info["duration"] for frame in frames]
+            self._webp_loop = img.info.get("loop", 0)
+            self.frame_count = len(frames)
+            return frames
 
         if (
             self.context.config.ALLOW_ANIMATED_GIFS
@@ -246,6 +272,12 @@ class Engine(BaseEngine):
         self, extension=None, quality=None
     ):  # noqa pylint: disable=too-many-statements,too-many-branches
         # returns image buffer in byte format.
+
+        if self._webp_durations is not None:
+            first_frame = self.frame_engines()[0]
+            self.image = first_frame.image
+            self.icc_profile = first_frame.icc_profile
+            self.exif = first_frame.exif
 
         img_buffer = BytesIO()
         requested_extension = extension or self.extension
@@ -411,6 +443,15 @@ class Engine(BaseEngine):
 
         try:
             if ext == ".webp":
+                if self._webp_durations is not None:
+                    options.update(
+                        save_all=True,
+                        append_images=[
+                            engine.image for engine in self.frame_engines()[1:]
+                        ],
+                        duration=self._webp_durations,
+                        loop=self._webp_loop,
+                    )
                 if options["quality"] == 100:
                     logger.debug("webp quality is 100, using lossless instead")
                     options["lossless"] = True
@@ -435,6 +476,9 @@ class Engine(BaseEngine):
             )
             self.image.save(img_buffer, self.image.format, **options)
         except IOError:
+            if options.get("save_all"):
+                # A static fallback would silently discard the animation.
+                raise
             logger.exception(
                 "Could not save as improved image, consider to increase ImageFile.MAXBLOCK"
             )

--- a/thumbor/filters/grayscale.py
+++ b/thumbor/filters/grayscale.py
@@ -13,5 +13,4 @@ from thumbor.filters import BaseFilter, filter_method
 class Filter(BaseFilter):
     @filter_method()
     async def grayscale(self):
-        engine = self.context.modules.engine
-        engine.convert_to_grayscale()
+        self.engine.convert_to_grayscale()


### PR DESCRIPTION
Animated WebP inputs currently return a static image even when no transformation is requested. Preserve their frames through the Pillow pipeline and encode WebP output with the original frame durations and loop count. Resizing, cropping, flips and per-frame filters retain animation, full color and alpha; the existing quality and ICC/EXIF handling remain in use.

Add `ALLOW_ANIMATED_WEBP=True`, independently of the GIF setting. Setting it to `False` restores first-frame processing. Explicit conversion to another output format still uses the first transformed frame; APNG/animated AVIF support is outside this change. `grayscale()` now uses the current frame engine. Animated WebP encoder failures propagate to an HTTP error instead of falling back to a static image. The existing GIF encoder and `read_multiple` interface are retained.

Validation:

- Regression tests fail before the fix and pass afterward. The focused suite has 23 tests covering frame content/count, alpha, timing (including all-zero and mixed zero/nonzero durations), loops, transforms, HTTP responses, auto-format behavior, quality, metadata preservation/stripping, static inputs, explicit static conversion, configuration controls and encoder failure. Fixtures are small, generated locally, and include a GIF control.
- Focused engine/HTTP tests pass on Python 3.10.20 with Pillow 10.4.0 and Python 3.14.7 with Pillow 12.3.0.
- `make unit`, `make integration_run` (558 requests), `make flake isort pylint`, and Black checks pass locally. The unit suite retains its existing skips and expected failures.

Fixes #1889.
