### PR TITLE
docs: add Compose examples and environment value conversion

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ thumbor-config > ./thumbor.conf
 This command writes to standard output. Shell redirection creates or replaces
 the destination file; it does not merge with an existing configuration.
 
+(override-config-through-environment-variable)=
 ## Override configuration through environment variables
 
 Environment overrides are disabled by default. To enable the legacy derpconf
@@ -41,7 +42,48 @@ is safe only for string-valued settings. Boolean, integer, list, dictionary and
 other typed settings should remain in `thumbor.conf`.
 
 `--use-environment` currently requires a value. A bare `--use-environment`
-argument is not accepted.
+argument is not accepted. Omit the option to leave overrides disabled;
+`--use-environment=False` also enables them because the current CLI treats its
+value as a nonempty string.
+
+For boolean settings, `UPLOAD_ENABLED=True` can enable uploads because
+`"True"` is a nonempty string. However, `UPLOAD_ENABLED=False` also produces a
+nonempty string and does not disable uploads. Likewise, `QUALITY=85` remains
+a string instead of becoming an integer.
+
+(converting-environment-values)=
+### Converting environment values
+
+The Python configuration file can read and convert environment variables
+itself. For example, save this as `thumbor.conf`:
+
+```python
+import os
+
+
+def env_bool(name):
+    return os.environ.get(name, "false").strip().lower() == "true"
+
+
+UPLOAD_ENABLED = env_bool("UPLOAD_ENABLED")
+UPLOAD_DELETE_ALLOWED = env_bool("UPLOAD_DELETE_ALLOWED")
+UPLOAD_PUT_ALLOWED = env_bool("UPLOAD_PUT_ALLOWED")
+QUALITY = int(os.environ.get("QUALITY", "80"))
+```
+
+This helper enables a boolean option only for `true`, ignoring case and
+surrounding whitespace. Missing variables and other values leave it disabled.
+Set other configuration options in the file as usual.
+
+Load the file without `--use-environment`:
+
+```bash
+thumbor -c ./thumbor.conf
+```
+
+The file still reads the environment through `os.environ`. Enabling direct
+environment overrides would replace its converted values with strings again.
+See {ref}`docker-compose-configuration` for complete Compose examples.
 
 ## Extensibility Section
 

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -137,6 +137,47 @@ of thumbor.
 For more detailed configuration options, see the {doc}`configuration`
 documentation.
 
+(docker-compose-configuration)=
+#### Docker Compose configuration
+
+For string settings, enable environment overrides in Compose with:
+
+```yaml
+services:
+  thumbor:
+    image: ghcr.io/thumbor/thumbor:latest
+    ports:
+      - "8888:8888"
+    command: ["--use-environment=True"]
+    environment:
+      SECURITY_KEY: "replace-with-your-own-key"
+```
+
+The `command` list supplies arguments to the image's `thumbor` entrypoint.
+Quote environment values so Compose treats them as strings.
+
+For settings that need other types, use the Python configuration example in
+{ref}`converting-environment-values` and mount it as follows:
+
+```yaml
+services:
+  thumbor:
+    image: ghcr.io/thumbor/thumbor:latest
+    ports:
+      - "8888:8888"
+    command: ["-c", "/etc/thumbor.conf"]
+    environment:
+      UPLOAD_ENABLED: "true"
+      UPLOAD_DELETE_ALLOWED: "false"
+      UPLOAD_PUT_ALLOWED: "false"
+      QUALITY: "85"
+    volumes:
+      - ./thumbor.conf:/etc/thumbor.conf:ro
+```
+
+Here the file converts the environment values to Python booleans and integers.
+Keep `--use-environment` out of this command to preserve those types.
+
 <!--
 TODO: Update these instructions, as they are severely outdated.
 


### PR DESCRIPTION
Add complete Docker Compose examples for string environment overrides and for a mounted `thumbor.conf` that converts environment values to booleans and integers. Explain why `"False"` does not disable boolean settings and why `--use-environment=False` still enables overrides. Preserve the configuration section anchor referenced in #1900.

This PR extends #1891 and targets its branch, `docs/fix-config-runtime-docs`. That PR depends on the Markdown migration in #1882. The diff contains only the additions to `docs/configuration.md` and `docs/hosting.md`; merge after those dependencies.

Validation:

- Sphinx HTML build passes with `-W --keep-going -E -a` (no warnings).
- Both Compose examples pass `docker compose config`; their CLI arguments and converted configuration values were checked against the runtime.
- Checked shell syntax, rendered anchors and cross-references, and Markdown line lengths.
- `make unit` passes (9 skips and 2 expected failures); `make flake isort pylint` and pre-commit checks pass.

Refs #1900.
