### PR TITLE
fix: preserve animated GIF frame durations

### DIFF
--- a/tests/engines/test_pil.py
+++ b/tests/engines/test_pil.py
@@ -15,9 +15,10 @@ from unittest import TestCase, mock
 
 import piexif
 import pytest
-from PIL import Image, ImageChops
+from PIL import Image, ImageChops, ImageSequence
 
 from tests.base import (
+    AVIF_AVAILABLE,
     skip_unless_avif,
     skip_unless_avif_encoder,
     skip_unless_heif,
@@ -411,6 +412,57 @@ class PilEngineTestCase(TestCase):
         final_bytes = BytesIO(engine.read())
         image = Image.open(final_bytes)
         assert image.info.get("exif") is None
+
+
+@pytest.mark.parametrize(
+    "extension",
+    [
+        ".gif",
+        ".webp",
+        ".png",
+        pytest.param(
+            ".avif",
+            marks=pytest.mark.skipif(
+                not AVIF_AVAILABLE, reason="AVIF format support not found"
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("resize", [False, True])
+@pytest.mark.parametrize("durations", [[100, 200, 6010], None])
+def test_animated_gif_frame_durations(extension, resize, durations):
+    frames = [
+        Image.new("RGB", (32, 32), color) for color in ("red", "green", "blue")
+    ]
+    options = {} if durations is None else {"duration": durations}
+    with BytesIO() as source:
+        frames[0].save(
+            source,
+            "GIF",
+            save_all=True,
+            append_images=frames[1:],
+            loop=0,
+            optimize=False,
+            **options,
+        )
+        engine = Engine(PilEngineTestCase().get_context())
+        engine.load(source.getvalue(), ".gif")
+
+    if resize:
+        engine.resize(16, 16)
+
+    with Image.open(BytesIO(engine.read(extension))) as result:
+        assert result.size == ((16, 16) if resize else (32, 32))
+        assert result.n_frames == len(frames)
+        actual_durations = []
+        for frame in ImageSequence.Iterator(result):
+            # WebP exposes the frame duration after loading its pixels.
+            frame.load()
+            actual_durations.append(frame.info.get("duration", 0))
+
+    assert actual_durations == (
+        durations if durations is not None else [80] * len(frames)
+    )
 
 
 @skip_unless_avif_encoder("svt")

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -464,7 +464,7 @@ class Engine(BaseEngine):
                 self.image.format,
                 save_all=True,
                 append_images=images[1:],
-                duration=[im.info.get("duration", 80) / 1000 for im in images],
+                duration=[im.info.get("duration", 80) for im in images],
                 loop=int(self.image.info.get("loop", 1)),
             )
             return img_buffer.getvalue()


### PR DESCRIPTION
Fixes #1776.

Animated GIF frame delays were divided by 1000 before being passed to Pillow,
causing animations to play too fast. Preserve the original durations in
milliseconds, including the 80 ms fallback when timing metadata is missing.

The division was introduced in 2fd2ac096290 to convert milliseconds to seconds
for the old GifWriter. Commit 14319954142c replaced that writer with Pillow in
2024 but retained the conversion, although Pillow expects milliseconds. The
existing tests checked image format, dimensions, and animation presence without
checking frame timing.

Add 16 regression cases covering GIF, WebP, APNG, and AVIF output, with and
without resizing, and with explicit or missing frame durations. All 16 cases
failed before the fix and passed afterward. The original GIF from the issue
also reproduces the bug: its 6000 ms and 6010 ms frame delays were lost when
resizing, and are preserved by the fix.

Validation: `make unit`, `make flake isort pylint`, Black, and `git diff --check`
passed. The branch contains one commit on top of the current master.

