### PR TITLE
fix: antialias transparent rounded corners using alpha

### DIFF
--- a/tests/filters/test_round_corner.py
+++ b/tests/filters/test_round_corner.py
@@ -7,9 +7,84 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
+from io import BytesIO
+
+import pytest
+from PIL import Image, ImageChops
 from tornado.testing import gen_test
 
 from tests.base import FilterTestCase
+
+
+async def round_transparent_image(source, radius, extension=".png"):
+    fltr = FilterTestCase().get_filter(
+        "thumbor.filters.round_corner", f"round_corner({radius},0,0,0,1)"
+    )
+    with BytesIO() as buffer:
+        source.save(buffer, "PNG")
+        fltr.engine.load(buffer.getvalue(), ".png")
+    await fltr.run()
+    with Image.open(
+        BytesIO(fltr.engine.read(extension, quality=100))
+    ) as result:
+        return result.convert("RGBA")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("radius", ["30", "20|35", "150"])
+@pytest.mark.parametrize("mode, alpha", [("RGB", 255), ("RGBA", 128)])
+@pytest.mark.parametrize("extension", [".png", ".webp"])
+async def test_transparent_round_corners_have_no_dark_border(
+    radius, mode, alpha, extension
+):
+    source = Image.new(mode, (100, 100), "white")
+    if mode == "RGBA":
+        source.putalpha(alpha)
+    result = await round_transparent_image(source, radius, extension)
+
+    background = Image.new("RGBA", source.size, "white")
+    composite = Image.alpha_composite(background, result).convert("RGB")
+    assert composite.getextrema() == ((255, 255),) * 3
+    assert result.getpixel((50, 50)) == (255, 255, 255, alpha)
+
+    for box in (
+        (0, 0, 50, 50),
+        (50, 0, 100, 50),
+        (0, 50, 50, 100),
+        (50, 50, 100, 100),
+    ):
+        histogram = result.getchannel("A").crop(box).histogram()
+        assert histogram[0] > 0
+        assert histogram[alpha] > 0
+        assert sum(histogram[1:alpha]) > 0
+        assert sum(histogram[alpha + 1 :]) == 0
+
+
+@pytest.mark.asyncio
+async def test_transparent_round_corners_preserve_existing_color_and_alpha():
+    source = Image.new("RGBA", (100, 100))
+    source.putdata(
+        [
+            (2 * x, 2 * y, 150, ((x + y) % 3) * 127)
+            for y in range(100)
+            for x in range(100)
+        ]
+    )
+    result = await round_transparent_image(source, "20|35")
+
+    assert (
+        ImageChops.difference(
+            result.convert("RGB"), source.convert("RGB")
+        ).getbbox()
+        is None
+    )
+    assert (
+        ImageChops.subtract(
+            result.getchannel("A"), source.getchannel("A")
+        ).getbbox()
+        is None
+    )
+    assert result.getpixel((50, 50)) == source.getpixel((50, 50))
 
 
 class RoundCornerFilterTestCase(FilterTestCase):

--- a/thumbor/ext/filters/_round_corner.c
+++ b/thumbor/ext/filters/_round_corner.c
@@ -25,6 +25,19 @@ _round_corner_apply(PyObject *self, PyObject *args)
         b_idx = rgb_order(image_mode_str, 'B'),
         a_idx = rgb_order(image_mode_str, 'A');
 
+    unsigned char *original_alpha = NULL;
+    if (transparent == 1) {
+        /* Clipping and both antialiasing passes modify alpha in place. */
+        Py_ssize_t pixel_count = (Py_ssize_t)width * height;
+        original_alpha = PyMem_Malloc(pixel_count);
+        if (original_alpha == NULL) {
+            return PyErr_NoMemory();
+        }
+        for (Py_ssize_t i = 0; i < pixel_count; ++i) {
+            original_alpha[i] = ptr[i * num_bytes + a_idx];
+        }
+    }
+
     float aa_amount = .75f;
 
     if (a_radius > width / 2) {
@@ -68,11 +81,12 @@ _round_corner_apply(PyObject *self, PyObject *args)
             if (transparent == 1) {
                 assert(bottom_left + a_idx < image_size);
             }
-            ptr[top_left + r_idx] = ptr[bottom_left + r_idx] = r;
-            ptr[top_left + g_idx] = ptr[bottom_left + g_idx] = g;
-            ptr[top_left + b_idx] = ptr[bottom_left + b_idx] = b;
             if (transparent == 1) {
                 ptr[top_left + a_idx] = ptr[bottom_left + a_idx] = 0;
+            } else {
+                ptr[top_left + r_idx] = ptr[bottom_left + r_idx] = r;
+                ptr[top_left + g_idx] = ptr[bottom_left + g_idx] = g;
+                ptr[top_left + b_idx] = ptr[bottom_left + b_idx] = b;
             }
 
             if (curr_x > 0) {
@@ -88,11 +102,12 @@ _round_corner_apply(PyObject *self, PyObject *args)
                 if (transparent == 1) {
                     assert(bottom_right + a_idx < image_size);
                 }
-                ptr[top_right + r_idx] = ptr[bottom_right + r_idx] = r;
-                ptr[top_right + g_idx] = ptr[bottom_right + g_idx] = g;
-                ptr[top_right + b_idx] = ptr[bottom_right + b_idx] = b;
                 if (transparent == 1) {
                     ptr[top_right + a_idx] = ptr[bottom_right + a_idx] = 0;
+                } else {
+                    ptr[top_right + r_idx] = ptr[bottom_right + r_idx] = r;
+                    ptr[top_right + g_idx] = ptr[bottom_right + g_idx] = g;
+                    ptr[top_right + b_idx] = ptr[bottom_right + b_idx] = b;
                 }
             }
         }
@@ -142,21 +157,10 @@ _round_corner_apply(PyObject *self, PyObject *args)
             float aa = 1.f - ((idx / (float)pixel_count_x) * aa_amount);
 
             if (transparent == 1) {
-                ptr[top_left + r_idx] = (color_top_left[r_idx] * (1.f - aa));
-                ptr[top_left + g_idx] = (color_top_left[g_idx] * (1.f - aa));
-                ptr[top_left + b_idx] = (color_top_left[b_idx] * (1.f - aa));
-
-                ptr[bottom_left + r_idx] = (color_bottom_left[r_idx] * (1.f - aa));
-                ptr[bottom_left + g_idx] = (color_bottom_left[g_idx] * (1.f - aa));
-                ptr[bottom_left + b_idx] = (color_bottom_left[b_idx] * (1.f - aa));
-
-                ptr[top_right + r_idx] = (color_top_right[r_idx] * (1.f - aa));
-                ptr[top_right + g_idx] = (color_top_right[g_idx] * (1.f - aa));
-                ptr[top_right + b_idx] = (color_top_right[b_idx] * (1.f - aa));
-
-                ptr[bottom_right + r_idx] = (color_bottom_right[r_idx] * (1.f - aa));
-                ptr[bottom_right + g_idx] = (color_bottom_right[g_idx] * (1.f - aa));
-                ptr[bottom_right + b_idx] = (color_bottom_right[b_idx] * (1.f - aa));
+                ptr[top_left + a_idx] = original_alpha[top_left / num_bytes] * (1.f - aa);
+                ptr[bottom_left + a_idx] = original_alpha[bottom_left / num_bytes] * (1.f - aa);
+                ptr[top_right + a_idx] = original_alpha[top_right / num_bytes] * (1.f - aa);
+                ptr[bottom_right + a_idx] = original_alpha[bottom_right / num_bytes] * (1.f - aa);
             } else {
                 ptr[top_left + r_idx] = (color_top_left[r_idx] * (1.f - aa)) + (r * (aa));
                 ptr[top_left + g_idx] = (color_top_left[g_idx] * (1.f - aa)) + (g * (aa));
@@ -227,21 +231,10 @@ _round_corner_apply(PyObject *self, PyObject *args)
             float aa = 1.f - ((idx / (float)pixel_count_y) * aa_amount);
 
             if (transparent == 1) {
-                ptr[top_left + r_idx] = (color_top_left[r_idx] * (1.f - aa));
-                ptr[top_left + g_idx] = (color_top_left[g_idx] * (1.f - aa));
-                ptr[top_left + b_idx] = (color_top_left[b_idx] * (1.f - aa));
-
-                ptr[bottom_left + r_idx] = (color_bottom_left[r_idx] * (1.f - aa));
-                ptr[bottom_left + g_idx] = (color_bottom_left[g_idx] * (1.f - aa));
-                ptr[bottom_left + b_idx] = (color_bottom_left[b_idx] * (1.f - aa));
-
-                ptr[top_right + r_idx] = (color_top_right[r_idx] * (1.f - aa));
-                ptr[top_right + g_idx] = (color_top_right[g_idx] * (1.f - aa));
-                ptr[top_right + b_idx] = (color_top_right[b_idx] * (1.f - aa));
-
-                ptr[bottom_right + r_idx] = (color_bottom_right[r_idx] * (1.f - aa));
-                ptr[bottom_right + g_idx] = (color_bottom_right[g_idx] * (1.f - aa));
-                ptr[bottom_right + b_idx] = (color_bottom_right[b_idx] * (1.f - aa));
+                ptr[top_left + a_idx] = original_alpha[top_left / num_bytes] * (1.f - aa);
+                ptr[bottom_left + a_idx] = original_alpha[bottom_left / num_bytes] * (1.f - aa);
+                ptr[top_right + a_idx] = original_alpha[top_right / num_bytes] * (1.f - aa);
+                ptr[bottom_right + a_idx] = original_alpha[bottom_right / num_bytes] * (1.f - aa);
             } else {
                 ptr[top_left + r_idx] = (color_top_left[r_idx] * (1.f - aa)) + (r * (aa));
                 ptr[top_left + g_idx] = (color_top_left[g_idx] * (1.f - aa)) + (g * (aa));
@@ -264,6 +257,7 @@ _round_corner_apply(PyObject *self, PyObject *args)
 
 END:
 
+    PyMem_Free(original_alpha);
     Py_INCREF(buffer);
     return buffer;
 }


### PR DESCRIPTION
Fixes #1687.

With transparency enabled, `round_corner` darkened edge RGB values while
leaving their alpha unchanged, producing a dark border around the corners.
For example, rounding a white image produced opaque gray edge pixels.

Preserve the source RGB values and apply antialiasing to each pixel's original
alpha. A temporary alpha snapshot (one byte per pixel) lets clipping and both
antialiasing passes preserve existing transparency, including fully transparent
pixels. The incorrect RGB blending dates back to 168065cbf20a, which added
transparent round corners in 2019.

Add 13 regression cases covering PNG and lossless WebP output, RGB and RGBA
inputs, circular and elliptical corners, clamped radii, and spatially varying
colors and alpha. These check for dark fringes when compositing onto white,
partial transparency in all four corners, and preservation of source opacity.

Validation:

- All 13 regression cases failed before the fix and passed afterward.
- All 20 round-corner filter tests passed.
- `make unit` and `make flake isort pylint` passed.
- Black, `git diff --check`, and the pre-commit hooks passed.
- Checked the issue's example image at 500px wide with a 150px corner radius.
