### PR TITLE
fix: URL-encode uploaded filenames in Location header

### DIFF
--- a/tests/handlers/test_upload_api.py
+++ b/tests/handlers/test_upload_api.py
@@ -184,6 +184,35 @@ class UploadAPINewFileTestCase(UploadTestCase):
         assert_exists(expected_path)
         assert_same_as(expected_path, VALID_IMAGE_PATH)
 
+    @gen_test
+    async def test_can_post_from_html_form_with_url_encoded_filename(self):
+        filenames = (
+            ("gru\u0308n.jpg", "gru%CC%88n.jpg"),
+            ("grün.jpg", "gr%C3%BCn.jpg"),
+            ("猫.jpg", "%E7%8C%AB.jpg"),
+            ("photo #1?100%/crop.jpg", "photo%20%231%3F100%25%2Fcrop.jpg"),
+            ("photo%20name.jpg", "photo%2520name.jpg"),
+        )
+        for filename, encoded_filename in filenames:
+            with self.subTest(filename=filename):
+                response = await self.async_post_files(
+                    self.base_uri,
+                    files=(("media", filename, valid_image()),),
+                )
+
+                assert response.code == 201
+                location = response.headers["Location"]
+                assert re.fullmatch(
+                    self.base_uri
+                    + r"/[0-9a-f]{32}/"
+                    + re.escape(encoded_filename),
+                    location,
+                )
+
+                response = await self.async_get(location)
+                assert response.code == 200
+                assert_similar_to(response.body, valid_image())
+
 
 class UploadAPIUpdateFileTestCase(UploadTestCase):
     def get_context(self):

--- a/thumbor/handlers/upload.py
+++ b/thumbor/handlers/upload.py
@@ -9,6 +9,7 @@
 
 import mimetypes
 import uuid
+from urllib.parse import quote
 
 from thumbor.engines import BaseEngine
 from thumbor.handlers import ImageApiHandler
@@ -77,4 +78,4 @@ class ImageUploadHandler(ImageApiHandler):
 
     def location(self, image_id, filename):
         base_uri = self.request.uri
-        return f"{base_uri}/{image_id}/{filename}"
+        return f"{base_uri}/{image_id}/{quote(filename, safe='')}"


### PR DESCRIPTION
Uploading an image with a decomposed Unicode filename such as `gru\u0308n.jpg` fails while constructing the `Location` response header, after the image has already been saved.

Percent-encode the filename as a single URL path segment so Unicode and reserved characters produce a valid location. Add five regression cases covering composed and decomposed Unicode, non-Latin characters, reserved URL characters, and literal percent sequences. Each case verifies a successful upload and retrieval through the returned URL.

Fixes #1613.

Validation:

- The five regression cases fail before the fix and pass with it.
- `make unit`
- `make flake isort pylint`
- Black formatting check and pre-commit hooks

