### PR TITLE
fix: handle unavailable Unix sockets and native Cairo

### DIFF
--- a/tests/engines/test_base_engine.py
+++ b/tests/engines/test_base_engine.py
@@ -7,6 +7,8 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
+import builtins
+import importlib.util
 from os.path import abspath, dirname, join
 from struct import pack
 from unittest import TestCase, mock
@@ -14,6 +16,7 @@ from xml.etree.ElementTree import ParseError
 
 import pytest
 
+import thumbor.engines
 from thumbor.config import Config
 from thumbor.context import Context
 from thumbor.engines import BaseEngine
@@ -21,6 +24,25 @@ from thumbor.engines import BaseEngine
 # pylint: disable=line-too-long
 
 STORAGE_PATH = abspath(join(dirname(__file__), "../fixtures/images/"))
+
+
+@pytest.mark.parametrize("error_type", [ImportError, OSError])
+def test_can_import_engine_without_cairo(error_type):
+    original_import = builtins.__import__
+
+    def import_without_cairo(name, *args, **kwargs):
+        if name == "cairosvg":
+            raise error_type("cannot load library libcairo-2.dll")
+        return original_import(name, *args, **kwargs)
+
+    spec = importlib.util.spec_from_file_location(
+        "engine_without_cairo", thumbor.engines.__file__
+    )
+    engine_module = importlib.util.module_from_spec(spec)
+    with mock.patch("builtins.__import__", side_effect=import_without_cairo):
+        spec.loader.exec_module(engine_module)
+
+    assert engine_module.cairosvg is None
 
 
 def exif_str(exif_value):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -7,8 +7,59 @@
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
 
+import importlib
+from unittest import mock
 
-from thumbor.doctor import run_doctor
+import pytest
+
+from thumbor.doctor import check_modules, run_doctor
+
+
+@pytest.mark.parametrize("module_name", ["pycurl", "cairosvg"])
+@pytest.mark.parametrize("error_type", [ImportError, OSError])
+def test_reports_module_load_failure(capsys, module_name, error_type):
+    message = f"Cannot load a dependency of {module_name}"
+
+    def import_module(name):
+        if name == module_name:
+            raise error_type(message)
+        return mock.Mock()
+
+    with mock.patch(
+        "thumbor.doctor.import_module", side_effect=import_module
+    ) as importer:
+        warnings, errors = check_modules()
+
+    assert not warnings
+    assert len(errors) == 1
+    assert module_name in errors[0]
+    assert message in errors[0]
+    assert f"{module_name} could not be loaded." in capsys.readouterr().out
+    assert importer.call_args_list == [
+        mock.call("pycurl"),
+        mock.call("cairosvg"),
+    ]
+
+
+def test_doctor_finishes_when_cairo_library_is_missing(capsys):
+    message = "cannot load library libcairo-2.dll: error 0x7e"
+
+    def import_module(name):
+        if name == "cairosvg":
+            raise OSError(message)
+        return importlib.import_module(name)
+
+    with mock.patch("thumbor.doctor.import_module", side_effect=import_module):
+        with pytest.raises(SystemExit) as error:
+            run_doctor({"nocolor": True, "config": None}, print_version=False)
+
+    output = capsys.readouterr().out
+    assert error.value.code == 1
+    assert "Verifying thumbor compiled extensions..." in output
+    assert "Error Message:" in output
+    assert message in output
+    assert "https://cairosvg.org/" in output
+    assert "Need Help" in output
 
 
 def test_get_doctor_output(capsys, doctor_output):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -58,7 +58,10 @@ def test_doctor_finishes_when_cairo_library_is_missing(capsys):
     assert "Verifying thumbor compiled extensions..." in output
     assert "Error Message:" in output
     assert message in output
-    assert "https://cairosvg.org/" in output
+    assert (
+        "Thumbor uses CairoSVG for reading SVG files. "
+        "For more information check https://cairosvg.org/."
+    ) in output.splitlines()
     assert "Need Help" in output
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,9 +6,11 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
 # Copyright (c) 2011 globo.com thumbor@googlegroups.com
+import importlib.util
 from unittest import TestCase, mock
 
 import pytest
+from tornado import netutil
 
 import thumbor.server
 from tests.fixtures.custom_error_handler import (
@@ -27,6 +29,68 @@ from thumbor.server import (
     run_server,
     validate_config,
 )
+
+
+@pytest.fixture(name="server_without_unix_sockets")
+def fixture_server_without_unix_sockets(monkeypatch):
+    monkeypatch.delattr(netutil, "bind_unix_socket", raising=False)
+    spec = importlib.util.spec_from_file_location(
+        "server_without_unix_sockets", thumbor.server.__file__
+    )
+    server_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(server_module)
+    return server_module
+
+
+def test_can_start_tcp_without_unix_sockets(server_without_unix_sockets):
+    context = mock.Mock(
+        server=mock.Mock(fd=None, port=1234, ip="127.0.0.1", processes=1)
+    )
+    with mock.patch.object(server_without_unix_sockets, "HTTPServer") as http:
+        server_without_unix_sockets.run_server(mock.Mock(), context)
+
+    http.return_value.bind.assert_called_once_with(1234, "127.0.0.1")
+    http.return_value.start.assert_called_once_with(1)
+    http.return_value.add_socket.assert_not_called()
+
+
+@pytest.mark.parametrize("non_blocking", [False, True])
+def test_can_use_fd_without_unix_sockets(
+    server_without_unix_sockets, non_blocking
+):
+    context = mock.Mock(
+        server=mock.Mock(fd="11", processes=1),
+        config=Config(NON_BLOCKING_SOCKETS=non_blocking),
+    )
+    with (
+        mock.patch.object(server_without_unix_sockets, "HTTPServer") as http,
+        mock.patch.object(server_without_unix_sockets, "socket") as socket,
+    ):
+        server_without_unix_sockets.run_server(mock.Mock(), context)
+
+    socket.assert_called_once_with(fileno=11)
+    if non_blocking:
+        socket.return_value.setblocking.assert_called_once_with(False)
+    else:
+        socket.return_value.setblocking.assert_not_called()
+    http.return_value.add_socket.assert_called_once_with(socket.return_value)
+    http.return_value.start.assert_called_once_with(1)
+    http.return_value.bind.assert_not_called()
+
+
+def test_rejects_unavailable_unix_socket(server_without_unix_sockets):
+    context = mock.Mock(
+        server=mock.Mock(fd="/tmp/thumbor.sock"), config=Config()
+    )
+    with mock.patch.object(server_without_unix_sockets, "HTTPServer") as http:
+        with pytest.raises(
+            RuntimeError, match="Unix domain sockets are not supported"
+        ):
+            server_without_unix_sockets.run_server(mock.Mock(), context)
+
+    http.return_value.bind.assert_not_called()
+    http.return_value.add_socket.assert_not_called()
+    http.return_value.start.assert_not_called()
 
 
 class ServerTestCase(TestCase):
@@ -245,7 +309,7 @@ class ServerTestCase(TestCase):
         server_instance_mock.start.assert_called_with(1)
 
     @mock.patch.object(thumbor.server, "HTTPServer")
-    @mock.patch.object(thumbor.server, "bind_unix_socket")
+    @mock.patch.object(netutil, "bind_unix_socket", create=True)
     def test_can_run_server_with_unix_socket(
         self, bind_unix_socket, server_mock
     ):

--- a/thumbor/doctor.py
+++ b/thumbor/doctor.py
@@ -282,8 +282,8 @@ def check_modules():
         try:
             import_module(module)  # NOQA
             print_success(f"{CHECK} {module} is installed correctly.")
-        except ImportError as error:
-            print_error(f"{CROSS} {module} is not installed.")
+        except (ImportError, OSError) as error:
+            print_error(f"{CROSS} {module} could not be loaded.")
             print(error_message)
             newline()
             errors.append(format_error(module, str(error), error_message))

--- a/thumbor/engines/__init__.py
+++ b/thumbor/engines/__init__.py
@@ -22,7 +22,7 @@ from thumbor.utils import EXTENSION, logger
 
 try:
     import cairosvg
-except ImportError:
+except (ImportError, OSError):
     cairosvg = None
 
 

--- a/thumbor/server.py
+++ b/thumbor/server.py
@@ -19,8 +19,8 @@ from socket import socket
 
 import tornado.ioloop
 from PIL import Image
+from tornado import netutil
 from tornado.httpserver import HTTPServer
-from tornado.netutil import bind_unix_socket
 
 from thumbor.config import Config
 from thumbor.console import get_server_parameters
@@ -116,6 +116,12 @@ def get_socket_from_fd(fname_or_fd, *, non_blocking=False):
         if non_blocking:
             sock.setblocking(False)
     else:
+        bind_unix_socket = getattr(netutil, "bind_unix_socket", None)
+        if bind_unix_socket is None:
+            raise RuntimeError(
+                "Unix domain sockets are not supported on this platform. "
+                "Use --ip and --port without --fd to listen on TCP."
+            )
         sock = bind_unix_socket(fname_or_fd)
 
     return sock


### PR DESCRIPTION
Thumbor currently fails to import on platforms where Tornado does not expose `bind_unix_socket`, even when starting a TCP server. Look up Unix socket support only when a socket path is requested, and report an explicit error if it is unavailable. TCP startup and numeric file descriptors retain their existing behavior.

A missing native Cairo library raises `OSError` during CairoSVG import. Handle it as an unavailable optional dependency in the image engine so JPEG/PNG processing can continue, and include the original error in the `thumbor-doctor` report instead of aborting the diagnostic. SVG rasterization still requires Cairo.

Added regression tests for imports without Unix socket support, TCP startup, numeric descriptors, unsupported Unix socket paths, and Cairo import failures in both the engine and doctor.

Validation:
- `make unit` passed on Python 3.14 (9 skipped, 2 expected failures).
- `make flake isort pylint` passed.
- A local HTTP smoke test with Unix socket binding and Cairo unavailable returned HTTP 200 for healthcheck and resized JPEG/PNG images to 10×10.
- Platform limitations were simulated on Linux; this has not been tested on native Windows.

Fixes #1684.
